### PR TITLE
do not normalize light curve to compute peridogram

### DIFF
--- a/lightkurve/periodogram.py
+++ b/lightkurve/periodogram.py
@@ -737,12 +737,6 @@ class LombScarglePeriodogram(Periodogram):
                           LightkurveWarning)
             maximum_frequency = kwargs.pop("max_frequency", None)
 
-        # Make sure the lightcurve object is normalized
-        if not np.in1d(lc.flux, lc.normalize().flux).all():
-            warnings.warn("Input light curve will be normalized.",
-                          LightkurveWarning)
-            lc = lc.normalize()
-
         # Check if any values of period have been passed and set format accordingly
         if not all(b is None for b in [period, minimum_period, maximum_period]):
             default_view = 'period'


### PR DESCRIPTION
Removing an unnecessary (and problematic; #569) call to normalize a lightcurve before computing the periodogram.  The Lomb Scargle algorithm used can compute the same spectrum from an unnormalized light curve.