### PR TITLE
one-line bug fix to tpf.get_coordinates : kjm2020JUL17

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -404,7 +404,8 @@ class TargetPixelFile(object):
              np.atleast_3d(pos_corr2_pix).transpose([1, 2, 0]))
 
         # Pass through WCS
-        ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)
+        #ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1) # OLD (<2020JUL17)
+        ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 0) # NEW KJM astropy documentation says origin=0 when using NUMPY
         ra = ra.reshape((pos_corr1_pix.shape[0], self.shape[1], self.shape[2]))
         dec = dec.reshape((pos_corr2_pix.shape[0], self.shape[1], self.shape[2]))
         ra, dec = ra[self.quality_mask], dec[self.quality_mask]

--- a/lightkurve/version.py
+++ b/lightkurve/version.py
@@ -1,3 +1,3 @@
 # It is important to store the version number in a separate file
 # so that we can read it from setup.py without importing the package
-__version__ = "2.0.dev"
+__version__ = "2.0.devx"


### PR DESCRIPTION
<img width="1125" alt="astropy wcs wcs_pix2world_documentation" src="https://user-images.githubusercontent.com/17578185/87829797-9745a580-c834-11ea-969c-e79dfc25f2cc.png">
[mkpy3_bad_radec_bug_v1.py.txt](https://github.com/KeplerGO/lightkurve/files/4940205/mkpy3_bad_radec_bug_v1.py.txt)

The attached Python3 function detects a bug in the tpf.get_coordinates() method which uses an origin=1 value instead of origin=0 when calling astropy's wcs.wcs_pix2world(x, y, origin) method.  See the attached documentation PNG.

I have made the change locally and the proposed changes fixes the bug.

I added 'x' to the version name just to help me track which version of lightkurve I was using (mine vs. master).