### PR TITLE
[WIP] CDIPS reader

### DIFF
--- a/lightkurve/io/__init__.py
+++ b/lightkurve/io/__init__.py
@@ -20,7 +20,7 @@ try:
     registry.register_reader('k2sff', LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader('everest', LightCurve, everest.read_everest_lightcurve)
     registry.register_reader('pathos', LightCurve, pathos.read_pathos_lightcurve)
-    registry.register_reader('cdips', LightCurve, pathos.read_cdips_lightcurve)
+    registry.register_reader('cdips', LightCurve, cdips.read_cdips_lightcurve)
     registry.register_reader('tasoc', LightCurve, tasoc.read_tasoc_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/lightkurve/io/__init__.py
+++ b/lightkurve/io/__init__.py
@@ -20,6 +20,7 @@ try:
     registry.register_reader('k2sff', LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader('everest', LightCurve, everest.read_everest_lightcurve)
     registry.register_reader('pathos', LightCurve, pathos.read_pathos_lightcurve)
+    registry.register_reader('cdips', LightCurve, pathos.read_cdips_lightcurve)
     registry.register_reader('tasoc', LightCurve, tasoc.read_tasoc_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/lightkurve/io/__init__.py
+++ b/lightkurve/io/__init__.py
@@ -2,7 +2,7 @@
 from .detect import *
 from .read import *
 
-from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc
+from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, cdips
 from .. import LightCurve
 
 from astropy.io import registry

--- a/lightkurve/io/cdips.py
+++ b/lightkurve/io/cdips.py
@@ -1,0 +1,74 @@
+"""Reader for A PSF-Based Approach to TESS Cluster Difference Imaging Photometric Survey (CDIPS) light curves
+
+Website: https://archive.stsci.edu/hlsp/cdips
+Product Description: https://archive.stsci.edu/hlsps/cdips/hlsp_cdips_tess_ffi_all_tess_v01_readme.md
+"""
+from ..lightcurve import TessLightCurve
+from ..utils import TessQualityFlags
+
+from .generic import read_generic_lightcurve
+
+
+def read_cdips_lightcurve(filename,
+                            flux_column="IRM1",
+                            include_inst_errs=False):
+    """Returns a `TessLightCurve`.
+
+    Note: CDIPS light curves have already had quality filtering applied, and
+    do not provide the bitflags necessary for a user to apply a new bitmask.
+    Therefore, frames corresponding to "momentum dumps and coarse point modes"
+    are removed according to Bouma et al. 2019, and no other quality filtering
+    is allowed.
+
+    Parameters
+    ----------
+    filename : str
+        Local path or remote url of CDIPS light curve FITS file.
+    flux_column : str
+        'IFL#', 'IRM#', 'TFA#', or 'PCA#' (# = 1, 2, or 3)
+        Which column in the FITS file contains the preferred flux data?
+    include_inst_errs: bool
+        Whether to include the instrumental flux/magnitude errors
+        (Errors are not provided for trend-filtered magnitudes)
+    """
+    ap = flux_column[-1]
+
+    # Only the instrumental magnitudes are provided, and are not provided for
+    # trend-filtered light curves. User should select whether to include the
+    # instrumental errors or ignore them
+    if include_inst_errs:
+        # If fluxes are requested, return flux errors
+        if flux_column[:-1].lower()=="ifl":
+            flux_err_column = f"ife{ap}"
+        # Otherwise magnitudes are being requested, return magnitude errors
+        else:
+            flux_err_column = f"ire{ap}"
+    else:
+        flux_err_column = ""
+
+    # Set the appropriate error column for this aperture
+    quality_column = f"irq{ap}"
+
+    lc = read_generic_lightcurve(filename,
+                                 time_column="tmid_bjd",
+                                 flux_column=flux_column.lower(),
+                                 flux_err_column=flux_err_column,
+                                 quality_column=quality_column,
+                                 time_format='bjd')
+
+    # Filter out poor-quality data
+    # NOTE: Unfortunately Astropy Table masking does not yet work for columns
+    # that are Quantity objects, so for now we remove poor-quality data instead
+    # of masking. Details: https://github.com/astropy/astropy/issues/10119
+
+    # CDIPS uses their own quality keywords instead of the default bitflags
+    # Based on Bouma+2019, they filter out coarse point (4) and desat (32)
+    # as well as other cadences flagged for particular sectors
+    quality_mask = (lc['quality']=="G") | (lc['quality']=="0")
+    lc = lc[quality_mask]
+
+    lc.meta['TARGETID'] = lc.meta.get('TICID')
+    lc.meta['QUALITY_BITMASK'] = 36
+    lc.meta['QUALITY_MASK'] = quality_mask
+
+    return TessLightCurve(data=lc)

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -1,6 +1,5 @@
 """Provides a function to automatically detect Kepler/TESS file types."""
 from astropy.io.fits import HDUList
-from astropy.io import fits
 
 
 __all__ = ['detect_filetype']
@@ -24,7 +23,6 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'K2VARCAT'`
         * `'QLP'`
         * `'PATHOS'`
-        * `'TASOC'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -53,12 +51,14 @@ def detect_filetype(hdulist: HDUList) -> str:
     if all(x in hdulist[1].columns.names for x in ["PSF_FLUX_RAW", "PSF_FLUX_COR", "AP4_FLUX_RAW", "AP4_FLUX_COR", "SKY_LOCAL"]):
         return "PATHOS"
 
-    # Is it a TASOC TESS light curve?
-    # cf. https://tasoc.dk and https://archive.stsci.edu/hlsp/tasoc
-    if hdulist[0].header.get('ORIGIN') == "TASOC/Aarhus":
-        return "TASOC"
+    # Is it a CDIPS TESS light curve?
+    # cf. http://archive.stsci.edu/hlsp/cdips
+    # The 'cdips' name doesn't stay in the filename when we use fits.open
+    # to download a file, so we have to check for the origin in the header
+    if (("ORIGIN" in list(hdulist[0].header.keys())) and
+        ("CDIPS" in hdulist[0]["ORIGIN"])):
+        return "CDIPS"
 
-    
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.
     if "hlsp_k2varcat" in (hdulist.filename() or ""):

--- a/lightkurve/io/detect.py
+++ b/lightkurve/io/detect.py
@@ -23,6 +23,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'K2VARCAT'`
         * `'QLP'`
         * `'PATHOS'`
+        * `'CDIPS'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -55,8 +56,7 @@ def detect_filetype(hdulist: HDUList) -> str:
     # cf. http://archive.stsci.edu/hlsp/cdips
     # The 'cdips' name doesn't stay in the filename when we use fits.open
     # to download a file, so we have to check for the origin in the header
-    if (("ORIGIN" in list(hdulist[0].header.keys())) and
-        ("CDIPS" in hdulist[0]["ORIGIN"])):
+    if "cdips" in hdulist[0].header.get("ORIGIN","").lower():
         return "CDIPS"
 
     # Is it a K2VARCAT file?

--- a/lightkurve/io/read.py
+++ b/lightkurve/io/read.py
@@ -94,6 +94,8 @@ def read(path_or_url, **kwargs):
         return TessLightCurve.read(path_or_url, format='qlp', **kwargs)
     elif filetype == "PATHOS":
         return TessLightCurve.read(path_or_url, format='pathos', **kwargs)
+    elif filetype == "CDIPS":
+        return TessLightCurve.read(path_or_url, format='cdips', **kwargs)
     elif filetype == "TASOC":
         return TessLightCurve.read(path_or_url, format='tasoc', **kwargs)
     elif filetype == "K2SFF":

--- a/lightkurve/io/tests/test_cdips.py
+++ b/lightkurve/io/tests/test_cdips.py
@@ -1,0 +1,55 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from ... import search_lightcurve
+from ..cdips import read_cdips_lightcurve
+from ..detect import detect_filetype
+
+@pytest.mark.remote_data
+def test_detect_cdips():
+    """Can we detect the correct format for CDIPS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/cdips/s0008/cam3_ccd4/hlsp_cdips_tess_ffi_gaiatwo0005318059532750974720-0008-cam3-ccd4_tess_v01_llc.fits"
+    f = fits.open(url)
+
+    assert detect_filetype(f)=="CDIPS"
+
+
+@pytest.mark.remote_data
+def test_read_cdips():
+    """Can we read CDIPS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/cdips/s0008/cam3_ccd4/hlsp_cdips_tess_ffi_gaiatwo0005318059532750974720-0008-cam3-ccd4_tess_v01_llc.fits"
+    f = fits.open(url)
+    # Verify different extensions
+    fluxes = []
+
+    # Test instrumental flux and magnitude, and detrended magnitudes
+    exts = [f'IFL{ap}' for ap in [1,2,3]]
+    exts.extend([f'IRM{ap}' for ap in [1,2,3]])
+    exts.extend([f'TFA{ap}' for ap in [1,2,3]])
+    exts.extend([f'PCA{ap}' for ap in [1,2,3]])
+
+    for ext in exts:
+        lc = read_cdips_lightcurve(url, flux_column=ext)
+        assert type(lc).__name__ == "TessLightCurve"
+        # Are `time` and `flux` consistent with the FITS file?
+        assert_array_equal(f[1].data['TIME'][lc.meta['QUALITY_MASK']],
+                           lc.time.value)
+        assert_array_equal(f[1].data[ext][lc.meta['QUALITY_MASK']],
+                           lc.flux.value)
+        fluxes.append(lc.flux)
+    # Different extensions should show different fluxes
+    for i in range(11):
+        assert not np.array_equal(fluxes[i] , fluxes[i+1])
+
+@pytest.mark.remote_data
+def test_search_cdips():
+    """Can we search and download a cdips light curve?"""
+    search = search_lightcurve("TIC 93270923", author="CDIPS", sector=8)
+    assert len(search) == 1
+    assert search.table["author"][0] == "CDIPS"
+    lc = search.download()
+    assert type(lc).__name__ == "TessLightCurve"
+    assert lc.sector == 8


### PR DESCRIPTION
Includes functions to read in a CDIPS light curve, in response to #918 

One particular issue that came up is the fact that the CDIPS lightcurves do not include the standard bitflags for quality. Based on [Bouma et al. 2019](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...13B/abstract), the authors removed CoarsePoint (4) and momentum dump/desat (32) flags by default, as well as other cadences identified in the data release notes for each sector. Those deleted cadences are 0s or nans in the resulting lightcurve. Therefore, I removed the ability for the user to pass a quality_bitmask to the cdips reader, and simply deleted any datapoints that the CDIPS authors flagged as bad. 

This is still a WIP until I make sure the CI tests pass. 