### PR TITLE
Format Lightkurve 2 using "black" formatting

### DIFF
--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -3,8 +3,9 @@
 from __future__ import absolute_import
 
 import os
+
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
-MPLSTYLE = '{}/data/lightkurve.mplstyle'.format(PACKAGEDIR)
+MPLSTYLE = "{}/data/lightkurve.mplstyle".format(PACKAGEDIR)
 
 
 # Bibtex entry detailing how to cite the package
@@ -28,6 +29,7 @@ archivePrefix = "ascl",
 
 
 import logging
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -15,7 +15,7 @@ from .utils import LightkurveDeprecationWarning
 
 log = logging.getLogger(__name__)
 
-__all__ = ['LightCurveCollection', 'TargetPixelFileCollection']
+__all__ = ["LightCurveCollection", "TargetPixelFileCollection"]
 
 
 class Collection(object):
@@ -40,6 +40,7 @@ class Collection(object):
 
         >>>  lcc_filtered = lcc[0, 2]  # doctest: +SKIP
     """
+
     def __init__(self, data):
         if data is not None:
             # ensure we have our own container
@@ -51,24 +52,28 @@ class Collection(object):
         return len(self.data)
 
     def __getitem__(self, index_or_mask):
-        if (isinstance(index_or_mask, (int, np.integer, slice))):
+        if isinstance(index_or_mask, (int, np.integer, slice)):
             return self.data[index_or_mask]
-        elif (all([isinstance(i, (bool, np.bool_)) for i in index_or_mask])):
+        elif all([isinstance(i, (bool, np.bool_)) for i in index_or_mask]):
             # case indexOrMask is bool array like, e.g., np.ndarray, collections.abc.Sequence, etc.
 
             # note: filter using nd.array is very slow
             #   np.array(self.data)[np.nonzero(indexOrMask)]
             # specifically, nd.array(self.data) is very slow, as it deep copies the data
             # so we create the filtered list on our own
-            if (len(index_or_mask) != len(self.data)):
-                raise IndexError(f'boolean index did not match indexed array; dimension is {len(self.data)} '
-                                 f'but corresponding boolean dimension is {len(index_or_mask)}')
+            if len(index_or_mask) != len(self.data):
+                raise IndexError(
+                    f"boolean index did not match indexed array; dimension is {len(self.data)} "
+                    f"but corresponding boolean dimension is {len(index_or_mask)}"
+                )
             return type(self)([self.data[i] for i in np.nonzero(index_or_mask)[0]])
-        elif (all([isinstance(i, (int, np.integer)) for i in index_or_mask])):
+        elif all([isinstance(i, (int, np.integer)) for i in index_or_mask]):
             # case int array like, follow ndarray behavior
             return type(self)([self.data[i] for i in index_or_mask])
         else:
-            raise IndexError('only integers, slices (`:`) and integer or boolean arrays are valid indices')
+            raise IndexError(
+                "only integers, slices (`:`) and integer or boolean arrays are valid indices"
+            )
 
     def __setitem__(self, index, obj):
         self.data[index] = obj
@@ -85,10 +90,10 @@ class Collection(object):
 
     def __repr__(self):
         result = "{} of {} objects:\n".format(self.__class__.__name__, len(self.data))
-        if (isinstance(self[0], TargetPixelFile)):
+        if isinstance(self[0], TargetPixelFile):
             labels = np.asarray([tpf.targetid for tpf in self])
         else:
-            labels = np.asarray([lc.meta.get('LABEL') for lc in self])
+            labels = np.asarray([lc.meta.get("LABEL") for lc in self])
 
         try:
             unique_labels = np.sort(np.unique(labels))
@@ -97,29 +102,34 @@ class Collection(object):
 
         for idx, targetid in enumerate(unique_labels):
             jdxs = np.where(labels == targetid)[0]
-            if not hasattr(jdxs, '__iter__'):
+            if not hasattr(jdxs, "__iter__"):
                 jdxs = [jdxs]
 
-            if hasattr(self[jdxs[0]], 'mission'):
+            if hasattr(self[jdxs[0]], "mission"):
                 mission = self[jdxs[0]].mission
-                if mission == 'Kepler':
-                    subtype = 'Quarters'
-                elif mission == 'K2':
-                    subtype = 'Campaigns'
-                elif mission == 'TESS':
-                    subtype = 'Sectors'
+                if mission == "Kepler":
+                    subtype = "Quarters"
+                elif mission == "K2":
+                    subtype = "Campaigns"
+                elif mission == "TESS":
+                    subtype = "Sectors"
                 else:
                     subtype = None
             else:
                 subtype = None
-            objstr = str(type(self[0]))[8:-2].split('.')[-1]
-            title = '\t{} ({} {}s) {}: '.format(targetid, len(jdxs), objstr, subtype)
+            objstr = str(type(self[0]))[8:-2].split(".")[-1]
+            title = "\t{} ({} {}s) {}: ".format(targetid, len(jdxs), objstr, subtype)
             result += title
             if subtype is not None:
-                result += ','.join(['{}'.format(getattr(self[jdx], subtype[:-1].lower())) for jdx in jdxs])
+                result += ",".join(
+                    [
+                        "{}".format(getattr(self[jdx], subtype[:-1].lower()))
+                        for jdx in jdxs
+                    ]
+                )
             else:
-                result += ','.join(['{}'.format(i) for i in np.arange(len(jdxs))])
-            result += '\n'
+                result += ",".join(["{}".format(i) for i in np.arange(len(jdxs))])
+            result += "\n"
         return result
 
     def _safeGetScalarAttr(self, attrName):
@@ -145,7 +155,7 @@ class Collection(object):
             >>> lcc[lcc.sector == 22][0].plot()  # doctest: +SKIP
 
         """
-        return self._safeGetScalarAttr('sector')
+        return self._safeGetScalarAttr("sector")
 
     @property
     def quarter(self):
@@ -153,7 +163,7 @@ class Collection(object):
 
         The Kepler quarters of the lightcurves / target pixel files; `numpy.nan` for those with none.
         """
-        return self._safeGetScalarAttr('quarter')
+        return self._safeGetScalarAttr("quarter")
 
     @property
     def campaign(self):
@@ -161,7 +171,7 @@ class Collection(object):
 
         The K2 campaigns of the lightcurves / target pixel files; `numpy.nan` for those with none.
         """
-        return self._safeGetScalarAttr('campaign')
+        return self._safeGetScalarAttr("campaign")
 
 
 class LightCurveCollection(Collection):
@@ -172,6 +182,7 @@ class LightCurveCollection(Collection):
     lightcurves : array-like
         List of LightCurve objects.
     """
+
     def __init__(self, lightcurves):
         super(LightCurveCollection, self).__init__(lightcurves)
 
@@ -192,7 +203,7 @@ class LightCurveCollection(Collection):
         return LightCurveCollection([lc.SAP_FLUX for lc in self])
 
     def stitch(self, corrector_func=lambda x: x.normalize()):
-        """ Stitch all light curves in the collection into a single lk.LightCurve
+        """Stitch all light curves in the collection into a single lk.LightCurve
 
         Any function passed to `corrector_func` will be applied to each light curve
         before stitching. For example, passing "lambda x: x.normalize().flatten()"
@@ -214,9 +225,9 @@ class LightCurveCollection(Collection):
             corrector_func = lambda x: x  # noqa: E731
         lcs = [corrector_func(lc) for lc in self]
         # Need `join_type='inner'` until AstroPy supports masked Quantities
-        return vstack(lcs, join_type='inner', metadata_conflicts='silent')
+        return vstack(lcs, join_type="inner", metadata_conflicts="silent")
 
-    def plot(self, ax=None, offset=0., **kwargs) -> matplotlib.axes.Axes:
+    def plot(self, ax=None, offset=0.0, **kwargs) -> matplotlib.axes.Axes:
         """Plots all light curves in the collection on a single plot.
 
         Parameters
@@ -242,11 +253,11 @@ class LightCurveCollection(Collection):
         with plt.style.context(MPLSTYLE):
             if ax is None:
                 _, ax = plt.subplots()
-            for kwarg in ['c', 'color', 'label']:
+            for kwarg in ["c", "color", "label"]:
                 if kwarg in kwargs:
                     kwargs.pop(kwarg)
 
-            labels = np.asarray([lc.meta.get('LABEL') for lc in self])
+            labels = np.asarray([lc.meta.get("LABEL") for lc in self])
             try:
                 unique_labels = np.sort(np.unique(labels))
             except TypeError:  # sorting will fail if labels includes None
@@ -256,8 +267,8 @@ class LightCurveCollection(Collection):
                 jdxs = np.where(labels == targetid)[0]
                 for jdx in np.atleast_1d(jdxs):
                     if jdx != jdxs[0]:  # Avoid multiple labels for same object
-                        kwargs['label'] = ''
-                    self[jdx].plot(ax=ax, c=f'C{idx}', offset=idx*offset, **kwargs)
+                        kwargs["label"] = ""
+                    self[jdx].plot(ax=ax, c=f"C{idx}", offset=idx * offset, **kwargs)
         return ax
 
 
@@ -269,6 +280,7 @@ class TargetPixelFileCollection(Collection):
     tpfs : list or iterable
         List of `~lightkurve.targetpixelfile.TargetPixelFile` objects.
     """
+
     def __init__(self, tpfs):
         super(TargetPixelFileCollection, self).__init__(tpfs)
 
@@ -288,8 +300,7 @@ class TargetPixelFileCollection(Collection):
             The matplotlib axes object.
         """
         if ax is None:
-            _, ax = plt.subplots(len(self.data), 1,
-                                 figsize=(7, (7*len(self.data))))
+            _, ax = plt.subplots(len(self.data), 1, figsize=(7, (7 * len(self.data))))
         if len(self.data) == 1:
             self.data[0].plot(ax=ax)
         else:

--- a/src/lightkurve/convenience.py
+++ b/src/lightkurve/convenience.py
@@ -5,7 +5,7 @@ import numpy as np
 from .lightcurve import LightCurve
 
 
-__all__ = ['estimate_cdpp']
+__all__ = ["estimate_cdpp"]
 
 
 def estimate_cdpp(flux, **kwargs):

--- a/src/lightkurve/correctors/corrector.py
+++ b/src/lightkurve/correctors/corrector.py
@@ -118,7 +118,7 @@ class Corrector(ABC):
         pass
 
     def compute_overfit_metric(self, **kwargs) -> float:
-        """ Measures the degree of over-fitting in the correction.
+        """Measures the degree of over-fitting in the correction.
 
         See the docstring of `lightkurve.correctors.metrics.overfit_metric_lombscargle`
         for details.

--- a/src/lightkurve/correctors/designmatrix.py
+++ b/src/lightkurve/correctors/designmatrix.py
@@ -17,11 +17,15 @@ from .. import MPLSTYLE
 from ..utils import LightkurveWarning, plot_image
 
 
-__all__ = ['DesignMatrix', 'SparseDesignMatrix',
-           'DesignMatrixCollection', 'SparseDesignMatrixCollection']
+__all__ = [
+    "DesignMatrix",
+    "SparseDesignMatrix",
+    "DesignMatrixCollection",
+    "SparseDesignMatrixCollection",
+]
 
 
-class DesignMatrix():
+class DesignMatrix:
     """A matrix of column vectors for use in linear regression.
 
     The purpose of this class is to provide a convenient method to interact
@@ -54,8 +58,10 @@ class DesignMatrix():
     >>> create_spline_matrix(np.arange(100), n_knots=5, name='spline')
     spline DesignMatrix (100, 5)
     """
-    def __init__(self, df, columns=None, name='unnamed_matrix', prior_mu=None,
-                 prior_sigma=None):
+
+    def __init__(
+        self, df, columns=None, name="unnamed_matrix", prior_mu=None, prior_sigma=None
+    ):
         if not isinstance(df, pd.DataFrame):
             df = pd.DataFrame(df)
         self.df = df
@@ -99,14 +105,22 @@ class DesignMatrix():
             The matplotlib axes object.
         """
         with plt.style.context(MPLSTYLE):
-            ax = plot_image(self.values, ax=ax, xlabel='Component', ylabel='X',
-                            clabel='Component Value', title=self.name,
-                            interpolation='nearest', **kwargs)
-            ax.set_aspect(self.shape[1]/(1.6*self.shape[0]))
+            ax = plot_image(
+                self.values,
+                ax=ax,
+                xlabel="Component",
+                ylabel="X",
+                clabel="Component Value",
+                title=self.name,
+                interpolation="nearest",
+                **kwargs
+            )
+            ax.set_aspect(self.shape[1] / (1.6 * self.shape[0]))
             if self.shape[1] <= 40:
                 ax.set_xticks(np.arange(self.shape[1]))
-                ax.set_xticklabels([r'${}$'.format(i) for i in self.columns],
-                                   rotation=90, fontsize=8)
+                ax.set_xticklabels(
+                    [r"${}$".format(i) for i in self.columns], rotation=90, fontsize=8
+                )
         return ax
 
     def plot_priors(self, ax=None):
@@ -123,19 +137,21 @@ class DesignMatrix():
         `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
+
         def gauss(x, mu=0, sigma=1):
-            return np.exp(-(x - mu)**2/(2*sigma**2))
+            return np.exp(-((x - mu) ** 2) / (2 * sigma ** 2))
+
         with plt.style.context(MPLSTYLE):
             if ax is None:
                 _, ax = plt.subplots()
             for m, s in zip(self.prior_mu, self.prior_sigma):
                 if ~np.isfinite(s):
-                    ax.axhline(1, color='k')
+                    ax.axhline(1, color="k")
                 else:
-                    x = np.linspace(m - 5*s, m + 5*s, 1000)
-                    ax.plot(x, gauss(x, m, s), c='k')
-            ax.set_xlabel('Value')
-            ax.set_title('{} Priors'.format(self.name))
+                    x = np.linspace(m - 5 * s, m + 5 * s, 1000)
+                    ax.plot(x, gauss(x, m, s), c="k")
+            ax.set_xlabel("Value")
+            ax.set_title("{} Priors".format(self.name))
         return ax
 
     def _get_prior_sample(self):
@@ -173,8 +189,9 @@ class DesignMatrix():
         dfs = []
         for idx, a, b in zip(range(len(lower_idx)), lower_idx, upper_idx):
             new_columns = dict(
-                ('{}'.format(val), '{}'.format(val) + ' {}'.format(idx + 1))
-                for val in list(self.df.columns))
+                ("{}".format(val), "{}".format(val) + " {}".format(idx + 1))
+                for val in list(self.df.columns)
+            )
             dfs.append(self.df[a:b].rename(columns=new_columns))
 
         prior_mu = np.hstack([self.prior_mu for idx in range(len(dfs))])
@@ -250,6 +267,7 @@ class DesignMatrix():
         # we find this to be too few, and that n_iter=10 is still fast but
         # produces more stable results.
         from fbpca import pca  # local import because not used elsewhere
+
         new_values, _, _ = pca(self.values, nterms, n_iter=10)
         return DesignMatrix(new_values, name=self.name)
 
@@ -266,7 +284,9 @@ class DesignMatrix():
             dm = self
         else:
             dm = self.copy()
-        extra_df = pd.DataFrame(np.atleast_2d(np.ones(self.shape[0])).T, columns=['offset'])
+        extra_df = pd.DataFrame(
+            np.atleast_2d(np.ones(self.shape[0])).T, columns=["offset"]
+        )
         dm.df = pd.concat([self.df, extra_df], axis=1)
         dm.columns = list(dm.df.columns)
         dm.prior_mu = np.append(self.prior_mu, prior_mu)
@@ -277,25 +297,30 @@ class DesignMatrix():
         """Helper function for validating."""
         # Matrix rank shouldn't be significantly smaller than the # of columns
         if rank:
-            if self.rank < (0.5*self.shape[1]):
-                warnings.warn("The design matrix has low rank ({}) compared to the "
-                              "number of columns ({}), which suggests that the "
-                              "matrix contains duplicate or correlated columns. "
-                              "This may prevent the regression from succeeding. "
-                              "Consider reducing the dimensionality by calling the "
-                              "`pca()` method.".format(self.rank, self.shape[1]),
-                              LightkurveWarning)
+            if self.rank < (0.5 * self.shape[1]):
+                warnings.warn(
+                    "The design matrix has low rank ({}) compared to the "
+                    "number of columns ({}), which suggests that the "
+                    "matrix contains duplicate or correlated columns. "
+                    "This may prevent the regression from succeeding. "
+                    "Consider reducing the dimensionality by calling the "
+                    "`pca()` method.".format(self.rank, self.shape[1]),
+                    LightkurveWarning,
+                )
         if self.prior_mu is not None:
             if len(self.prior_mu) != self.shape[1]:
-                raise ValueError('`prior_mu` must have shape {}'
-                                 ''.format(self.shape[1]))
+                raise ValueError(
+                    "`prior_mu` must have shape {}" "".format(self.shape[1])
+                )
         if self.prior_sigma is not None:
             if len(self.prior_sigma) != self.shape[1]:
-                raise ValueError('`prior_sigma` must have shape {}'
-                                 ''.format(self.shape[1]))
+                raise ValueError(
+                    "`prior_sigma` must have shape {}" "".format(self.shape[1])
+                )
             if np.any(np.asarray(self.prior_sigma) <= 0):
-                raise ValueError('`prior_sigma` values cannot be smaller than '
-                                 'or equal to zero')
+                raise ValueError(
+                    "`prior_sigma` values cannot be smaller than " "or equal to zero"
+                )
 
     def validate(self, rank=True):
         """Emits `LightkurveWarning` if matrix has low rank or priors have incorrect shape.
@@ -327,7 +352,7 @@ class DesignMatrix():
         return self.df[key].values
 
     def __repr__(self):
-        return '{} DesignMatrix {}'.format(self.name, self.shape)
+        return "{} DesignMatrix {}".format(self.name, self.shape)
 
     def to_sparse(self):
         """Convert this dense matrix object to a `SparseDesignMatrix`.
@@ -336,18 +361,20 @@ class DesignMatrix():
         `scipy.sparse.csr_matrix`, which stores the values in a
         lower memory matrix. This is not recommended for dense matrices.
         """
-        return SparseDesignMatrix(csr_matrix(self.values),
-                                  name=self.name,
-                                  columns=self.columns,
-                                  prior_mu=self.prior_mu,
-                                  prior_sigma=self.prior_sigma)
+        return SparseDesignMatrix(
+            csr_matrix(self.values),
+            name=self.name,
+            columns=self.columns,
+            prior_mu=self.prior_mu,
+            prior_sigma=self.prior_sigma,
+        )
 
     def collect(self, matrix):
         """ Join two designmatrices, return a design matrix collection """
         return DesignMatrixCollection([self, matrix])
 
 
-class DesignMatrixCollection():
+class DesignMatrixCollection:
     """Object which stores multiple design matrices.
 
     DesignMatrixCollection objects are useful when users want to regress against
@@ -366,13 +393,18 @@ class DesignMatrixCollection():
     >>> dmc.matrices
     [spline DesignMatrix (100, 5), slope DesignMatrix (100, 1)]
     """
+
     def __init__(self, matrices):
         if np.any([issparse(m.X) for m in matrices]):
             # This collection is designed for dense matrices, so we warn if a
             # SparseDesignMatrix is passed
-            warnings.warn(('Some matrices are `SparseDesignMatrix` objects. '
-                           'Sparse matrices will be converted to dense matrices.'),
-                          LightkurveWarning)
+            warnings.warn(
+                (
+                    "Some matrices are `SparseDesignMatrix` objects. "
+                    "Sparse matrices will be converted to dense matrices."
+                ),
+                LightkurveWarning,
+            )
             dense_matrices = []
             for m in matrices:
                 if isinstance(m, SparseDesignMatrix):
@@ -494,18 +526,21 @@ class DesignMatrixCollection():
         [d.validate() for d in self]
 
     def __repr__(self):
-        return 'DesignMatrixCollection:\n' + \
-                    ''.join(['\t{}\n'.format(i.__repr__()) for i in self])
+        return "DesignMatrixCollection:\n" + "".join(
+            ["\t{}\n".format(i.__repr__()) for i in self]
+        )
 
     def to_designmatrix(self, name=None):
         """Flatten a `DesignMatrixCollection` into a `DesignMatrix`."""
         if name is None:
             name = self.matrices[0].name
-        return self._child_class(self.X,
-                                 columns=self.columns,
-                                 prior_mu=self.prior_mu,
-                                 prior_sigma=self.prior_sigma,
-                                 name=name)
+        return self._child_class(
+            self.X,
+            columns=self.columns,
+            prior_mu=self.prior_mu,
+            prior_sigma=self.prior_sigma,
+            name=name,
+        )
 
 
 class SparseDesignMatrix(DesignMatrix):
@@ -535,10 +570,14 @@ class SparseDesignMatrix(DesignMatrix):
         Prior standard deviations of the coefficients associated with each
         column in a linear regression problem.
     """
-    def __init__(self, X, columns=None, name='unnamed_matrix', prior_mu=None,
-                 prior_sigma=None):
+
+    def __init__(
+        self, X, columns=None, name="unnamed_matrix", prior_mu=None, prior_sigma=None
+    ):
         if not issparse(X):
-            raise ValueError('Must pass a `scipy.sparse` matrix (e.g. `scipy.sparse.csr_matrix`)')
+            raise ValueError(
+                "Must pass a `scipy.sparse` matrix (e.g. `scipy.sparse.csr_matrix`)"
+            )
         if columns is None:
             columns = np.arange(X.shape[1])
         self.columns = columns
@@ -590,11 +629,13 @@ class SparseDesignMatrix(DesignMatrix):
             A new design matrix with shape (n_rows, len(row_indices)*n_columns).
         """
 
-        if not hasattr(row_indices, '__iter__'):
+        if not hasattr(row_indices, "__iter__"):
             row_indices = [row_indices]
 
         # You can't split on the first or last index
-        row_indices = list(np.asarray(row_indices)[~np.in1d(row_indices, [0, self.shape[0]])])
+        row_indices = list(
+            np.asarray(row_indices)[~np.in1d(row_indices, [0, self.shape[0]])]
+        )
         if len(row_indices) == 0:
             return self
         if inplace:
@@ -603,13 +644,28 @@ class SparseDesignMatrix(DesignMatrix):
             dm = self.copy()
         x = np.arange(dm.shape[0])
         dm.prior_mu = np.concatenate([list(self.prior_mu) * (len(row_indices) + 1)])
-        dm.prior_sigma = np.concatenate([list(self.prior_sigma) * (len(row_indices) + 1)])
-        dm._X = hstack([dm.X.multiply(lil_matrix(np.in1d(x, idx).astype(int)).T) for idx in np.array_split(x, row_indices)], format='lil')
+        dm.prior_sigma = np.concatenate(
+            [list(self.prior_sigma) * (len(row_indices) + 1)]
+        )
+        dm._X = hstack(
+            [
+                dm.X.multiply(lil_matrix(np.in1d(x, idx).astype(int)).T)
+                for idx in np.array_split(x, row_indices)
+            ],
+            format="lil",
+        )
         non_zero = dm.X.sum(axis=0) != 0
         non_zero = np.asarray(non_zero).ravel()
         dm._X = dm.X[:, non_zero]
         if dm.columns is not None:
-            dm.columns = list(np.asarray([['{}_{}'.format(c, idx) for c in dm.columns] for idx in range(len(row_indices) + 1)]).ravel())
+            dm.columns = list(
+                np.asarray(
+                    [
+                        ["{}_{}".format(c, idx) for c in dm.columns]
+                        for idx in range(len(row_indices) + 1)
+                    ]
+                ).ravel()
+            )
         dm.prior_mu = dm.prior_mu[non_zero]
         dm.prior_sigma = dm.prior_sigma[non_zero]
         return dm
@@ -643,11 +699,19 @@ class SparseDesignMatrix(DesignMatrix):
         idx, jdx, v = find(dm.X)
         weights = dm.X.copy()
         weights[dm.X != 0] = 1
-        mean = np.bincount(jdx, weights=v)/np.bincount(jdx)
-        std = np.asarray([((np.sum((v[jdx == i] - mean[i])**2) * (1/((jdx == i).sum() - 1))))**0.5 for i in np.unique(jdx)])
+        mean = np.bincount(jdx, weights=v) / np.bincount(jdx)
+        std = np.asarray(
+            [
+                ((np.sum((v[jdx == i] - mean[i]) ** 2) * (1 / ((jdx == i).sum() - 1))))
+                ** 0.5
+                for i in np.unique(jdx)
+            ]
+        )
         mean[std == 0] = 0
         std[std == 0] = 1
-        white = (dm.X - vstack([lil_matrix(mean)] * dm.shape[0])).multiply(vstack([lil_matrix(1/std)] * dm.shape[0]))
+        white = (dm.X - vstack([lil_matrix(mean)] * dm.shape[0])).multiply(
+            vstack([lil_matrix(1 / std)] * dm.shape[0])
+        )
         dm._X = white.multiply(weights)
         return dm
 
@@ -682,7 +746,7 @@ class SparseDesignMatrix(DesignMatrix):
             dm = self
         else:
             dm = self.copy()
-        dm._X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format='lil')
+        dm._X = hstack([dm.X, lil_matrix(np.ones(dm.shape[0])).T], format="lil")
         dm.prior_mu = np.append(dm.prior_mu, prior_mu)
         dm.prior_sigma = np.append(dm.prior_sigma, prior_sigma)
         return dm
@@ -690,35 +754,45 @@ class SparseDesignMatrix(DesignMatrix):
     def __getitem__(self, key):
         loc = np.where(np.asarray(self.columns) == key)[0]
         if len(loc) == 0:
-            raise ValueError('No such column as `{}`.'.format(key))
+            raise ValueError("No such column as `{}`.".format(key))
         return self.X[:, loc].toarray()
 
     def __repr__(self):
-        return '{} SparseDesignMatrix {}'.format(self.name, self.shape)
+        return "{} SparseDesignMatrix {}".format(self.name, self.shape)
 
     def collect(self, matrix):
         """ Join two designmatrices, return a design matrix collection """
         return SparseDesignMatrixCollection([self, matrix])
 
     def to_dense(self):
-        """ Convert a SparseDesignMatrix object to a dense DesignMatrix
+        """Convert a SparseDesignMatrix object to a dense DesignMatrix
 
         The values of this design matrix will be converted to a
         `numpy.ndarray`. This is not recommended for sparse matrices containing
         mostly zeros.
         """
-        return DesignMatrix(self.values, name=self.name,
-                            columns=self.columns, prior_mu=self.prior_mu,
-                            prior_sigma=self.prior_sigma)
+        return DesignMatrix(
+            self.values,
+            name=self.name,
+            columns=self.columns,
+            prior_mu=self.prior_mu,
+            prior_sigma=self.prior_sigma,
+        )
 
 
 class SparseDesignMatrixCollection(DesignMatrixCollection):
     """A set of design matrices."""
+
     def __init__(self, matrices):
         if not np.all([issparse(m.X) for m in matrices]):
             # This collection is designed for sparse matrices, so we raise a warning if a dense DesignMatrix is passed
-            warnings.warn(('Not all matrices are `SparseDesignMatrix` objects. '
-                            'Dense matrices will be converted to sparse matrices.'), LightkurveWarning)
+            warnings.warn(
+                (
+                    "Not all matrices are `SparseDesignMatrix` objects. "
+                    "Dense matrices will be converted to sparse matrices."
+                ),
+                LightkurveWarning,
+            )
             sparse_matrices = []
             for m in matrices:
                 if isinstance(m, DesignMatrix):
@@ -728,7 +802,7 @@ class SparseDesignMatrixCollection(DesignMatrixCollection):
             self.matrices = sparse_matrices
         else:
             self.matrices = matrices
-        self.X = hstack([m.X for m in self.matrices], format='csr')
+        self.X = hstack([m.X for m in self.matrices], format="csr")
         self._child_class = SparseDesignMatrix
         self.validate()
 
@@ -757,14 +831,15 @@ class SparseDesignMatrixCollection(DesignMatrixCollection):
         return ax
 
     def __repr__(self):
-        return 'SparseDesignMatrixCollection:\n' + \
-                    ''.join(['\t{}\n'.format(i.__repr__()) for i in self])
-
+        return "SparseDesignMatrixCollection:\n" + "".join(
+            ["\t{}\n".format(i.__repr__()) for i in self]
+        )
 
 
 ####################################################
 # Functions to create commonly-used design matrices.
 ####################################################
+
 
 @jit(nopython=True)
 def _spline_basis_vector(x, degree, i, knots):
@@ -792,23 +867,25 @@ def _spline_basis_vector(x, degree, i, knots):
     """
     if degree == 0:
         B = np.zeros(len(x))
-        B[(x >= knots[i]) & (x <= knots[i+1])] = 1
+        B[(x >= knots[i]) & (x <= knots[i + 1])] = 1
     else:
-        da = (knots[degree + i] - knots[i])
-        db = (knots[i + degree + 1] - knots[i + 1])
-        if ((knots[degree + i] - knots[i]) != 0):
-            alpha1 = ((x - knots[i])/da)
+        da = knots[degree + i] - knots[i]
+        db = knots[i + degree + 1] - knots[i + 1]
+        if (knots[degree + i] - knots[i]) != 0:
+            alpha1 = (x - knots[i]) / da
         else:
             alpha1 = np.zeros(len(x))
-        if ((knots[i+degree+1] - knots[i+1]) != 0):
-            alpha2 = ((knots[i + degree + 1] - x)/db)
+        if (knots[i + degree + 1] - knots[i + 1]) != 0:
+            alpha2 = (knots[i + degree + 1] - x) / db
         else:
             alpha2 = np.zeros(len(x))
-        B = (_spline_basis_vector(x, (degree-1), i, knots)) * (alpha1) + (_spline_basis_vector(x, (degree-1), (i+1), knots)) * (alpha2)
+        B = (_spline_basis_vector(x, (degree - 1), i, knots)) * (alpha1) + (
+            _spline_basis_vector(x, (degree - 1), (i + 1), knots)
+        ) * (alpha2)
     return B
 
 
-def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline'):
+def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name="spline"):
     """Creates a piecewise polynomial function, creating a continuous, smooth function in x
 
     See https://en.wikipedia.org/wiki/B-spline for the definitions of Basis Splines
@@ -840,25 +917,33 @@ def create_sparse_spline_matrix(x, n_knots=20, knots=None, degree=3, name='splin
     x = np.asarray(x, np.float64)
 
     if not isinstance(n_knots, int):
-        raise ValueError('`n_knots` must be an integer.')
+        raise ValueError("`n_knots` must be an integer.")
     if n_knots - degree <= 0:
-        raise ValueError('n_knots must be greater than degree.')
-    if (knots is None)  and (n_knots is not None):
-        knots = np.asarray([s[-1] for s in np.array_split(np.argsort(x), n_knots - degree)[:-1]])
+        raise ValueError("n_knots must be greater than degree.")
+    if (knots is None) and (n_knots is not None):
+        knots = np.asarray(
+            [s[-1] for s in np.array_split(np.argsort(x), n_knots - degree)[:-1]]
+        )
         knots = [np.mean([x[k], x[k + 1]]) for k in knots]
-    elif (knots is None)  and (n_knots is None):
-        raise ValueError('Pass either `n_knots` or `knots`.')
+    elif (knots is None) and (n_knots is None):
+        raise ValueError("Pass either `n_knots` or `knots`.")
     knots = np.append(np.append(x.min(), knots), x.max())
     knots = np.unique(knots)
-    knots_wbounds = np.append(np.append([x.min()] * (degree - 1), knots), [x.max()] * (degree))
+    knots_wbounds = np.append(
+        np.append([x.min()] * (degree - 1), knots), [x.max()] * (degree)
+    )
 
-    matrices = [csr_matrix(_spline_basis_vector(x, degree, idx, knots_wbounds)) for idx in np.arange(-1, len(knots_wbounds) - degree - 1)]
-    spline_dm = vstack([m for m in matrices if (m.sum() != 0) ], format='csr').T
+    matrices = [
+        csr_matrix(_spline_basis_vector(x, degree, idx, knots_wbounds))
+        for idx in np.arange(-1, len(knots_wbounds) - degree - 1)
+    ]
+    spline_dm = vstack([m for m in matrices if (m.sum() != 0)], format="csr").T
     return SparseDesignMatrix(spline_dm, name=name)
 
 
-def create_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline',
-                         include_intercept=True):
+def create_spline_matrix(
+    x, n_knots=20, knots=None, degree=3, name="spline", include_intercept=True
+):
     """Returns a `.DesignMatrix` which models splines using `patsy.dmatrix`.
     Parameters
     ----------
@@ -878,16 +963,22 @@ def create_spline_matrix(x, n_knots=20, knots=None, degree=3, name='spline',
         Design matrix object with shape (len(x), n_knots*degree).
     """
     from patsy import dmatrix  # local import because it's rarely-used
+
     if knots is not None:
-        dm_formula = "bs(x, knots={}, degree={}, include_intercept={}) - 1" \
-                     "".format(knots, degree, include_intercept)
+        dm_formula = "bs(x, knots={}, degree={}, include_intercept={}) - 1" "".format(
+            knots, degree, include_intercept
+        )
         spline_dm = np.asarray(dmatrix(dm_formula, {"x": x}))
-        df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
-                                              for idx in range(spline_dm.shape[1])])
+        df = pd.DataFrame(
+            spline_dm,
+            columns=["knot{}".format(idx + 1) for idx in range(spline_dm.shape[1])],
+        )
     else:
-        dm_formula = "bs(x, df={}, degree={}, include_intercept={}) - 1" \
-                 "".format(n_knots, degree, include_intercept)
+        dm_formula = "bs(x, df={}, degree={}, include_intercept={}) - 1" "".format(
+            n_knots, degree, include_intercept
+        )
         spline_dm = np.asarray(dmatrix(dm_formula, {"x": x}))
-        df = pd.DataFrame(spline_dm, columns=['knot{}'.format(idx + 1)
-                                              for idx in range(n_knots)])
+        df = pd.DataFrame(
+            spline_dm, columns=["knot{}".format(idx + 1) for idx in range(n_knots)]
+        )
     return DesignMatrix(df, name=name)

--- a/src/lightkurve/correctors/metrics.py
+++ b/src/lightkurve/correctors/metrics.py
@@ -97,8 +97,10 @@ def overfit_metric_lombscargle(
             # We want the goodness to begin to degrade when the introduced
             # noise is greater than the uncertainties.
             # So, when Sigmoid > 0.5 (given twiceSigmoidInv defn.)
-            denominator = (len(np.nonzero(pgChange > 0.0)[0])) * meanCorrectedUncertPower
-            if (denominator == 0):
+            denominator = (
+                len(np.nonzero(pgChange > 0.0)[0])
+            ) * meanCorrectedUncertPower
+            if denominator == 0:
                 # Suppress divide by zero warning
                 result = np.inf
             else:
@@ -130,8 +132,8 @@ def underfit_metric_neighbors(
     target Pearson correlation between the target under study and a selection of
     neighboring SPOC SAP target light curves.
 
-    This function will search within the given radiu in arceseconds and find the 
-    min_targets nearest targets up until max_targets is reached. If less than 
+    This function will search within the given radiu in arceseconds and find the
+    min_targets nearest targets up until max_targets is reached. If less than
     min_targets is found a MinTargetsError Exception is raised.
 
     The downloaded neighboring targets will normally be "aligned" to the
@@ -245,8 +247,11 @@ def underfit_metric_neighbors(
 
     return metric
 
+
 # Custom exception to track when minimum targets is not reached
-class MinTargetsError(Exception): pass
+class MinTargetsError(Exception):
+    pass
+
 
 def _unique_key_for_processing_neighbors(
     corrected_lc: LightCurve,
@@ -302,7 +307,9 @@ def _download_and_preprocess_neighbors(
         List containing the flux arrays of the neighboring light curves,
         interpolated and aligned with `corrected_lc` if requested.
     """
-    search = corrected_lc.search_neighbors(limit=max_targets, radius=radius, author=author)
+    search = corrected_lc.search_neighbors(
+        limit=max_targets, radius=radius, author=author
+    )
     if len(search) < min_targets:
         raise MinTargetsError(
             f"Unable to find at least {min_targets} neighbors within {radius} arcseconds radius."

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -33,8 +33,17 @@ try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
     from bokeh.io import show, output_notebook, push_notebook
     from bokeh.plotting import figure, ColumnDataSource
-    from bokeh.models import LogColorMapper, Slider, RangeSlider, \
-        Span, ColorBar, LogTicker, Range1d, LinearColorMapper, BasicTicker
+    from bokeh.models import (
+        LogColorMapper,
+        Slider,
+        RangeSlider,
+        Span,
+        ColorBar,
+        LogTicker,
+        Range1d,
+        LinearColorMapper,
+        BasicTicker,
+    )
     from bokeh.layouts import layout, Spacer
     from bokeh.models.tools import HoverTool
     from bokeh.models.widgets import Button, Div
@@ -46,7 +55,8 @@ except ImportError:
 
 def _to_unitless(items):
     """Convert the values in the item list to unitless one"""
-    return [getattr(item, 'value', item) for item in items]
+    return [getattr(item, "value", item) for item in items]
+
 
 def prepare_lightcurve_datasource(lc):
     """Prepare a bokeh ColumnDataSource object for tool tips.
@@ -65,7 +75,7 @@ def prepare_lightcurve_datasource(lc):
     if (lc.time == lc.time).all():
         human_time = lc.time.isot
     else:
-        human_time = [' '] * len(lc.flux)
+        human_time = [" "] * len(lc.flux)
 
     # Convert binary quality numbers into human readable strings
     qual_strings = []
@@ -74,19 +84,22 @@ def prepare_lightcurve_datasource(lc):
             bitmask = bitmask.value
         flag_str_list = KeplerQualityFlags.decode(bitmask)
         if len(flag_str_list) == 0:
-            qual_strings.append(' ')
+            qual_strings.append(" ")
         if len(flag_str_list) == 1:
             qual_strings.append(flag_str_list[0])
         if len(flag_str_list) > 1:
             qual_strings.append("; ".join(flag_str_list))
 
-    lc_source = ColumnDataSource(data=dict(
-                                 time=lc.time.value,
-                                 time_iso=human_time,
-                                 flux=lc.flux.value,
-                                 cadence=lc.cadenceno.value,
-                                 quality_code=lc.quality.value,
-                                 quality=np.array(qual_strings)))
+    lc_source = ColumnDataSource(
+        data=dict(
+            time=lc.time.value,
+            time_iso=human_time,
+            flux=lc.flux.value,
+            cadence=lc.cadenceno.value,
+            quality_code=lc.quality.value,
+            quality=np.array(qual_strings),
+        )
+    )
     return lc_source
 
 
@@ -130,7 +143,7 @@ def get_lightcurve_y_limits(lc_source):
     """
     with warnings.catch_warnings():  # Ignore warnings due to NaNs
         warnings.simplefilter("ignore", AstropyUserWarning)
-        flux = sigma_clip(lc_source.data['flux'], sigma=5, masked=False)
+        flux = sigma_clip(lc_source.data["flux"], sigma=5, masked=False)
     low, high = np.nanpercentile(flux, (1, 99))
     margin = 0.10 * (high - low)
     return low - margin, high + margin
@@ -152,34 +165,34 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
     step_renderer : GlyphRenderer
     vertical_line : Span
     """
-    mission = lc.meta.get('MISSION')
-    if mission == 'K2':
-        title = "Lightcurve for {} (K2 C{})".format(
-            lc.label, lc.campaign)
-    elif mission == 'Kepler':
-        title = "Lightcurve for {} (Kepler Q{})".format(
-            lc.label, lc.quarter)
-    elif mission == 'TESS':
-        title = "Lightcurve for {} (TESS Sec. {})".format(
-            lc.label, lc.sector)
+    mission = lc.meta.get("MISSION")
+    if mission == "K2":
+        title = "Lightcurve for {} (K2 C{})".format(lc.label, lc.campaign)
+    elif mission == "Kepler":
+        title = "Lightcurve for {} (Kepler Q{})".format(lc.label, lc.quarter)
+    elif mission == "TESS":
+        title = "Lightcurve for {} (TESS Sec. {})".format(lc.label, lc.sector)
     else:
         title = "Lightcurve for target {}".format(lc.label)
 
-    fig = figure(title=title, plot_height=340, plot_width=600,
-                 tools="pan,wheel_zoom,box_zoom,tap,reset",
-                 toolbar_location="below",
-                 border_fill_color="whitesmoke")
+    fig = figure(
+        title=title,
+        plot_height=340,
+        plot_width=600,
+        tools="pan,wheel_zoom,box_zoom,tap,reset",
+        toolbar_location="below",
+        border_fill_color="whitesmoke",
+    )
     fig.title.offset = -10
-    fig.yaxis.axis_label = 'Flux (e/s)'
-    fig.xaxis.axis_label = 'Time (days)'
+    fig.yaxis.axis_label = "Flux (e/s)"
+    fig.xaxis.axis_label = "Time (days)"
     try:
-        if (lc.mission == 'K2') or (lc.mission == 'Kepler'):
-            fig.xaxis.axis_label = 'Time - 2454833 (days)'
-        elif lc.mission == 'TESS':
-            fig.xaxis.axis_label = 'Time - 2457000 (days)'
+        if (lc.mission == "K2") or (lc.mission == "Kepler"):
+            fig.xaxis.axis_label = "Time - 2454833 (days)"
+        elif lc.mission == "TESS":
+            fig.xaxis.axis_label = "Time - 2457000 (days)"
     except AttributeError:  # no mission keyword available
-      pass
-
+        pass
 
     if ylim_func is None:
         ylims = get_lightcurve_y_limits(lc_source)
@@ -188,30 +201,57 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
     fig.y_range = Range1d(start=ylims[0], end=ylims[1])
 
     # Add step lines, circles, and hover-over tooltips
-    fig.step('time', 'flux', line_width=1, color='gray',
-             source=lc_source, nonselection_line_color='gray',
-             nonselection_line_alpha=1.0)
-    circ = fig.circle('time', 'flux', source=lc_source, fill_alpha=0.3, size=8,
-                      line_color=None, selection_color="firebrick",
-                      nonselection_fill_alpha=0.0,
-                      nonselection_fill_color="grey",
-                      nonselection_line_color=None,
-                      nonselection_line_alpha=0.0,
-                      fill_color=None, hover_fill_color="firebrick",
-                      hover_alpha=0.9, hover_line_color="white")
-    tooltips = [("Cadence", "@cadence"),
-                ("Time ({})".format(lc.time.format.upper()),
-                 "@time{0,0.000}"),
-                ("Time (ISO)", "@time_iso"),
-                ("Flux", "@flux"),
-                ("Quality Code", "@quality_code"),
-                ("Quality Flag", "@quality")]
-    fig.add_tools(HoverTool(tooltips=tooltips, renderers=[circ],
-                            mode='mouse', point_policy="snap_to_data"))
+    fig.step(
+        "time",
+        "flux",
+        line_width=1,
+        color="gray",
+        source=lc_source,
+        nonselection_line_color="gray",
+        nonselection_line_alpha=1.0,
+    )
+    circ = fig.circle(
+        "time",
+        "flux",
+        source=lc_source,
+        fill_alpha=0.3,
+        size=8,
+        line_color=None,
+        selection_color="firebrick",
+        nonselection_fill_alpha=0.0,
+        nonselection_fill_color="grey",
+        nonselection_line_color=None,
+        nonselection_line_alpha=0.0,
+        fill_color=None,
+        hover_fill_color="firebrick",
+        hover_alpha=0.9,
+        hover_line_color="white",
+    )
+    tooltips = [
+        ("Cadence", "@cadence"),
+        ("Time ({})".format(lc.time.format.upper()), "@time{0,0.000}"),
+        ("Time (ISO)", "@time_iso"),
+        ("Flux", "@flux"),
+        ("Quality Code", "@quality_code"),
+        ("Quality Flag", "@quality"),
+    ]
+    fig.add_tools(
+        HoverTool(
+            tooltips=tooltips,
+            renderers=[circ],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
 
     # Vertical line to indicate the cadence
-    vertical_line = Span(location=lc.time[0].value, dimension='height',
-                         line_color='firebrick', line_width=4, line_alpha=0.5)
+    vertical_line = Span(
+        location=lc.time[0].value,
+        dimension="height",
+        line_color="firebrick",
+        line_width=4,
+        line_alpha=0.5,
+    )
     fig.add_layout(vertical_line)
 
     return fig, vertical_line
@@ -220,19 +260,26 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
 def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
     """Make the Gaia Figure Elements"""
     # Get the positions of the Gaia sources
-    c1 = SkyCoord(tpf.ra, tpf.dec, frame='icrs', unit='deg')
+    c1 = SkyCoord(tpf.ra, tpf.dec, frame="icrs", unit="deg")
     # Use pixel scale for query size
     pix_scale = 4.0  # arcseconds / pixel for Kepler, default
-    if tpf.mission == 'TESS':
+    if tpf.mission == "TESS":
         pix_scale = 21.0
     # We are querying with a diameter as the radius, overfilling by 2x.
     from astroquery.vizier import Vizier
+
     Vizier.ROW_LIMIT = -1
-    result = Vizier.query_region(c1, catalog=["I/345/gaia2"],
-                                 radius=Angle(np.max(tpf.shape[1:]) * pix_scale, "arcsec"))
-    no_targets_found_message = ValueError('Either no sources were found in the query region '
-                                          'or Vizier is unavailable')
-    too_few_found_message = ValueError('No sources found brighter than {:0.1f}'.format(magnitude_limit))
+    result = Vizier.query_region(
+        c1,
+        catalog=["I/345/gaia2"],
+        radius=Angle(np.max(tpf.shape[1:]) * pix_scale, "arcsec"),
+    )
+    no_targets_found_message = ValueError(
+        "Either no sources were found in the query region " "or Vizier is unavailable"
+    )
+    too_few_found_message = ValueError(
+        "No sources found brighter than {:0.1f}".format(magnitude_limit)
+    )
     if result is None:
         raise no_targets_found_message
     elif len(result) == 0:
@@ -244,55 +291,93 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
 
     # Apply correction for proper motion
     year = ((tpf.time[0].jd - 2457206.375) * u.day).to(u.year)
-    pmra = ((np.nan_to_num(np.asarray(result.pmRA)) * u.milliarcsecond/u.year) * year).to(u.deg).value
-    pmdec = ((np.nan_to_num(np.asarray(result.pmDE)) * u.milliarcsecond/u.year) * year).to(u.deg).value
+    pmra = (
+        ((np.nan_to_num(np.asarray(result.pmRA)) * u.milliarcsecond / u.year) * year)
+        .to(u.deg)
+        .value
+    )
+    pmdec = (
+        ((np.nan_to_num(np.asarray(result.pmDE)) * u.milliarcsecond / u.year) * year)
+        .to(u.deg)
+        .value
+    )
     result.RA_ICRS += pmra
     result.DE_ICRS += pmdec
 
     # Convert to pixel coordinates
-    radecs = np.vstack([result['RA_ICRS'], result['DE_ICRS']]).T
+    radecs = np.vstack([result["RA_ICRS"], result["DE_ICRS"]]).T
     coords = tpf.wcs.all_world2pix(radecs, 0)
 
     # Gently size the points by their Gaia magnitude
-    sizes = 64.0 / 2**(result['Gmag']/5.0)
-    one_over_parallax = 1.0 / (result['Plx']/1000.)
-    source = ColumnDataSource(data=dict(ra=result['RA_ICRS'],
-                                        dec=result['DE_ICRS'],
-                                        pmra=result['pmRA'],
-                                        pmde=result['pmDE'],
-                                        source=result['Source'].astype(str),
-                                        Gmag=result['Gmag'],
-                                        plx=result['Plx'],
-                                        one_over_plx=one_over_parallax,
-                                        x=coords[:, 0] + tpf.column,
-                                        y=coords[:, 1] + tpf.row,
-                                        size=sizes))
+    sizes = 64.0 / 2 ** (result["Gmag"] / 5.0)
+    one_over_parallax = 1.0 / (result["Plx"] / 1000.0)
+    source = ColumnDataSource(
+        data=dict(
+            ra=result["RA_ICRS"],
+            dec=result["DE_ICRS"],
+            pmra=result["pmRA"],
+            pmde=result["pmDE"],
+            source=result["Source"].astype(str),
+            Gmag=result["Gmag"],
+            plx=result["Plx"],
+            one_over_plx=one_over_parallax,
+            x=coords[:, 0] + tpf.column,
+            y=coords[:, 1] + tpf.row,
+            size=sizes,
+        )
+    )
 
-    r = fig.circle('x', 'y', source=source, fill_alpha=0.3, size='size',
-                   line_color=None, selection_color="firebrick",
-                   nonselection_fill_alpha=0.0, nonselection_line_color=None,
-                   nonselection_line_alpha=0.0, fill_color="firebrick",
-                   hover_fill_color="firebrick", hover_alpha=0.9,
-                   hover_line_color="white")
+    r = fig.circle(
+        "x",
+        "y",
+        source=source,
+        fill_alpha=0.3,
+        size="size",
+        line_color=None,
+        selection_color="firebrick",
+        nonselection_fill_alpha=0.0,
+        nonselection_line_color=None,
+        nonselection_line_alpha=0.0,
+        fill_color="firebrick",
+        hover_fill_color="firebrick",
+        hover_alpha=0.9,
+        hover_line_color="white",
+    )
 
-    fig.add_tools(HoverTool(tooltips=[("Gaia source", "@source"),
-                                      ("G", "@Gmag"),
-                                      ("Parallax (mas)", "@plx (~@one_over_plx{0,0} pc)"),
-                                      ("RA", "@ra{0,0.00000000}"),
-                                      ("DEC", "@dec{0,0.00000000}"),
-                                      ("pmRA", "@pmra{0,0.000} mas/yr"),
-                                      ("pmDE", "@pmde{0,0.000} mas/yr"),
-                                      ("x", "@x"),
-                                      ("y", "@y")],
-                            renderers=[r],
-                            mode='mouse',
-                            point_policy="snap_to_data"))
+    fig.add_tools(
+        HoverTool(
+            tooltips=[
+                ("Gaia source", "@source"),
+                ("G", "@Gmag"),
+                ("Parallax (mas)", "@plx (~@one_over_plx{0,0} pc)"),
+                ("RA", "@ra{0,0.00000000}"),
+                ("DEC", "@dec{0,0.00000000}"),
+                ("pmRA", "@pmra{0,0.000} mas/yr"),
+                ("pmDE", "@pmde{0,0.000} mas/yr"),
+                ("x", "@x"),
+                ("y", "@y"),
+            ],
+            renderers=[r],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
     return fig, r
 
 
-def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None,
-                             plot_width=370, plot_height=340, scale='log', vmin=None, vmax=None,
-                             cmap='Viridis256', tools='tap,box_select,wheel_zoom,reset'):
+def make_tpf_figure_elements(
+    tpf,
+    tpf_source,
+    pedestal=None,
+    fiducial_frame=None,
+    plot_width=370,
+    plot_height=340,
+    scale="log",
+    vmin=None,
+    vmax=None,
+    cmap="Viridis256",
+    tools="tap,box_select,wheel_zoom,reset",
+):
     """Returns the lightcurve figure elements.
 
     Parameters
@@ -324,28 +409,31 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     """
     if pedestal is None:
         pedestal = -np.nanmin(tpf.flux.value) + 1
-    if scale == 'linear':
+    if scale == "linear":
         pedestal = 0
 
-    if tpf.mission in ['Kepler', 'K2']:
-        title = 'Pixel data (CCD {}.{})'.format(tpf.module, tpf.output)
-    elif tpf.mission == 'TESS':
-        title = 'Pixel data (Camera {}.{})'.format(tpf.camera, tpf.ccd)
+    if tpf.mission in ["Kepler", "K2"]:
+        title = "Pixel data (CCD {}.{})".format(tpf.module, tpf.output)
+    elif tpf.mission == "TESS":
+        title = "Pixel data (Camera {}.{})".format(tpf.camera, tpf.ccd)
     else:
         title = "Pixel data"
 
     # We subtract 0.5 from the range below because pixel coordinates refer to
     # the middle of a pixel, e.g. (col, row) = (10.0, 20.0) is a pixel center.
-    fig = figure(plot_width=plot_width, plot_height=plot_height,
-                 x_range=(tpf.column-0.5, tpf.column+tpf.shape[2]-0.5),
-                 y_range=(tpf.row-0.5, tpf.row+tpf.shape[1]-0.5),
-                 title=title, tools=tools,
-                 toolbar_location="below",
-                 border_fill_color="whitesmoke")
+    fig = figure(
+        plot_width=plot_width,
+        plot_height=plot_height,
+        x_range=(tpf.column - 0.5, tpf.column + tpf.shape[2] - 0.5),
+        y_range=(tpf.row - 0.5, tpf.row + tpf.shape[1] - 0.5),
+        title=title,
+        tools=tools,
+        toolbar_location="below",
+        border_fill_color="whitesmoke",
+    )
 
-    fig.yaxis.axis_label = 'Pixel Row Number'
-    fig.xaxis.axis_label = 'Pixel Column Number'
-
+    fig.yaxis.axis_label = "Pixel Row Number"
+    fig.xaxis.axis_label = "Pixel Column Number"
 
     vlo, lo, hi, vhi = np.nanpercentile(tpf.flux.value + pedestal, [0.2, 1, 95, 99.8])
     if vmin is not None:
@@ -353,22 +441,28 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     if vmax is not None:
         vhi, hi = vmax, vmax
 
-    if scale == 'log':
+    if scale == "log":
         vstep = (np.log10(vhi) - np.log10(vlo)) / 300.0  # assumes counts >> 1.0!
-    if scale == 'linear':
+    if scale == "linear":
         vstep = (vhi - vlo) / 300.0  # assumes counts >> 1.0!
 
-    if scale == 'log':
+    if scale == "log":
         color_mapper = LogColorMapper(palette=cmap, low=lo, high=hi)
-    elif scale == 'linear':
+    elif scale == "linear":
         color_mapper = LinearColorMapper(palette=cmap, low=lo, high=hi)
     else:
-        raise ValueError('Please specify either `linear` or `log` scale for color.')
+        raise ValueError("Please specify either `linear` or `log` scale for color.")
 
-    fig.image([tpf.flux.value[fiducial_frame, :, :] + pedestal],
-              x=tpf.column-0.5, y=tpf.row-0.5,
-              dw=tpf.shape[2], dh=tpf.shape[1], dilate=True,
-              color_mapper=color_mapper, name="tpfimg")
+    fig.image(
+        [tpf.flux.value[fiducial_frame, :, :] + pedestal],
+        x=tpf.column - 0.5,
+        y=tpf.row - 0.5,
+        dw=tpf.shape[2],
+        dh=tpf.shape[1],
+        dilate=True,
+        color_mapper=color_mapper,
+        name="tpfimg",
+    )
 
     # The colorbar will update with the screen stretch slider
     # The colorbar margin increases as the length of the tick labels grows.
@@ -376,87 +470,105 @@ def make_tpf_figure_elements(tpf, tpf_source, pedestal=None, fiducial_frame=None
     # This effect is known, some workarounds might work to fix the plot area:
     # https://github.com/bokeh/bokeh/issues/5186
 
-    if scale == 'log':
+    if scale == "log":
         ticker = LogTicker(desired_num_ticks=8)
-    elif scale == 'linear':
+    elif scale == "linear":
         ticker = BasicTicker(desired_num_ticks=8)
 
-    color_bar = ColorBar(color_mapper=color_mapper,
-                         ticker=ticker,
-                         label_standoff=-10, border_line_color=None,
-                         location=(0, 0), background_fill_color='whitesmoke',
-                         major_label_text_align='left',
-                         major_label_text_baseline='middle',
-                         title='e/s', margin=0)
-    fig.add_layout(color_bar, 'right')
+    color_bar = ColorBar(
+        color_mapper=color_mapper,
+        ticker=ticker,
+        label_standoff=-10,
+        border_line_color=None,
+        location=(0, 0),
+        background_fill_color="whitesmoke",
+        major_label_text_align="left",
+        major_label_text_baseline="middle",
+        title="e/s",
+        margin=0,
+    )
+    fig.add_layout(color_bar, "right")
 
     color_bar.formatter = PrintfTickFormatter(format="%14i")
 
     if tpf_source is not None:
-        fig.rect('xx', 'yy', 1, 1, source=tpf_source, fill_color='gray',
-                fill_alpha=0.4, line_color='white')
+        fig.rect(
+            "xx",
+            "yy",
+            1,
+            1,
+            source=tpf_source,
+            fill_color="gray",
+            fill_alpha=0.4,
+            line_color="white",
+        )
 
     # Configure the stretch slider and its callback function
-    if scale == 'log':
+    if scale == "log":
         start, end = np.log10(vlo), np.log10(vhi)
         values = (np.log10(lo), np.log10(hi))
-    elif scale == 'linear':
+    elif scale == "linear":
         start, end = vlo, vhi
         values = (lo, hi)
 
-    stretch_slider = RangeSlider(start=start,
-                                 end=end,
-                                 step=vstep,
-                                 title='Screen Stretch ({})'.format(scale),
-                                 value=values,
-                                 orientation='horizontal',
-                                 width=200,
-                                 direction='ltr',
-                                 show_value=True,
-                                 sizing_mode='fixed',
-                                 height=15,
-                                 name='tpfstretch')
+    stretch_slider = RangeSlider(
+        start=start,
+        end=end,
+        step=vstep,
+        title="Screen Stretch ({})".format(scale),
+        value=values,
+        orientation="horizontal",
+        width=200,
+        direction="ltr",
+        show_value=True,
+        sizing_mode="fixed",
+        height=15,
+        name="tpfstretch",
+    )
 
     def stretch_change_callback_log(attr, old, new):
         """TPF stretch slider callback."""
-        fig.select('tpfimg')[0].glyph.color_mapper.high = 10**new[1]
-        fig.select('tpfimg')[0].glyph.color_mapper.low = 10**new[0]
+        fig.select("tpfimg")[0].glyph.color_mapper.high = 10 ** new[1]
+        fig.select("tpfimg")[0].glyph.color_mapper.low = 10 ** new[0]
 
     def stretch_change_callback_linear(attr, old, new):
         """TPF stretch slider callback."""
-        fig.select('tpfimg')[0].glyph.color_mapper.high = new[1]
-        fig.select('tpfimg')[0].glyph.color_mapper.low = new[0]
+        fig.select("tpfimg")[0].glyph.color_mapper.high = new[1]
+        fig.select("tpfimg")[0].glyph.color_mapper.low = new[0]
 
-    if scale == 'log':
-        stretch_slider.on_change('value', stretch_change_callback_log)
-    if scale == 'linear':
-        stretch_slider.on_change('value', stretch_change_callback_linear)
+    if scale == "log":
+        stretch_slider.on_change("value", stretch_change_callback_log)
+    if scale == "linear":
+        stretch_slider.on_change("value", stretch_change_callback_linear)
 
     return fig, stretch_slider
 
 
-def make_default_export_name(tpf, suffix='custom-lc'):
+def make_default_export_name(tpf, suffix="custom-lc"):
     """makes the default name to save a custom interact mask"""
     fn = tpf.hdu.filename()
     if fn is None:
         outname = "{}_{}_{}.fits".format(tpf.mission, tpf.targetid, suffix)
     else:
         base = os.path.basename(fn)
-        outname = base.rsplit('.fits')[0] + '-{}.fits'.format(suffix)
+        outname = base.rsplit(".fits")[0] + "-{}.fits".format(suffix)
     return outname
 
 
-def show_interact_widget(tpf, notebook_url='localhost:8888',
-                         lc=None,
-                         max_cadences=200000,
-                         aperture_mask='default',
-                         exported_filename=None,
-                         transform_func=None,
-                         ylim_func=None,
-                         vmin=None,
-                         vmax=None,
-                         scale='log',
-                         cmap='Viridis256'):
+def show_interact_widget(
+    tpf,
+    notebook_url="localhost:8888",
+    lc=None,
+    max_cadences=200000,
+    aperture_mask="default",
+    exported_filename=None,
+    transform_func=None,
+    ylim_func=None,
+    vmin=None,
+    vmax=None,
+    scale="log",
+    cmap="Viridis256",
+):
     """Display an interactive Jupyter Notebook widget to inspect the pixel data.
 
     The widget will show both the lightcurve and pixel data.  The pixel data
@@ -520,42 +632,48 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
     """
     try:
         import bokeh
-        if bokeh.__version__[0] == '0':
-            warnings.warn("interact() requires Bokeh version 1.0 or later", LightkurveWarning)
+
+        if bokeh.__version__[0] == "0":
+            warnings.warn(
+                "interact() requires Bokeh version 1.0 or later", LightkurveWarning
+            )
     except ImportError:
-        log.error("The interact() tool requires the `bokeh` Python package; "
-                  "you can install bokeh using e.g. `conda install bokeh`.")
+        log.error(
+            "The interact() tool requires the `bokeh` Python package; "
+            "you can install bokeh using e.g. `conda install bokeh`."
+        )
         return None
 
     aperture_mask = tpf._parse_aperture_mask(aperture_mask)
     if ~aperture_mask.any():
-        log.error("No pixels in `aperture_mask`, finding optimum aperture using `tpf.create_threshold_mask`.")
+        log.error(
+            "No pixels in `aperture_mask`, finding optimum aperture using `tpf.create_threshold_mask`."
+        )
         aperture_mask = tpf.create_threshold_mask()
     if ~aperture_mask.any():
         log.error("No pixels in `aperture_mask`, using all pixels.")
-        aperture_mask = tpf._parse_aperture_mask('all')
-
+        aperture_mask = tpf._parse_aperture_mask("all")
 
     if exported_filename is None:
         exported_filename = make_default_export_name(tpf)
     try:
         exported_filename = str(exported_filename)
     except:
-        log.error('Invalid input filename type for interact()')
+        log.error("Invalid input filename type for interact()")
         raise
-    if ('.fits' not in exported_filename.lower()):
-        exported_filename += '.fits'
+    if ".fits" not in exported_filename.lower():
+        exported_filename += ".fits"
 
     if lc is None:
         lc = tpf.to_lightcurve(aperture_mask=aperture_mask)
-        tools = 'tap,box_select,wheel_zoom,reset'
+        tools = "tap,box_select,wheel_zoom,reset"
     else:
         lc = lc.copy()
-        tools = 'wheel_zoom,reset'
+        tools = "wheel_zoom,reset"
         aperture_mask = np.zeros(tpf.flux.shape[1:]).astype(bool)
         aperture_mask[0, 0] = True
 
-    lc.meta['APERTURE_MASK'] = aperture_mask
+    lc.meta["APERTURE_MASK"] = aperture_mask
 
     if transform_func is not None:
         lc = transform_func(lc)
@@ -567,16 +685,20 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
     # https://github.com/bokeh/bokeh/issues/7490
     n_cadences = len(lc.cadenceno)
     if n_cadences > max_cadences:
-        log.error(f"Error: interact cannot display more than {max_cadences} "
-                  "cadences without suffering significant performance issues. "
-                  "You can limit the number of cadences show using slicing, e.g. "
-                  "`tpf[0:1000].interact()`. Alternatively, you can override "
-                  "this limitation by passing the `max_cadences` argument.")
+        log.error(
+            f"Error: interact cannot display more than {max_cadences} "
+            "cadences without suffering significant performance issues. "
+            "You can limit the number of cadences show using slicing, e.g. "
+            "`tpf[0:1000].interact()`. Alternatively, you can override "
+            "this limitation by passing the `max_cadences` argument."
+        )
     elif n_cadences > 30000:
-        log.warning(f"Warning: the pixel file contains {n_cadences} cadences. "
-                    "The performance of interact() is very slow for such a "
-                    "large number of frames. Consider using slicing, e.g. "
-                    "`tpf[0:1000].interact()`, to make interact run faster.")
+        log.warning(
+            f"Warning: the pixel file contains {n_cadences} cadences. "
+            "The performance of interact() is very slow for such a "
+            "large number of frames. Consider using slicing, e.g. "
+            "`tpf[0:1000].interact()`, to make interact run faster."
+        )
 
     def create_interact_ui(doc):
         # The data source includes metadata for hover-over tooltips
@@ -584,65 +706,80 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         tpf_source = prepare_tpf_datasource(tpf, aperture_mask)
 
         # Create the lightcurve figure and its vertical marker
-        fig_lc, vertical_line = make_lightcurve_figure_elements(lc, lc_source,
-                                                            ylim_func=ylim_func)
+        fig_lc, vertical_line = make_lightcurve_figure_elements(
+            lc, lc_source, ylim_func=ylim_func
+        )
 
         # Create the TPF figure and its stretch slider
         pedestal = -np.nanmin(tpf.flux.value) + 1
-        if scale == 'linear':
+        if scale == "linear":
             pedestal = 0
-        fig_tpf, stretch_slider = make_tpf_figure_elements(tpf, tpf_source,
-                                                           pedestal=pedestal,
-                                                           fiducial_frame=0,
-                                                           vmin=vmin, vmax=vmax,
-                                                           scale=scale, cmap=cmap,
-                                                           tools=tools)
+        fig_tpf, stretch_slider = make_tpf_figure_elements(
+            tpf,
+            tpf_source,
+            pedestal=pedestal,
+            fiducial_frame=0,
+            vmin=vmin,
+            vmax=vmax,
+            scale=scale,
+            cmap=cmap,
+            tools=tools,
+        )
 
         # Helper lookup table which maps cadence number onto flux array index.
         tpf_index_lookup = {cad: idx for idx, cad in enumerate(tpf.cadenceno)}
 
         # Interactive slider widgets and buttons to select the cadence number
-        cadence_slider = Slider(start=np.min(tpf.cadenceno),
-                                end=np.max(tpf.cadenceno),
-                                value=np.min(tpf.cadenceno),
-                                step=1,
-                                title="Cadence Number",
-                                width=490)
+        cadence_slider = Slider(
+            start=np.min(tpf.cadenceno),
+            end=np.max(tpf.cadenceno),
+            value=np.min(tpf.cadenceno),
+            step=1,
+            title="Cadence Number",
+            width=490,
+        )
         r_button = Button(label=">", button_type="default", width=30)
         l_button = Button(label="<", button_type="default", width=30)
-        export_button = Button(label="Save Lightcurve",
-                               button_type="success", width=120)
-        message_on_save = Div(text=' ',width=600, height=15)
+        export_button = Button(
+            label="Save Lightcurve", button_type="success", width=120
+        )
+        message_on_save = Div(text=" ", width=600, height=15)
 
         # Callbacks
-        def _create_lightcurve_from_pixels(tpf, selected_pixel_indices,
-                                            transform_func=transform_func):
+        def _create_lightcurve_from_pixels(
+            tpf, selected_pixel_indices, transform_func=transform_func
+        ):
             """Create the lightcurve from the selected pixel index list"""
             selected_indices = np.array(selected_pixel_indices)
             selected_mask = np.isin(pixel_index_array, selected_indices)
             lc_new = tpf.to_lightcurve(aperture_mask=selected_mask)
-            lc_new.meta['APERTURE_MASK'] = selected_mask
+            lc_new.meta["APERTURE_MASK"] = selected_mask
             if transform_func is not None:
                 lc_transformed = transform_func(lc_new)
-                if (len(lc_transformed) != len(lc_new)):
-                    warnings.warn('Dropping cadences in `transform_func` is not '
-                                  'yet supported due to fixed time coordinates.'
-                            'Skipping the transformation...', LightkurveWarning)
+                if len(lc_transformed) != len(lc_new):
+                    warnings.warn(
+                        "Dropping cadences in `transform_func` is not "
+                        "yet supported due to fixed time coordinates."
+                        "Skipping the transformation...",
+                        LightkurveWarning,
+                    )
                 else:
                     lc_new = lc_transformed
-                    lc_new.meta['APERTURE_MASK'] = selected_mask
+                    lc_new.meta["APERTURE_MASK"] = selected_mask
             return lc_new
 
         def update_upon_pixel_selection(attr, old, new):
             """Callback to take action when pixels are selected."""
             # Check if a selection was "re-clicked", then de-select
-            if ((sorted(old) == sorted(new)) & (new != [])):
+            if (sorted(old) == sorted(new)) & (new != []):
                 # Trigger recursion
                 tpf_source.selected.indices = new[1:]
 
             if new != []:
-                lc_new = _create_lightcurve_from_pixels(tpf, new, transform_func=transform_func)
-                lc_source.data['flux'] = lc_new.flux.value
+                lc_new = _create_lightcurve_from_pixels(
+                    tpf, new, transform_func=transform_func
+                )
+                lc_source.data["flux"] = lc_new.flux.value
 
                 if ylim_func is None:
                     ylims = get_lightcurve_y_limits(lc_source)
@@ -651,7 +788,7 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
                 fig_lc.y_range.start = ylims[0]
                 fig_lc.y_range.end = ylims[1]
             else:
-                lc_source.data['flux'] = lc.flux.value * 0.0
+                lc_source.data["flux"] = lc.flux.value * 0.0
                 fig_lc.y_range.start = -1
                 fig_lc.y_range.end = 1
 
@@ -662,12 +799,14 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
             """Callback to take action when cadence slider changes"""
             if new in tpf.cadenceno:
                 frameno = tpf_index_lookup[new]
-                fig_tpf.select('tpfimg')[0].data_source.data['image'] = \
-                    [tpf.flux.value[frameno, :, :] + pedestal]
+                fig_tpf.select("tpfimg")[0].data_source.data["image"] = [
+                    tpf.flux.value[frameno, :, :] + pedestal
+                ]
                 vertical_line.update(location=tpf.time.value[frameno])
             else:
-                fig_tpf.select('tpfimg')[0].data_source.data['image'] = \
-                    [tpf.flux.value[0, :, :] * np.NaN]
+                fig_tpf.select("tpfimg")[0].data_source.data["image"] = [
+                    tpf.flux.value[0, :, :] * np.NaN
+                ]
             lc_source.selected.indices = []
 
         def go_right_by_one():
@@ -685,14 +824,18 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         def save_lightcurve():
             """Save the lightcurve as a fits file with mask as HDU extension"""
             if tpf_source.selected.indices != []:
-                lc_new = _create_lightcurve_from_pixels(tpf, tpf_source.selected.indices,
-                                                    transform_func=transform_func)
-                lc_new.to_fits(exported_filename, overwrite=True,
-                               flux_column_name='SAP_FLUX',
-                               aperture_mask=lc_new.meta['APERTURE_MASK'].astype(np.int),
-                               SOURCE='lightkurve interact',
-                               NOTE='custom mask',
-                               MASKNPIX=np.nansum(lc_new.meta['APERTURE_MASK']))
+                lc_new = _create_lightcurve_from_pixels(
+                    tpf, tpf_source.selected.indices, transform_func=transform_func
+                )
+                lc_new.to_fits(
+                    exported_filename,
+                    overwrite=True,
+                    flux_column_name="SAP_FLUX",
+                    aperture_mask=lc_new.meta["APERTURE_MASK"].astype(np.int),
+                    SOURCE="lightkurve interact",
+                    NOTE="custom mask",
+                    MASKNPIX=np.nansum(lc_new.meta["APERTURE_MASK"]),
+                )
                 if message_on_save.text == " ":
                     text = '<font color="black"><i>Saved file {} </i></font>'
                     message_on_save.text = text.format(exported_filename)
@@ -701,7 +844,9 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
                     text = '<font color="gray"><i>Saved file {} </i></font>'
                     message_on_save.text = text.format(exported_filename)
             else:
-                text = '<font color="gray"><i>No pixels selected, no mask saved</i></font>'
+                text = (
+                    '<font color="gray"><i>No pixels selected, no mask saved</i></font>'
+                )
                 export_button.button_type = "warning"
                 message_on_save.text = text
 
@@ -712,25 +857,30 @@ def show_interact_widget(tpf, notebook_url='localhost:8888',
         # Map changes to callbacks
         r_button.on_click(go_right_by_one)
         l_button.on_click(go_left_by_one)
-        tpf_source.selected.on_change('indices', update_upon_pixel_selection)
-        lc_source.selected.on_change('indices', jump_to_lightcurve_position)
+        tpf_source.selected.on_change("indices", update_upon_pixel_selection)
+        lc_source.selected.on_change("indices", jump_to_lightcurve_position)
         export_button.on_click(save_lightcurve)
-        cadence_slider.on_change('value', update_upon_cadence_change)
+        cadence_slider.on_change("value", update_upon_cadence_change)
 
         # Layout all of the plots
-        sp1, sp2, sp3, sp4 = (Spacer(width=15), Spacer(width=30),
-                              Spacer(width=80), Spacer(width=60))
-        widgets_and_figures = layout([fig_lc, fig_tpf],
-                                     [l_button, sp1, r_button, sp2,
-                                     cadence_slider, sp3, stretch_slider],
-                                     [export_button, sp4, message_on_save])
+        sp1, sp2, sp3, sp4 = (
+            Spacer(width=15),
+            Spacer(width=30),
+            Spacer(width=80),
+            Spacer(width=60),
+        )
+        widgets_and_figures = layout(
+            [fig_lc, fig_tpf],
+            [l_button, sp1, r_button, sp2, cadence_slider, sp3, stretch_slider],
+            [export_button, sp4, message_on_save],
+        )
         doc.add_root(widgets_and_figures)
 
     output_notebook(verbose=False, hide_banner=True)
     return show(create_interact_ui, notebook_url=notebook_url)
 
 
-def show_skyview_widget(tpf, notebook_url='localhost:8888', magnitude_limit=18):
+def show_skyview_widget(tpf, notebook_url="localhost:8888", magnitude_limit=18):
     """skyview
 
     Parameters
@@ -751,17 +901,21 @@ def show_skyview_widget(tpf, notebook_url='localhost:8888', magnitude_limit=18):
     """
     try:
         import bokeh
-        if bokeh.__version__[0] == '0':
-            warnings.warn("interact_sky() requires Bokeh version 1.0 or later",
-                          LightkurveWarning)
+
+        if bokeh.__version__[0] == "0":
+            warnings.warn(
+                "interact_sky() requires Bokeh version 1.0 or later", LightkurveWarning
+            )
     except ImportError:
-        log.error("The interact_sky() tool requires the `bokeh` Python package; "
-                  "you can install bokeh using e.g. `conda install bokeh`.")
+        log.error(
+            "The interact_sky() tool requires the `bokeh` Python package; "
+            "you can install bokeh using e.g. `conda install bokeh`."
+        )
         return None
 
     # Try to identify the "fiducial frame", for which the TPF WCS is exact
     zp = (tpf.pos_corr1 == 0) & (tpf.pos_corr2 == 0)
-    zp_loc, = np.where(zp)
+    (zp_loc,) = np.where(zp)
 
     if len(zp_loc) == 1:
         fiducial_frame = zp_loc[0]
@@ -773,22 +927,34 @@ def show_skyview_widget(tpf, notebook_url='localhost:8888', magnitude_limit=18):
         tpf_source = None
 
         # Create the TPF figure and its stretch slider
-        fig_tpf, stretch_slider = make_tpf_figure_elements(tpf, tpf_source,
-                                                fiducial_frame=fiducial_frame,
-                                                plot_width=640, plot_height=600)
-        fig_tpf, r = add_gaia_figure_elements(tpf, fig_tpf,
-                                              magnitude_limit=magnitude_limit)
+        fig_tpf, stretch_slider = make_tpf_figure_elements(
+            tpf,
+            tpf_source,
+            fiducial_frame=fiducial_frame,
+            plot_width=640,
+            plot_height=600,
+        )
+        fig_tpf, r = add_gaia_figure_elements(
+            tpf, fig_tpf, magnitude_limit=magnitude_limit
+        )
 
         # Optionally override the default title
-        if tpf.mission == 'K2':
-            fig_tpf.title.text = "Skyview for EPIC {}, K2 Campaign {}, CCD {}.{}".format(
-                                tpf.targetid, tpf.campaign, tpf.module, tpf.output)
-        elif tpf.mission == 'Kepler':
-            fig_tpf.title.text = "Skyview for KIC {}, Kepler Quarter {}, CCD {}.{}".format(
-                            tpf.targetid, tpf.quarter, tpf.module, tpf.output)
-        elif tpf.mission == 'TESS':
-            fig_tpf.title.text = 'Skyview for TESS {} Sector {}, Camera {}.{}'.format(
-                            tpf.targetid, tpf.sector, tpf.camera, tpf.ccd)
+        if tpf.mission == "K2":
+            fig_tpf.title.text = (
+                "Skyview for EPIC {}, K2 Campaign {}, CCD {}.{}".format(
+                    tpf.targetid, tpf.campaign, tpf.module, tpf.output
+                )
+            )
+        elif tpf.mission == "Kepler":
+            fig_tpf.title.text = (
+                "Skyview for KIC {}, Kepler Quarter {}, CCD {}.{}".format(
+                    tpf.targetid, tpf.quarter, tpf.module, tpf.output
+                )
+            )
+        elif tpf.mission == "TESS":
+            fig_tpf.title.text = "Skyview for TESS {} Sector {}, Camera {}.{}".format(
+                tpf.targetid, tpf.sector, tpf.camera, tpf.ccd
+            )
 
         # Layout all of the plots
         widgets_and_figures = layout([fig_tpf, stretch_slider])

--- a/src/lightkurve/interact_bls.py
+++ b/src/lightkurve/interact_bls.py
@@ -31,7 +31,7 @@ from .interact import prepare_lightcurve_datasource
 from .lightcurve import LightCurve
 
 
-__all__ = ['show_interact_widget']
+__all__ = ["show_interact_widget"]
 
 #
 # Convert Time / Quantity to unitless ones for the use with bokeh
@@ -41,37 +41,43 @@ __all__ = ['show_interact_widget']
 # - TypeError('Object of type TimeDelta is not JSON serializable')
 #
 
+
 def _to_unitless(data):
     """Convet the values in the data dict to unitless one"""
-    return { key: getattr(val, 'value', val) for key, val in data.items() }
+    return {key: getattr(val, "value", val) for key, val in data.items()}
+
 
 def _to_ColumnDataSource(data):
     """Convet the values in the data dict to unitless one for use with ColumnDataSource"""
     return ColumnDataSource(data=_to_unitless(data))
+
 
 def _update_source(source, data):
     """Convet the values in the data dict to unitless one and use it to update the given DataSource"""
     source.data = _to_unitless(data)
     return source
 
+
 def _at_ratio(values, ratio):
     """Return a unitless scalar value that is at the given ratio in the range of the given values.
 
-       Conceptually, it is `max(values) - min(values) * ratio + min(values)`
-       It's frequently used to place the position the help icon of a plot based on the axis' values
+    Conceptually, it is `max(values) - min(values) * ratio + min(values)`
+    It's frequently used to place the position the help icon of a plot based on the axis' values
     """
-    if getattr(values, 'end', None) is not None:
+    if getattr(values, "end", None) is not None:
         # case range ,with start / end
         return (values.end - values.start) * ratio + values.start
     else:
         # case plain number array, Time, or Quantity (with .value)
         result = (np.max(values) - np.min(values)) * ratio + np.min(values)
         # return raw value without unit
-        return getattr(result, 'value', result)
+        return getattr(result, "value", result)
+
 
 def _isfinite(val):
-    val_actual = getattr(val, 'value', val)
+    val_actual = getattr(val, "value", val)
     return np.isfinite(val_actual)
+
 
 def prepare_bls_datasource(result, loc):
     """Prepare a bls result for bokeh plotting
@@ -88,12 +94,15 @@ def prepare_bls_datasource(result, loc):
     bls_source : Bokeh.plotting.ColumnDataSource
         Bokeh style source for plotting
     """
-    bls_source = _to_ColumnDataSource(data=dict(
-                                        period=result['period'],
-                                        power=result['power'],
-                                        depth=result['depth'],
-                                        duration=result['duration'],
-                                        transit_time=result['transit_time']))
+    bls_source = _to_ColumnDataSource(
+        data=dict(
+            period=result["period"],
+            power=result["power"],
+            depth=result["depth"],
+            duration=result["duration"],
+            transit_time=result["transit_time"],
+        )
+    )
     bls_source.selected.indices = [loc]
     return bls_source
 
@@ -111,24 +120,27 @@ def prepare_folded_datasource(folded_lc):
     folded_source : Bokeh.plotting.ColumnDataSource
         Bokeh style source for plotting
     """
-    folded_src = _to_ColumnDataSource(data=dict(
-                                  phase=folded_lc.time,
-                                  flux=folded_lc.flux))
+    folded_src = _to_ColumnDataSource(
+        data=dict(phase=folded_lc.time, flux=folded_lc.flux)
+    )
     return folded_src
 
 
 # Helper functions for help text...
 
+
 def prepare_lc_help_source(lc):
-    data = dict(time=[_at_ratio(lc.time, 0.98)],
-                flux=[_at_ratio(lc.flux, 0.95)],
-                boxicon=['https://bokeh.pydata.org/en/latest/_images/BoxZoom.png'],
-                panicon=['https://bokeh.pydata.org/en/latest/_images/Pan.png'],
-                reseticon=['https://bokeh.pydata.org/en/latest/_images/Reset.png'],
-                tapicon=['https://bokeh.pydata.org/en/latest/_images/Tap.png'],
-                hovericon=['https://bokeh.pydata.org/en/latest/_images/Hover.png'],
-                helpme=['?'],
-                help=["""
+    data = dict(
+        time=[_at_ratio(lc.time, 0.98)],
+        flux=[_at_ratio(lc.flux, 0.95)],
+        boxicon=["https://bokeh.pydata.org/en/latest/_images/BoxZoom.png"],
+        panicon=["https://bokeh.pydata.org/en/latest/_images/Pan.png"],
+        reseticon=["https://bokeh.pydata.org/en/latest/_images/Reset.png"],
+        tapicon=["https://bokeh.pydata.org/en/latest/_images/Tap.png"],
+        hovericon=["https://bokeh.pydata.org/en/latest/_images/Hover.png"],
+        helpme=["?"],
+        help=[
+            """
                              <div style="width: 550px;">
                                  <div>
                                      <span style="font-size: 12px; font-weight: bold;">Light Curve</span>
@@ -168,15 +180,19 @@ def prepare_lc_help_source(lc):
                                      </center>
                                  </div>
                              </div>
-                         """])
+                         """
+        ],
+    )
     return _to_ColumnDataSource(data=data)
 
 
 def prepare_bls_help_source(bls_source, slider_value):
-    data = dict(period=[bls_source.data['period'][int(slider_value*0.95)]],
-                power=[_at_ratio(bls_source.data['power'], 0.98)],
-                helpme=['?'],
-                help=["""
+    data = dict(
+        period=[bls_source.data["period"][int(slider_value * 0.95)]],
+        power=[_at_ratio(bls_source.data["power"], 0.98)],
+        helpme=["?"],
+        help=[
+            """
                              <div style="width: 375px;">
                                  <div style="height: 190px;">
                                  </div>
@@ -201,15 +217,19 @@ def prepare_bls_help_source(bls_source, slider_value):
 
                                  </div>
                              </div>
-                         """])
+                         """
+        ],
+    )
     return _to_ColumnDataSource(data=data)
 
 
 def prepare_f_help_source(f):
-    data = dict(phase=[_at_ratio(f.time, 0.98)],
-                flux=[_at_ratio(f.flux, 0.98)],
-                helpme=['?'],
-                help=["""
+    data = dict(
+        phase=[_at_ratio(f.time, 0.98)],
+        flux=[_at_ratio(f.flux, 0.98)],
+        helpme=["?"],
+        help=[
+            """
                         <div style="width: 375px;">
                             <div style="height: 190px;">
                             </div>
@@ -231,21 +251,25 @@ def prepare_f_help_source(f):
                                 Look in the BLS Periodogram for a peak at (e.g. 0.25x, 0.5x, 2x, 4x the current period etc).</span>
                             </div>
                         </div>
-                """])
+                """
+        ],
+    )
     return _to_ColumnDataSource(data=data)
 
 
 def _to_axis_label(label_base, unit):
-    if (unit) and (unit.to_string() != ''):
+    if (unit) and (unit.to_string() != ""):
         # bokeh does not support latex rendering. astropy's default string tends to be too verbose
         # so we support a shortform for the typical use case
         unit_str = "e/s" if unit == u.electron / u.second else unit.to_string()
-        return  f"{label_base} [{unit_str}]"
+        return f"{label_base} [{unit_str}]"
     else:
         return label_base
 
 
-def make_lightcurve_figure_elements(lc, model_lc, lc_source, model_lc_source, help_source):
+def make_lightcurve_figure_elements(
+    lc, model_lc, lc_source, model_lc_source, help_source
+):
     """Make a figure with a simple light curve scatter and model light curve line.
 
     Parameters
@@ -267,45 +291,86 @@ def make_lightcurve_figure_elements(lc, model_lc, lc_source, model_lc_source, he
         Bokeh figure object
     """
     # Make figure
-    fig = figure(title='Light Curve', plot_height=300, plot_width=900,
-                 tools="pan,box_zoom,wheel_zoom,reset",
-                 toolbar_location="below",
-                 border_fill_color="#FFFFFF", active_drag="box_zoom")
+    fig = figure(
+        title="Light Curve",
+        plot_height=300,
+        plot_width=900,
+        tools="pan,box_zoom,wheel_zoom,reset",
+        toolbar_location="below",
+        border_fill_color="#FFFFFF",
+        active_drag="box_zoom",
+    )
     fig.title.offset = -10
-    fig.yaxis.axis_label = _to_axis_label('Flux', lc.flux.unit)
-    if lc.time.format == 'bkjd':
-        fig.xaxis.axis_label = 'Time - 2454833 (days)'
-    elif lc.time.format == 'btjd':
-        fig.xaxis.axis_label = 'Time - 2457000 (days)'
+    fig.yaxis.axis_label = _to_axis_label("Flux", lc.flux.unit)
+    if lc.time.format == "bkjd":
+        fig.xaxis.axis_label = "Time - 2454833 (days)"
+    elif lc.time.format == "btjd":
+        fig.xaxis.axis_label = "Time - 2457000 (days)"
     else:
-        fig.xaxis.axis_label = 'Time (days)'
+        fig.xaxis.axis_label = "Time (days)"
     ylims = [np.nanmin(lc.flux.value), np.nanmax(lc.flux.value)]
     fig.y_range = Range1d(start=ylims[0], end=ylims[1])
 
     # Add light curve
-    fig.circle('time', 'flux', line_width=1, color='#191919',
-               source=lc_source, nonselection_line_color='#191919', size=0.5,
-               nonselection_line_alpha=1.0)
+    fig.circle(
+        "time",
+        "flux",
+        line_width=1,
+        color="#191919",
+        source=lc_source,
+        nonselection_line_color="#191919",
+        size=0.5,
+        nonselection_line_alpha=1.0,
+    )
     # Add model
-    fig.step('time', 'flux', line_width=1, color='firebrick',
-             source=model_lc_source, nonselection_line_color='firebrick',
-             nonselection_line_alpha=1.0)
+    fig.step(
+        "time",
+        "flux",
+        line_width=1,
+        color="firebrick",
+        source=model_lc_source,
+        nonselection_line_color="firebrick",
+        nonselection_line_alpha=1.0,
+    )
 
     # Help button
-    question_mark = Text(x="time", y="flux", text="helpme", text_color="grey",
-                         text_align='center', text_baseline="middle",
-                         text_font_size='12px', text_font_style='bold',
-                         text_alpha=0.6)
+    question_mark = Text(
+        x="time",
+        y="flux",
+        text="helpme",
+        text_color="grey",
+        text_align="center",
+        text_baseline="middle",
+        text_font_size="12px",
+        text_font_style="bold",
+        text_alpha=0.6,
+    )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle('time', 'flux', alpha=0.0, size=15, source=help_source,
-                      line_width=2, line_color='grey', line_alpha=0.6)
-    tooltips = help_source.data['help'][0]
-    fig.add_tools(HoverTool(tooltips=tooltips, renderers=[help],
-                            mode='mouse', point_policy="snap_to_data"))
+    help = fig.circle(
+        "time",
+        "flux",
+        alpha=0.0,
+        size=15,
+        source=help_source,
+        line_width=2,
+        line_color="grey",
+        line_alpha=0.6,
+    )
+    tooltips = help_source.data["help"][0]
+    fig.add_tools(
+        HoverTool(
+            tooltips=tooltips,
+            renderers=[help],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
     return fig
 
 
-def make_folded_figure_elements(f, f_model_lc, f_source, f_model_lc_source, help_source):
+def make_folded_figure_elements(
+    f, f_model_lc, f_source, f_model_lc_source, help_source
+):
     """Make a scatter plot of a FoldedLightCurve.
 
     Parameters
@@ -328,36 +393,75 @@ def make_folded_figure_elements(f, f_model_lc, f_source, f_model_lc_source, help
     """
 
     # Build Figure
-    fig = figure(title='Folded Light Curve', plot_height=340, plot_width=450,
-                 tools="pan,box_zoom,wheel_zoom,reset",
-                 toolbar_location="below",
-                 border_fill_color="#FFFFFF", active_drag="box_zoom")
+    fig = figure(
+        title="Folded Light Curve",
+        plot_height=340,
+        plot_width=450,
+        tools="pan,box_zoom,wheel_zoom,reset",
+        toolbar_location="below",
+        border_fill_color="#FFFFFF",
+        active_drag="box_zoom",
+    )
     fig.title.offset = -10
-    fig.yaxis.axis_label = _to_axis_label('Flux', f.flux.unit)
-    fig.xaxis.axis_label = f'Phase [{f.time.format.upper()}]'
+    fig.yaxis.axis_label = _to_axis_label("Flux", f.flux.unit)
+    fig.xaxis.axis_label = f"Phase [{f.time.format.upper()}]"
 
     # Scatter point for data
-    fig.circle('phase', 'flux', line_width=1, color='#191919',
-               source=f_source, nonselection_line_color='#191919',
-               nonselection_line_alpha=1.0, size=0.1)
+    fig.circle(
+        "phase",
+        "flux",
+        line_width=1,
+        color="#191919",
+        source=f_source,
+        nonselection_line_color="#191919",
+        nonselection_line_alpha=1.0,
+        size=0.1,
+    )
 
     # Line plot for model
-    fig.step('phase', 'flux', line_width=3, color='firebrick',
-             source=f_model_lc_source, nonselection_line_color='firebrick',
-             nonselection_line_alpha=1.0)
+    fig.step(
+        "phase",
+        "flux",
+        line_width=3,
+        color="firebrick",
+        source=f_model_lc_source,
+        nonselection_line_color="firebrick",
+        nonselection_line_alpha=1.0,
+    )
 
     # Help button
-    question_mark = Text(x="phase", y="flux", text="helpme", text_color="grey",
-                         text_align='center', text_baseline="middle",
-                         text_font_size='12px', text_font_style='bold',
-                         text_alpha=0.6)
+    question_mark = Text(
+        x="phase",
+        y="flux",
+        text="helpme",
+        text_color="grey",
+        text_align="center",
+        text_baseline="middle",
+        text_font_size="12px",
+        text_font_style="bold",
+        text_alpha=0.6,
+    )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle('phase', 'flux', alpha=0.0, size=15, source=help_source,
-                      line_width=2, line_color='grey', line_alpha=0.6)
+    help = fig.circle(
+        "phase",
+        "flux",
+        alpha=0.0,
+        size=15,
+        source=help_source,
+        line_width=2,
+        line_color="grey",
+        line_alpha=0.6,
+    )
 
-    tooltips = help_source.data['help'][0]
-    fig.add_tools(HoverTool(tooltips=tooltips, renderers=[help],
-                            mode='mouse', point_policy="snap_to_data"))
+    tooltips = help_source.data["help"][0]
+    fig.add_tools(
+        HoverTool(
+            tooltips=tooltips,
+            renderers=[help],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
     return fig
 
 
@@ -382,53 +486,98 @@ def make_bls_figure_elements(result, bls_source, help_source):
     """
 
     # Build Figure
-    fig = figure(title='BLS Periodogram', plot_height=340, plot_width=450,
-                 tools="pan,box_zoom,wheel_zoom,tap,reset",
-                 toolbar_location="below",
-                 border_fill_color="#FFFFFF", x_axis_type='log', active_drag="box_zoom")
+    fig = figure(
+        title="BLS Periodogram",
+        plot_height=340,
+        plot_width=450,
+        tools="pan,box_zoom,wheel_zoom,tap,reset",
+        toolbar_location="below",
+        border_fill_color="#FFFFFF",
+        x_axis_type="log",
+        active_drag="box_zoom",
+    )
     fig.title.offset = -10
-    fig.yaxis.axis_label = 'Power'
-    fig.xaxis.axis_label = 'Period [days]'
-    fig.y_range = Range1d(start=result.power.min().value * 0.95, end=result.power.max().value * 1.05)
-    fig.x_range = Range1d(start=result.period.min().value, end=result.period.max().value)
+    fig.yaxis.axis_label = "Power"
+    fig.xaxis.axis_label = "Period [days]"
+    fig.y_range = Range1d(
+        start=result.power.min().value * 0.95, end=result.power.max().value * 1.05
+    )
+    fig.x_range = Range1d(
+        start=result.period.min().value, end=result.period.max().value
+    )
 
     # Add circles for the selection of new period. These are always hidden
-    fig.circle('period', 'power',
-               source=bls_source,
-               fill_alpha=0.,
-               size=6,
-               line_color=None,
-               selection_color="white",
-               nonselection_fill_alpha=0.0,
-               nonselection_fill_color='white',
-               nonselection_line_color=None,
-               nonselection_line_alpha=0.0,
-               fill_color=None,
-               hover_fill_color="white",
-               hover_alpha=0.,
-               hover_line_color="white")
+    fig.circle(
+        "period",
+        "power",
+        source=bls_source,
+        fill_alpha=0.0,
+        size=6,
+        line_color=None,
+        selection_color="white",
+        nonselection_fill_alpha=0.0,
+        nonselection_fill_color="white",
+        nonselection_line_color=None,
+        nonselection_line_alpha=0.0,
+        fill_color=None,
+        hover_fill_color="white",
+        hover_alpha=0.0,
+        hover_line_color="white",
+    )
 
     # Add line for the BLS power
-    fig.line('period', 'power', line_width=1, color='#191919',
-             source=bls_source, nonselection_line_color='#191919',
-             nonselection_line_alpha=1.0)
+    fig.line(
+        "period",
+        "power",
+        line_width=1,
+        color="#191919",
+        source=bls_source,
+        nonselection_line_color="#191919",
+        nonselection_line_alpha=1.0,
+    )
 
     # Vertical line to indicate the current period
-    vertical_line = Span(location=0, dimension='height',
-                         line_color='firebrick', line_width=3, line_alpha=0.5)
+    vertical_line = Span(
+        location=0,
+        dimension="height",
+        line_color="firebrick",
+        line_width=3,
+        line_alpha=0.5,
+    )
     fig.add_layout(vertical_line)
 
     # Help button
-    question_mark = Text(x="period", y="power", text="helpme", text_color="grey",
-                         text_align='center', text_baseline="middle",
-                         text_font_size='12px', text_font_style='bold',
-                         text_alpha=0.6)
+    question_mark = Text(
+        x="period",
+        y="power",
+        text="helpme",
+        text_color="grey",
+        text_align="center",
+        text_baseline="middle",
+        text_font_size="12px",
+        text_font_style="bold",
+        text_alpha=0.6,
+    )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle('period', 'power', alpha=0.0, size=15, source=help_source,
-                      line_width=2, line_color='grey', line_alpha=0.6)
-    tooltips = help_source.data['help'][0]
-    fig.add_tools(HoverTool(tooltips=tooltips, renderers=[help],
-                            mode='mouse', point_policy="snap_to_data"))
+    help = fig.circle(
+        "period",
+        "power",
+        alpha=0.0,
+        size=15,
+        source=help_source,
+        line_width=2,
+        line_color="grey",
+        line_alpha=0.6,
+    )
+    tooltips = help_source.data["help"][0]
+    fig.add_tools(
+        HoverTool(
+            tooltips=tooltips,
+            renderers=[help],
+            mode="mouse",
+            point_policy="snap_to_data",
+        )
+    )
 
     return fig, vertical_line
 
@@ -438,7 +587,7 @@ def _preprocess_lc_for_bls(lc):
     # convert to  normalized unscaled flux if needed,
     # so that its scale is the same as the BLS model lc (to be generated),
     # making it easier to be visualized in the same plot.
-    if not clean.meta.get('NORMALIZED', False):
+    if not clean.meta.get("NORMALIZED", False):
         clean = clean.normalize()
     elif clean.flux.unit != u.dimensionless_unscaled:
         # case normalized, but in other units (percents, etc.)
@@ -447,8 +596,13 @@ def _preprocess_lc_for_bls(lc):
     return clean
 
 
-def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
-                         maximum_period=None, resolution=2000):
+def show_interact_widget(
+    lc,
+    notebook_url="localhost:8888",
+    minimum_period=None,
+    maximum_period=None,
+    resolution=2000,
+):
     """Show the BLS interact widget.
 
     Parameters
@@ -475,15 +629,20 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
     """
     try:
         import bokeh
-        if bokeh.__version__[0] == '0':
-            warnings.warn("interact_bls() requires Bokeh version 1.0 or later", LightkurveWarning)
+
+        if bokeh.__version__[0] == "0":
+            warnings.warn(
+                "interact_bls() requires Bokeh version 1.0 or later", LightkurveWarning
+            )
     except ImportError:
-        log.error("The interact_bls() tool requires the `bokeh` package; "
-                  "you can install bokeh using e.g. `conda install bokeh`.")
+        log.error(
+            "The interact_bls() tool requires the `bokeh` package; "
+            "you can install bokeh using e.g. `conda install bokeh`."
+        )
         return None
 
     def _round_strip_unit(val, decimals):
-        return np.round(getattr(val, 'value', val), decimals)
+        return np.round(getattr(val, "value", val), decimals)
 
     def _as_1d(time):
         """Convert scalar Time to a 1-d array, suitable to be used in creating LightCurve"""
@@ -493,39 +652,48 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         """Shorthand to create a LightCurve with time and flux used in creating a Model LightCurve"""
         return LightCurve(time=time, flux=flux)
 
-    def _create_interact_ui(doc, minp=minimum_period, maxp=maximum_period, resolution=resolution):
+    def _create_interact_ui(
+        doc, minp=minimum_period, maxp=maximum_period, resolution=resolution
+    ):
         """Create BLS interact user interface."""
         if minp is None:
             minp = 0.3
         if maxp is None:
-            maxp = ((lc.time[-1].value - lc.time[0].value)/2)
+            maxp = (lc.time[-1].value - lc.time[0].value) / 2
         # TODO: consider to accept Time as minp / maxp, and convert it to unitless days
 
-        time_format = ''
-        if lc.time.format == 'bkjd':
-            time_format = ' - 2454833 days'
-        if lc.time.format == 'btjd':
-            time_format = ' - 2457000 days'
+        time_format = ""
+        if lc.time.format == "bkjd":
+            time_format = " - 2454833 days"
+        if lc.time.format == "btjd":
+            time_format = " - 2457000 days"
 
         # Some sliders
-        duration_slider = Slider(start=0.01,
-                                 end=0.5,
-                                 value=0.05,
-                                 step=0.01,
-                                 title="Duration [Days]",
-                                 width=400)
+        duration_slider = Slider(
+            start=0.01,
+            end=0.5,
+            value=0.05,
+            step=0.01,
+            title="Duration [Days]",
+            width=400,
+        )
 
-        npoints_slider = Slider(start=500,
-                                end=10000,
-                                value=resolution,
-                                step=100,
-                                title="BLS Resolution",
-                                width=400)
+        npoints_slider = Slider(
+            start=500,
+            end=10000,
+            value=resolution,
+            step=100,
+            title="BLS Resolution",
+            width=400,
+        )
 
         # Set up the period values, BLS model and best period
-        period_values = np.logspace(np.log10(minp), np.log10(maxp), npoints_slider.value)
-        period_values = period_values[(period_values > duration_slider.value) &
-                                        (period_values < maxp)]
+        period_values = np.logspace(
+            np.log10(minp), np.log10(maxp), npoints_slider.value
+        )
+        period_values = period_values[
+            (period_values > duration_slider.value) & (period_values < maxp)
+        ]
         model = BoxLeastSquares(lc.time, lc.flux)
         result = model.power(period_values, duration_slider.value)
         loc = np.argmax(result.power)
@@ -535,16 +703,23 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         # Some Buttons
         double_button = Button(label="Double Period", button_type="danger", width=100)
         half_button = Button(label="Half Period", button_type="danger", width=100)
-        text_output = Paragraph(text="Period: {} days, T0: {}{}".format(
-                                                    _round_strip_unit(best_period, 7),
-                                                    _round_strip_unit(best_t0, 7), time_format),
-                                width=350, height=40)
+        text_output = Paragraph(
+            text="Period: {} days, T0: {}{}".format(
+                _round_strip_unit(best_period, 7),
+                _round_strip_unit(best_t0, 7),
+                time_format,
+            ),
+            width=350,
+            height=40,
+        )
 
         # Set up BLS source
         bls_source = prepare_bls_datasource(result, loc)
-        bls_source_units = dict(transit_time_format=result['transit_time'].format,
-                                transit_time_scale=result['transit_time'].scale,
-                                period=result['period'].unit)
+        bls_source_units = dict(
+            transit_time_format=result["transit_time"].format,
+            transit_time_scale=result["transit_time"].scale,
+            period=result["period"].unit,
+        )
         bls_help_source = prepare_bls_help_source(bls_source, npoints_slider.value)
 
         # Set up the model LC
@@ -553,17 +728,17 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         mask = ~(convolve(np.asarray(mf == np.median(mf)), Box1DKernel(2)) > 0.9)
         model_lc = _to_lc(lc.time[mask], mf[mask])
 
-        model_lc_source = _to_ColumnDataSource(data=dict(
-                                     time=model_lc.time,
-                                     flux=model_lc.flux))
+        model_lc_source = _to_ColumnDataSource(
+            data=dict(time=model_lc.time, flux=model_lc.flux)
+        )
 
         # Set up the LC
-        nb = int(np.ceil(len(lc.flux)/5000))
+        nb = int(np.ceil(len(lc.flux) / 5000))
         lc_source = prepare_lightcurve_datasource(lc[::nb])
         lc_help_source = prepare_lc_help_source(lc)
 
         # Set up folded LC
-        nb = int(np.ceil(len(lc.flux)/10000))
+        nb = int(np.ceil(len(lc.flux) / 10000))
         f = lc.fold(best_period, best_t0)
         f_source = prepare_folded_datasource(f[::nb])
         f_help_source = prepare_f_help_source(f)
@@ -572,54 +747,70 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         f_model_lc = _to_lc(_as_1d(f.time.min()), [1]).append(f_model_lc)
         f_model_lc = f_model_lc.append(_to_lc(_as_1d(f.time.max()), [1]))
 
-        f_model_lc_source = _to_ColumnDataSource(data=dict(
-                                 phase=f_model_lc.time,
-                                 flux=f_model_lc.flux))
+        f_model_lc_source = _to_ColumnDataSource(
+            data=dict(phase=f_model_lc.time, flux=f_model_lc.flux)
+        )
 
         def _update_light_curve_plot(event):
             """If we zoom in on LC plot, update the binning."""
             mint, maxt = fig_lc.x_range.start, fig_lc.x_range.end
             inwindow = (lc.time.value > mint) & (lc.time.value < maxt)
-            nb = int(np.ceil(inwindow.sum()/5000))
+            nb = int(np.ceil(inwindow.sum() / 5000))
             temp_lc = lc[inwindow]
-            _update_source(lc_source, {'time': temp_lc.time[::nb],
-                                       'flux': temp_lc.flux[::nb]})
+            _update_source(
+                lc_source, {"time": temp_lc.time[::nb], "flux": temp_lc.flux[::nb]}
+            )
 
         def _update_folded_plot(event):
-            loc = np.argmax(bls_source.data['power'])
-            best_period = bls_source.data['period'][loc]
-            best_t0 = bls_source.data['transit_time'][loc]
+            loc = np.argmax(bls_source.data["power"])
+            best_period = bls_source.data["period"][loc]
+            best_t0 = bls_source.data["transit_time"][loc]
             # Otherwise, we can just update the best_period index
             minphase, maxphase = fig_folded.x_range.start, fig_folded.x_range.end
             f = lc.fold(best_period, best_t0)
             inwindow = (f.time > minphase) & (f.time < maxphase)
-            nb = int(np.ceil(inwindow.sum()/10000))
-            _update_source(f_source, {'phase': f[inwindow].time[::nb],
-                                      'flux': f[inwindow].flux[::nb]})
+            nb = int(np.ceil(inwindow.sum() / 10000))
+            _update_source(
+                f_source,
+                {"phase": f[inwindow].time[::nb], "flux": f[inwindow].flux[::nb]},
+            )
 
         # Function to update the widget
         def _update_params(all=False, best_period=None, best_t0=None):
             if all:
                 # If we're updating everything, recalculate the BLS model
                 minp, maxp = fig_bls.x_range.start, fig_bls.x_range.end
-                period_values = np.logspace(np.log10(minp), np.log10(maxp), npoints_slider.value)
+                period_values = np.logspace(
+                    np.log10(minp), np.log10(maxp), npoints_slider.value
+                )
                 ok = (period_values > duration_slider.value) & (period_values < maxp)
                 if ok.sum() == 0:
                     return
                 period_values = period_values[ok]
                 result = model.power(period_values, duration_slider.value)
-                ok = _isfinite(result['power']) & _isfinite(result['duration']) &\
-                         _isfinite(result['transit_time']) & _isfinite(result['period'])
-                ok_result = dict(period=result['period'][ok],             # useful for accessing values with units needed later
-                                 power=result['power'][ok],
-                                 duration=result['duration'][ok],
-                                 transit_time=result['transit_time'][ok])
+                ok = (
+                    _isfinite(result["power"])
+                    & _isfinite(result["duration"])
+                    & _isfinite(result["transit_time"])
+                    & _isfinite(result["period"])
+                )
+                ok_result = dict(
+                    period=result["period"][
+                        ok
+                    ],  # useful for accessing values with units needed later
+                    power=result["power"][ok],
+                    duration=result["duration"][ok],
+                    transit_time=result["transit_time"][ok],
+                )
                 _update_source(bls_source, ok_result)
-                loc = np.nanargmax(ok_result['power'])
-                best_period = ok_result['period'][loc]
-                best_t0 = ok_result['transit_time'][loc]
+                loc = np.nanargmax(ok_result["power"])
+                best_period = ok_result["period"][loc]
+                best_t0 = ok_result["transit_time"][loc]
 
-                minpow, maxpow = bls_source.data['power'].min()*0.95,  bls_source.data['power'].max()*1.05
+                minpow, maxpow = (
+                    bls_source.data["power"].min() * 0.95,
+                    bls_source.data["power"].max() * 1.05,
+                )
                 fig_bls.y_range.start = minpow
                 fig_bls.y_range.end = maxpow
 
@@ -627,42 +818,54 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
             minphase, maxphase = fig_folded.x_range.start, fig_folded.x_range.end
             f = lc.fold(best_period, best_t0)
             inwindow = (f.time > minphase) & (f.time < maxphase)
-            nb = int(np.ceil(inwindow.sum()/10000))
-            _update_source(f_source, {'phase': f[inwindow].time[::nb],
-                                      'flux': f[inwindow].flux[::nb]})
+            nb = int(np.ceil(inwindow.sum() / 10000))
+            _update_source(
+                f_source,
+                {"phase": f[inwindow].time[::nb], "flux": f[inwindow].flux[::nb]},
+            )
 
             mf = model.model(lc.time, best_period, duration_slider.value, best_t0)
             mf /= np.median(mf)
             mask = ~(convolve(np.asarray(mf == np.median(mf)), Box1DKernel(2)) > 0.9)
             model_lc = _to_lc(lc.time[mask], mf[mask])
 
-            _update_source(model_lc_source, {'time': model_lc.time,
-                                             'flux': model_lc.flux})
+            _update_source(
+                model_lc_source, {"time": model_lc.time, "flux": model_lc.flux}
+            )
 
             f_model_lc = model_lc.fold(best_period, best_t0)
             f_model_lc = _to_lc(_as_1d(f.time.min()), [1]).append(f_model_lc)
             f_model_lc = f_model_lc.append(_to_lc(_as_1d(f.time.max()), [1]))
 
-            _update_source(f_model_lc_source, {'phase': f_model_lc.time,
-                                               'flux': f_model_lc.flux})
+            _update_source(
+                f_model_lc_source, {"phase": f_model_lc.time, "flux": f_model_lc.flux}
+            )
 
             vertical_line.update(location=best_period.value)
-            fig_folded.title.text = 'Period: {} days \t T0: {}{}'.format(
-                                        _round_strip_unit(best_period, 7),
-                                        _round_strip_unit(best_t0, 7), time_format)
+            fig_folded.title.text = "Period: {} days \t T0: {}{}".format(
+                _round_strip_unit(best_period, 7),
+                _round_strip_unit(best_t0, 7),
+                time_format,
+            )
             text_output.text = "Period: {} days, \t T0: {}{}".format(
-                                        _round_strip_unit(best_period, 7),
-                                        _round_strip_unit(best_t0, 7), time_format)
+                _round_strip_unit(best_period, 7),
+                _round_strip_unit(best_t0, 7),
+                time_format,
+            )
 
         # Callbacks
         def _update_upon_period_selection(attr, old, new):
-            """When we select a period we should just update a few things, but we should not recalculate model
-            """
+            """When we select a period we should just update a few things, but we should not recalculate model"""
             if len(new) > 0:
                 new = new[0]
-                best_period = bls_source.data['period'][new] * bls_source_units['period']
-                best_t0 = Time(bls_source.data['transit_time'][new],
-                               format=bls_source_units['transit_time_format'], scale=bls_source_units['transit_time_scale'])
+                best_period = (
+                    bls_source.data["period"][new] * bls_source_units["period"]
+                )
+                best_t0 = Time(
+                    bls_source.data["transit_time"][new],
+                    format=bls_source_units["transit_time_format"],
+                    scale=bls_source_units["transit_time_scale"],
+                )
                 _update_params(best_period=best_period, best_t0=best_t0)
 
         def _update_model_slider(attr, old, new):
@@ -687,47 +890,61 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
 
         # Help Hover Call Backs
         def _update_folded_plot_help_reset(event):
-            f_help_source.data['phase'] = [_at_ratio(f.time, 0.95)]
-            f_help_source.data['flux'] = [_at_ratio(f.flux, 0.95)]
+            f_help_source.data["phase"] = [_at_ratio(f.time, 0.95)]
+            f_help_source.data["flux"] = [_at_ratio(f.flux, 0.95)]
 
         def _update_folded_plot_help(event):
-            f_help_source.data['phase'] = [_at_ratio(fig_folded.x_range, 0.95)]
-            f_help_source.data['flux'] = [_at_ratio(fig_folded.y_range, 0.95)]
+            f_help_source.data["phase"] = [_at_ratio(fig_folded.x_range, 0.95)]
+            f_help_source.data["flux"] = [_at_ratio(fig_folded.y_range, 0.95)]
 
         def _update_lc_plot_help_reset(event):
-            lc_help_source.data['time'] = [_at_ratio(lc.time, 0.98)]
-            lc_help_source.data['flux'] = [_at_ratio(lc.flux, 0.95)]
+            lc_help_source.data["time"] = [_at_ratio(lc.time, 0.98)]
+            lc_help_source.data["flux"] = [_at_ratio(lc.flux, 0.95)]
 
         def _update_lc_plot_help(event):
-            lc_help_source.data['time'] = [_at_ratio(fig_lc.x_range, 0.98)]
-            lc_help_source.data['flux'] = [_at_ratio(fig_lc.y_range, 0.95)]
+            lc_help_source.data["time"] = [_at_ratio(fig_lc.x_range, 0.98)]
+            lc_help_source.data["flux"] = [_at_ratio(fig_lc.y_range, 0.95)]
 
         def _update_bls_plot_help_event(event):
             # cannot use _at_ratio helper for period, because period is log scaled.
-            bls_help_source.data['period'] = [bls_source.data['period'][int(npoints_slider.value*0.95)]]
-            bls_help_source.data['power'] = [_at_ratio(bls_source.data['power'], 0.98)]
+            bls_help_source.data["period"] = [
+                bls_source.data["period"][int(npoints_slider.value * 0.95)]
+            ]
+            bls_help_source.data["power"] = [_at_ratio(bls_source.data["power"], 0.98)]
 
         def _update_bls_plot_help(attr, old, new):
-            bls_help_source.data['period'] = [bls_source.data['period'][int(npoints_slider.value*0.95)]]
-            bls_help_source.data['power'] = [_at_ratio(bls_source.data['power'], 0.98)]
+            bls_help_source.data["period"] = [
+                bls_source.data["period"][int(npoints_slider.value * 0.95)]
+            ]
+            bls_help_source.data["power"] = [_at_ratio(bls_source.data["power"], 0.98)]
 
         # Create all the figures.
-        fig_folded = make_folded_figure_elements(f, f_model_lc, f_source, f_model_lc_source, f_help_source)
-        fig_folded.title.text = 'Period: {} days \t T0: {}{}'.format(_round_strip_unit(best_period, 7), _round_strip_unit(best_t0, 5), time_format)
-        fig_bls, vertical_line = make_bls_figure_elements(result, bls_source, bls_help_source)
-        fig_lc = make_lightcurve_figure_elements(lc, model_lc, lc_source, model_lc_source, lc_help_source)
+        fig_folded = make_folded_figure_elements(
+            f, f_model_lc, f_source, f_model_lc_source, f_help_source
+        )
+        fig_folded.title.text = "Period: {} days \t T0: {}{}".format(
+            _round_strip_unit(best_period, 7),
+            _round_strip_unit(best_t0, 5),
+            time_format,
+        )
+        fig_bls, vertical_line = make_bls_figure_elements(
+            result, bls_source, bls_help_source
+        )
+        fig_lc = make_lightcurve_figure_elements(
+            lc, model_lc, lc_source, model_lc_source, lc_help_source
+        )
 
         # Map changes
 
         # If we click a new period, update
-        bls_source.selected.on_change('indices', _update_upon_period_selection)
+        bls_source.selected.on_change("indices", _update_upon_period_selection)
 
         # If we change the duration, update everything, including help button for BLS
-        duration_slider.on_change('value', _update_model_slider)
-        duration_slider.on_change('value', _update_bls_plot_help)
+        duration_slider.on_change("value", _update_model_slider)
+        duration_slider.on_change("value", _update_bls_plot_help)
 
         # If we increase resolution, update everything
-        npoints_slider.on_change('value', _update_model_slider)
+        npoints_slider.on_change("value", _update_model_slider)
 
         # Make sure the vertical line always goes to the best period.
         vertical_line.update(location=best_period.value)
@@ -757,13 +974,28 @@ def show_interact_widget(lc, notebook_url='localhost:8888', minimum_period=None,
         half_button.on_click(_half_period_event)
 
         # Layout the widget
-        doc.add_root(layout([
-                            [fig_bls, fig_folded],
-                            fig_lc,
-                            [Spacer(width=70), duration_slider, Spacer(width=50), npoints_slider],
-                            [Spacer(width=70), double_button, Spacer(width=70), half_button, Spacer(width=300), text_output]
-                                ]))
-
+        doc.add_root(
+            layout(
+                [
+                    [fig_bls, fig_folded],
+                    fig_lc,
+                    [
+                        Spacer(width=70),
+                        duration_slider,
+                        Spacer(width=50),
+                        npoints_slider,
+                    ],
+                    [
+                        Spacer(width=70),
+                        double_button,
+                        Spacer(width=70),
+                        half_button,
+                        Spacer(width=300),
+                        text_output,
+                    ],
+                ]
+            )
+        )
 
     # TODO: pre-process LC
     lc = _preprocess_lc_for_bls(lc)

--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -8,18 +8,18 @@ from .. import LightCurve
 from astropy.io import registry
 
 
-__all__ = ['read', 'open']
+__all__ = ["read", "open"]
 
 
 # We intend the reader functions to be accessed via `LightCurve.read()`,
 # so we add them to the `astropy.io.registry`.
 try:
-    registry.register_reader('kepler', LightCurve, kepler.read_kepler_lightcurve)
-    registry.register_reader('tess', LightCurve, tess.read_tess_lightcurve)
-    registry.register_reader('qlp', LightCurve, qlp.read_qlp_lightcurve)
-    registry.register_reader('k2sff', LightCurve, k2sff.read_k2sff_lightcurve)
-    registry.register_reader('everest', LightCurve, everest.read_everest_lightcurve)
-    registry.register_reader('pathos', LightCurve, pathos.read_pathos_lightcurve)
-    registry.register_reader('tasoc', LightCurve, tasoc.read_tasoc_lightcurve)
+    registry.register_reader("kepler", LightCurve, kepler.read_kepler_lightcurve)
+    registry.register_reader("tess", LightCurve, tess.read_tess_lightcurve)
+    registry.register_reader("qlp", LightCurve, qlp.read_qlp_lightcurve)
+    registry.register_reader("k2sff", LightCurve, k2sff.read_k2sff_lightcurve)
+    registry.register_reader("everest", LightCurve, everest.read_everest_lightcurve)
+    registry.register_reader("pathos", LightCurve, pathos.read_pathos_lightcurve)
+    registry.register_reader("tasoc", LightCurve, tasoc.read_tasoc_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -3,7 +3,7 @@ from astropy.io.fits import HDUList
 from astropy.io import fits
 
 
-__all__ = ['detect_filetype']
+__all__ = ["detect_filetype"]
 
 
 def detect_filetype(hdulist: HDUList) -> str:
@@ -42,7 +42,7 @@ def detect_filetype(hdulist: HDUList) -> str:
 
     # Is it a MIT/QLP TESS FFI Quicklook Pipeline light curve?
     # cf. http://archive.stsci.edu/hlsp/qlp
-    if "mit/qlp" in hdulist[0].header.get('origin', '').lower():
+    if "mit/qlp" in hdulist[0].header.get("origin", "").lower():
         return "QLP"
 
     # Is it a PATHOS TESS light curve?
@@ -50,36 +50,47 @@ def detect_filetype(hdulist: HDUList) -> str:
     # The 'pathos' name doesn't stay in the filename if when we use fits.open
     # to download a file, so we have to check for all the important columns
     # This will cause problems if another HLSP has the exact same colnames...
-    if all(x in hdulist[1].columns.names for x in ["PSF_FLUX_RAW", "PSF_FLUX_COR", "AP4_FLUX_RAW", "AP4_FLUX_COR", "SKY_LOCAL"]):
+    if all(
+        x in hdulist[1].columns.names
+        for x in [
+            "PSF_FLUX_RAW",
+            "PSF_FLUX_COR",
+            "AP4_FLUX_RAW",
+            "AP4_FLUX_COR",
+            "SKY_LOCAL",
+        ]
+    ):
         return "PATHOS"
 
     # Is it a TASOC TESS light curve?
     # cf. https://tasoc.dk and https://archive.stsci.edu/hlsp/tasoc
-    if hdulist[0].header.get('ORIGIN') == "TASOC/Aarhus":
+    if hdulist[0].header.get("ORIGIN") == "TASOC/Aarhus":
         return "TASOC"
 
-    
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.
     if "hlsp_k2varcat" in (hdulist.filename() or ""):
         return "K2VARCAT"
 
     # Is it a K2SC file?
-    if "k2sc" in hdulist[0].header.get('creator', '').lower():
+    if "k2sc" in hdulist[0].header.get("creator", "").lower():
         return "K2SC"
 
     # Is it a K2SFF file?
     try:
         # There are no metadata keywords identifying K2SFF FITS files,
         # so we go by structure.
-        if hdulist[1].header.get('EXTNAME') == "BESTAPER" and hdulist[1].header.get("TTYPE4") == "ARCLENGTH":
+        if (
+            hdulist[1].header.get("EXTNAME") == "BESTAPER"
+            and hdulist[1].header.get("TTYPE4") == "ARCLENGTH"
+        ):
             return "K2SFF"
     except Exception:
         pass
 
     # Is it an EVEREST file?
     try:
-        if "EVEREST" in str(hdulist[0].header.get('COMMENT')):
+        if "EVEREST" in str(hdulist[0].header.get("COMMENT")):
             return "EVEREST"
     except Exception:
         pass
@@ -89,31 +100,34 @@ def detect_filetype(hdulist: HDUList) -> str:
     try:
         # use `telescop` keyword to determine mission
         # and `creator` to determine tpf or lc
-        if 'TELESCOP' in header.keys():
-            telescop = header['telescop'].lower()
+        if "TELESCOP" in header.keys():
+            telescop = header["telescop"].lower()
         else:
             # Some old custom TESS data did not define the `TELESCOP` card
-            telescop = header['mission'].lower()
-        creator = header['creator'].lower()
-        origin = header['origin'].lower()
-        if telescop == 'kepler':
+            telescop = header["mission"].lower()
+        creator = header["creator"].lower()
+        origin = header["origin"].lower()
+        if telescop == "kepler":
             # Kepler TPFs will contain "TargetPixelExporterPipelineModule"
-            if 'targetpixel' in creator:
-                return 'KeplerTargetPixelFile'
+            if "targetpixel" in creator:
+                return "KeplerTargetPixelFile"
             # Kepler LCFs will contain "FluxExporter2PipelineModule"
-            elif ('fluxexporter' in creator or 'lightcurve' in creator
-                or 'lightcurve' in creator):
-                return 'KeplerLightCurve'
-        elif telescop == 'tess':
+            elif (
+                "fluxexporter" in creator
+                or "lightcurve" in creator
+                or "lightcurve" in creator
+            ):
+                return "KeplerLightCurve"
+        elif telescop == "tess":
             # TESS TPFs will contain "TargetPixelExporterPipelineModule"
-            if 'targetpixel' in creator:
-                return 'TessTargetPixelFile'
+            if "targetpixel" in creator:
+                return "TessTargetPixelFile"
             # TESS LCFs will contain "LightCurveExporterPipelineModule"
-            elif 'lightcurve' in creator:
-                return 'TessLightCurve'
+            elif "lightcurve" in creator:
+                return "TessLightCurve"
             # Early versions of TESScut did not set a good CREATOR keyword
-            elif 'stsci' in origin:
-                return 'TessTargetPixelFile'
+            elif "stsci" in origin:
+                return "TessTargetPixelFile"
     # If the TELESCOP or CREATOR keywords don't exist we expect a KeyError;
     # if one of them is Undefined we expect `.lower()` to yield an AttributeError.
     except (KeyError, AttributeError):

--- a/src/lightkurve/io/everest.py
+++ b/src/lightkurve/io/everest.py
@@ -5,10 +5,9 @@ from ..utils import KeplerQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_everest_lightcurve(filename,
-                            flux_column="flux",
-                            quality_bitmask="default",
-                            **kwargs):
+def read_everest_lightcurve(
+    filename, flux_column="flux", quality_bitmask="default", **kwargs
+):
     """Read an EVEREST light curve file.
 
     More information: https://archive.stsci.edu/hlsp/everest
@@ -39,24 +38,26 @@ def read_everest_lightcurve(filename,
     lc : `KeplerLightCurve`
         A populated light curve object.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column,
-                                 quality_column='quality',
-                                 cadenceno_column='cadn',
-                                 time_format='bkjd')
+    lc = read_generic_lightcurve(
+        filename,
+        flux_column=flux_column,
+        quality_column="quality",
+        cadenceno_column="cadn",
+        time_format="bkjd",
+    )
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = KeplerQualityFlags.create_quality_mask(
-                                quality_array=lc['quality'],
-                                bitmask=quality_bitmask)
+        quality_array=lc["quality"], bitmask=quality_bitmask
+    )
     lc = lc[quality_mask]
 
-    lc.meta['LABEL'] = '{} (EVEREST)'.format(lc.meta.get('OBJECT'))
-    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
-    lc.meta['QUALITY_BITMASK'] = quality_bitmask
-    lc.meta['QUALITY_MASK'] = quality_mask
+    lc.meta["LABEL"] = "{} (EVEREST)".format(lc.meta.get("OBJECT"))
+    lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
 
     return KeplerLightCurve(data=lc, **kwargs)

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -13,16 +13,18 @@ from ..lightcurve import LightCurve
 log = logging.getLogger(__name__)
 
 
-def read_generic_lightcurve(filename,
-                            time_column='time',
-                            flux_column='flux',
-                            flux_err_column='flux_err',
-                            quality_column='quality',
-                            cadenceno_column='cadenceno',
-                            centroid_col_column='mom_centr1',
-                            centroid_row_column='mom_centr2',
-                            time_format=None,
-                            ext=1):
+def read_generic_lightcurve(
+    filename,
+    time_column="time",
+    flux_column="flux",
+    flux_err_column="flux_err",
+    quality_column="quality",
+    cadenceno_column="cadenceno",
+    centroid_col_column="mom_centr1",
+    centroid_row_column="mom_centr2",
+    time_format=None,
+    ext=1,
+):
     """Generic helper function to convert a Kepler ot TESS light curve file
     into a generic `LightCurve` object.
     """
@@ -39,17 +41,17 @@ def read_generic_lightcurve(filename,
     # Make sure the meta data also includes header fields from extension #0
     tab.meta.update(hdulist[0].header)
 
-    tab.meta = {k : v for k, v in tab.meta.items()}
+    tab.meta = {k: v for k, v in tab.meta.items()}
 
     for colname in tab.colnames:
         # Ensure units have the correct astropy format
         # Speed-up: comparing units by their string representation is 1000x
         # faster than performing full-blown unit comparison
         unitstr = str(tab[colname].unit)
-        if unitstr == 'e-/s':
-            tab[colname].unit = 'electron/s'
-        elif unitstr == 'pixels':
-            tab[colname].unit = 'pixel'
+        if unitstr == "e-/s":
+            tab[colname].unit = "electron/s"
+        elif unitstr == "pixels":
+            tab[colname].unit = "pixel"
 
         # Rename columns to lowercase
         tab.rename_column(colname, colname.lower())
@@ -63,47 +65,51 @@ def read_generic_lightcurve(filename,
     # We *have* to remove rows with TIME=NaN because the Astropy Time
     # object does not support the presence of NaNs.
     # Fortunately, such rows are always bad data.
-    nans = np.isnan(tab['time'].data)
+    nans = np.isnan(tab["time"].data)
     if np.any(nans):
-        log.debug('Ignoring {} rows with NaN times'.format(np.sum(nans)))
+        log.debug("Ignoring {} rows with NaN times".format(np.sum(nans)))
     tab = tab[~nans]
 
     # Prepare a special time column
     if not time_format:
-        if hdulist[ext].header.get('BJDREFI') == 2454833:
-            time_format = 'bkjd'
-        elif hdulist[ext].header.get('BJDREFI') == 2457000:
-            time_format = 'btjd'
+        if hdulist[ext].header.get("BJDREFI") == 2454833:
+            time_format = "bkjd"
+        elif hdulist[ext].header.get("BJDREFI") == 2457000:
+            time_format = "btjd"
         else:
             raise ValueError(f"Input file has unclear time format: {filename}")
-    time = Time(tab['time'].data,
-                scale=hdulist[ext].header.get('TIMESYS', 'tdb').lower(),
-                format=time_format)
-    tab.remove_column('time')
+    time = Time(
+        tab["time"].data,
+        scale=hdulist[ext].header.get("TIMESYS", "tdb").lower(),
+        format=time_format,
+    )
+    tab.remove_column("time")
 
     # For backwards compatibility with Lightkurve v1.x,
     # we make sure standard columns and attributes exist.
-    if 'flux' not in tab.columns:
+    if "flux" not in tab.columns:
         tab.add_column(tab[flux_column], name="flux", index=0)
-    if 'flux_err' not in tab.columns:
+    if "flux_err" not in tab.columns:
         # Try falling back to `{flux_column}_err` if possible
         if flux_err_column not in tab.columns:
             flux_err_column = flux_column + "_err"
         if flux_err_column in tab.columns:
             tab.add_column(tab[flux_err_column], name="flux_err", index=1)
-    if 'quality' not in tab.columns and quality_column in tab.columns:
+    if "quality" not in tab.columns and quality_column in tab.columns:
         tab.add_column(tab[quality_column], name="quality", index=2)
-    if 'cadenceno' not in tab.columns and cadenceno_column in tab.columns:
+    if "cadenceno" not in tab.columns and cadenceno_column in tab.columns:
         tab.add_column(tab[cadenceno_column], name="cadenceno", index=3)
-    if 'centroid_col' not in tab.columns and centroid_col_column in tab.columns:
+    if "centroid_col" not in tab.columns and centroid_col_column in tab.columns:
         tab.add_column(tab[centroid_col_column], name="centroid_col", index=4)
-    if 'centroid_row' not in tab.columns and centroid_row_column in tab.columns:
+    if "centroid_row" not in tab.columns and centroid_row_column in tab.columns:
         tab.add_column(tab[centroid_row_column], name="centroid_row", index=5)
 
-    tab.meta['LABEL'] = hdulist[0].header.get('OBJECT')
-    tab.meta['MISSION'] = hdulist[0].header.get('MISSION', hdulist[0].header.get('TELESCOP'))
-    tab.meta['RA'] = hdulist[0].header.get('RA_OBJ')
-    tab.meta['DEC'] = hdulist[0].header.get('DEC_OBJ')
-    tab.meta['FILENAME'] = filename
+    tab.meta["LABEL"] = hdulist[0].header.get("OBJECT")
+    tab.meta["MISSION"] = hdulist[0].header.get(
+        "MISSION", hdulist[0].header.get("TELESCOP")
+    )
+    tab.meta["RA"] = hdulist[0].header.get("RA_OBJ")
+    tab.meta["DEC"] = hdulist[0].header.get("DEC_OBJ")
+    tab.meta["FILENAME"] = filename
 
     return LightCurve(time=time, data=tab)

--- a/src/lightkurve/io/k2sff.py
+++ b/src/lightkurve/io/k2sff.py
@@ -23,12 +23,11 @@ def read_k2sff_lightcurve(filename, ext="BESTAPER", **kwargs):
     lc : `KeplerLightCurve`
         A populated light curve object.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column="fcor",
-                                 time_format='bkjd',
-                                 ext=ext)
+    lc = read_generic_lightcurve(
+        filename, flux_column="fcor", time_format="bkjd", ext=ext
+    )
 
-    lc.meta['LABEL'] = '{} (K2SFF)'.format(lc.meta.get('OBJECT'))
-    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
+    lc.meta["LABEL"] = "{} (K2SFF)".format(lc.meta.get("OBJECT"))
+    lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
 
     return KeplerLightCurve(data=lc, **kwargs)

--- a/src/lightkurve/io/kepler.py
+++ b/src/lightkurve/io/kepler.py
@@ -5,9 +5,9 @@ from ..utils import KeplerQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_kepler_lightcurve(filename,
-                           flux_column="pdcsap_flux",
-                           quality_bitmask="default"):
+def read_kepler_lightcurve(
+    filename, flux_column="pdcsap_flux", quality_bitmask="default"
+):
     """Returns a KeplerLightCurve.
 
     Parameters
@@ -31,21 +31,23 @@ def read_kepler_lightcurve(filename,
 
         See the :class:`KeplerQualityFlags` class for details on the bitmasks.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column,
-                                 quality_column='sap_quality',
-                                 time_format='bkjd')
+    lc = read_generic_lightcurve(
+        filename,
+        flux_column=flux_column,
+        quality_column="sap_quality",
+        time_format="bkjd",
+    )
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = KeplerQualityFlags.create_quality_mask(
-                                quality_array=lc['sap_quality'],
-                                bitmask=quality_bitmask)
+        quality_array=lc["sap_quality"], bitmask=quality_bitmask
+    )
     lc = lc[quality_mask]
 
-    lc.meta['TARGETID'] = lc.meta.get('KEPLERID')
-    lc.meta['QUALITY_BITMASK'] = quality_bitmask
-    lc.meta['QUALITY_MASK'] = quality_mask
+    lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
     return KeplerLightCurve(data=lc)

--- a/src/lightkurve/io/pathos.py
+++ b/src/lightkurve/io/pathos.py
@@ -9,9 +9,9 @@ from ..utils import TessQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_pathos_lightcurve(filename,
-                            flux_column="PSF_FLUX_COR",
-                            quality_bitmask="default"):
+def read_pathos_lightcurve(
+    filename, flux_column="PSF_FLUX_COR", quality_bitmask="default"
+):
     """Returns a `TessLightCurve`.
 
     Parameters
@@ -36,25 +36,27 @@ def read_pathos_lightcurve(filename,
 
         See the :class:`TessQualityFlags` class for details on the bitmasks.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column.lower(),
-                                 time_format='btjd',
-                                 quality_column="DQUALITY")
+    lc = read_generic_lightcurve(
+        filename,
+        flux_column=flux_column.lower(),
+        time_format="btjd",
+        quality_column="DQUALITY",
+    )
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = TessQualityFlags.create_quality_mask(
-                                quality_array=lc['dquality'],
-                                bitmask=quality_bitmask)
+        quality_array=lc["dquality"], bitmask=quality_bitmask
+    )
     lc = lc[quality_mask]
 
-    lc.meta['TARGETID'] = lc.meta.get('TICID')
-    lc.meta['QUALITY_BITMASK'] = quality_bitmask
-    lc.meta['QUALITY_MASK'] = quality_mask
+    lc.meta["TARGETID"] = lc.meta.get("TICID")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
 
     # QLP light curves are normalized by default
-    lc.meta['NORMALIZED'] = True
+    lc.meta["NORMALIZED"] = True
 
     return TessLightCurve(data=lc)

--- a/src/lightkurve/io/qlp.py
+++ b/src/lightkurve/io/qlp.py
@@ -9,9 +9,7 @@ from ..utils import TessQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_qlp_lightcurve(filename,
-                        flux_column="kspsap_flux",
-                        quality_bitmask="default"):
+def read_qlp_lightcurve(filename, flux_column="kspsap_flux", quality_bitmask="default"):
     """Returns a `TessLightCurve`.
 
     Parameters
@@ -35,24 +33,22 @@ def read_qlp_lightcurve(filename,
 
         See the :class:`TessQualityFlags` class for details on the bitmasks.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column,
-                                 time_format='btjd')
+    lc = read_generic_lightcurve(filename, flux_column=flux_column, time_format="btjd")
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = TessQualityFlags.create_quality_mask(
-                                quality_array=lc['quality'],
-                                bitmask=quality_bitmask)
+        quality_array=lc["quality"], bitmask=quality_bitmask
+    )
     lc = lc[quality_mask]
 
-    lc.meta['TARGETID'] = lc.meta.get('TICID')
-    lc.meta['QUALITY_BITMASK'] = quality_bitmask
-    lc.meta['QUALITY_MASK'] = quality_mask
+    lc.meta["TARGETID"] = lc.meta.get("TICID")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
 
     # QLP light curves are normalized by default
-    lc.meta['NORMALIZED'] = True
+    lc.meta["NORMALIZED"] = True
 
     return TessLightCurve(data=lc)

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -11,7 +11,7 @@ from ..utils import LightkurveDeprecationWarning, LightkurveError
 log = logging.getLogger(__name__)
 
 
-__all__ = ['open', 'read']
+__all__ = ["open", "read"]
 
 
 @deprecated("2.0", alternative="read()", warning_type=LightkurveDeprecationWarning)
@@ -83,35 +83,38 @@ def read(path_or_url, **kwargs):
     except OSError as e:
         filetype = None
         # Raise an explicit FileNotFoundError if file not found
-        if 'No such file' in str(e):
+        if "No such file" in str(e):
             raise e
 
     if filetype == "KeplerLightCurve":
-        return KeplerLightCurve.read(path_or_url, format='kepler', **kwargs)
+        return KeplerLightCurve.read(path_or_url, format="kepler", **kwargs)
     elif filetype == "TessLightCurve":
-        return TessLightCurve.read(path_or_url, format='tess', **kwargs)
+        return TessLightCurve.read(path_or_url, format="tess", **kwargs)
     elif filetype == "QLP":
-        return TessLightCurve.read(path_or_url, format='qlp', **kwargs)
+        return TessLightCurve.read(path_or_url, format="qlp", **kwargs)
     elif filetype == "PATHOS":
-        return TessLightCurve.read(path_or_url, format='pathos', **kwargs)
+        return TessLightCurve.read(path_or_url, format="pathos", **kwargs)
     elif filetype == "TASOC":
-        return TessLightCurve.read(path_or_url, format='tasoc', **kwargs)
+        return TessLightCurve.read(path_or_url, format="tasoc", **kwargs)
     elif filetype == "K2SFF":
-        return KeplerLightCurve.read(path_or_url, format='k2sff', **kwargs)
+        return KeplerLightCurve.read(path_or_url, format="k2sff", **kwargs)
     elif filetype == "EVEREST":
-        return KeplerLightCurve.read(path_or_url, format='everest', **kwargs)
+        return KeplerLightCurve.read(path_or_url, format="everest", **kwargs)
 
     # Official data products;
     # if the filetype is recognized, instantiate a class of that name
     if filetype is not None:
         try:
-            return getattr(__import__('lightkurve'), filetype)(path_or_url, **kwargs)
+            return getattr(__import__("lightkurve"), filetype)(path_or_url, **kwargs)
         except AttributeError as exc:
-            raise LightkurveError(f"{filetype} files are not supported "
-                                   "in this version of Lightkurve.") from exc
+            raise LightkurveError(
+                f"{filetype} files are not supported " "in this version of Lightkurve."
+            ) from exc
     else:
         # if these keywords don't exist, raise `ValueError`
-        raise LightkurveError("Not recognized as a supported data product:\n"
-                              f"{path_or_url}\n"
-                              "This file may be corrupt due to an interrupted download. "
-                              "Please remove it from your disk and try again.")
+        raise LightkurveError(
+            "Not recognized as a supported data product:\n"
+            f"{path_or_url}\n"
+            "This file may be corrupt due to an interrupted download. "
+            "Please remove it from your disk and try again."
+        )

--- a/src/lightkurve/io/tasoc.py
+++ b/src/lightkurve/io/tasoc.py
@@ -19,13 +19,13 @@ def read_tasoc_lightcurve(filename, flux_column="FLUX_RAW", quality_bitmask=None
     flux_column : str
         Column that will be used to populate the flux values.
         By default, "FLUX_RAW" is used. It contains the T'DA extracted lightcurve,
-        with no corrections applied to the raw light curves. Corrected lightcurves 
+        with no corrections applied to the raw light curves. Corrected lightcurves
         may become available in the future.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column.lower(),
-                                 time_format='btjd')
-    lc.meta['TARGETID'] = lc.meta.get('TICID')
+    lc = read_generic_lightcurve(
+        filename, flux_column=flux_column.lower(), time_format="btjd"
+    )
+    lc.meta["TARGETID"] = lc.meta.get("TICID")
     # TASOC light curves are normalized by default
-    lc.meta['NORMALIZED'] = True
+    lc.meta["NORMALIZED"] = True
     return TessLightCurve(data=lc)

--- a/src/lightkurve/io/tess.py
+++ b/src/lightkurve/io/tess.py
@@ -5,9 +5,9 @@ from ..utils import TessQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_tess_lightcurve(filename,
-                         flux_column="pdcsap_flux",
-                         quality_bitmask="default"):
+def read_tess_lightcurve(
+    filename, flux_column="pdcsap_flux", quality_bitmask="default"
+):
     """Returns a `TessLightCurve`.
 
     Parameters
@@ -31,20 +31,18 @@ def read_tess_lightcurve(filename,
 
         See the :class:`TessQualityFlags` class for details on the bitmasks.
     """
-    lc = read_generic_lightcurve(filename,
-                                 flux_column=flux_column,
-                                 time_format='btjd')
+    lc = read_generic_lightcurve(filename, flux_column=flux_column, time_format="btjd")
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns
     # that are Quantity objects, so for now we remove poor-quality data instead
     # of masking. Details: https://github.com/astropy/astropy/issues/10119
     quality_mask = TessQualityFlags.create_quality_mask(
-                                quality_array=lc['quality'],
-                                bitmask=quality_bitmask)
+        quality_array=lc["quality"], bitmask=quality_bitmask
+    )
     lc = lc[quality_mask]
 
-    lc.meta['TARGETID'] = lc.meta.get('TICID')
-    lc.meta['QUALITY_BITMASK'] = quality_bitmask
-    lc.meta['QUALITY_MASK'] = quality_mask
+    lc.meta["TARGETID"] = lc.meta.get("TICID")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
     return TessLightCurve(data=lc)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -23,19 +23,24 @@ from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import PACKAGEDIR, MPLSTYLE
-from .utils import (running_mean, bkjd_to_astropy_time, btjd_to_astropy_time,
-    validate_method, _query_solar_system_objects
+from .utils import (
+    running_mean,
+    bkjd_to_astropy_time,
+    btjd_to_astropy_time,
+    validate_method,
+    _query_solar_system_objects,
 )
 from .utils import LightkurveWarning, LightkurveDeprecationWarning
 
 
-__all__ = ['LightCurve', 'KeplerLightCurve', 'TessLightCurve', 'FoldedLightCurve']
+__all__ = ["LightCurve", "KeplerLightCurve", "TessLightCurve", "FoldedLightCurve"]
 
 log = logging.getLogger(__name__)
 
 
 class QColumn(Column):
     """(Temporary) workaround to provide ``.value`` alias to raw data, so as to match ``Quantity``."""
+
     @property
     def value(self):
         return self.data
@@ -43,6 +48,7 @@ class QColumn(Column):
 
 class QMaskedColumn(MaskedColumn):
     """(Temporary) workaround to provide ``.value`` alias to raw data, so as to match ``Quantity``."""
+
     @property
     def value(self):
         return self.data
@@ -56,15 +62,34 @@ class QTimeSeries(TimeSeries):
         and Lightkurve requires the correspond astropy release.
         """
         col = super()._convert_col_for_table(col)
-        if (isinstance(col, Column) and getattr(col, 'unit', None) is None and (not hasattr(col, 'value'))):
+        if (
+            isinstance(col, Column)
+            and getattr(col, "unit", None) is None
+            and (not hasattr(col, "value"))
+        ):
             # the logic is similar to those in the grandparent QTable for Quantity
             if isinstance(col, MaskedColumn):
-                qcol = QMaskedColumn(data=col.data, name=col.name, dtype=col.dtype, description=col.description,
-                                     mask=col.mask, fill_value=col.fill_value,
-                                     format=col.format, meta=col.meta, copy=False)
+                qcol = QMaskedColumn(
+                    data=col.data,
+                    name=col.name,
+                    dtype=col.dtype,
+                    description=col.description,
+                    mask=col.mask,
+                    fill_value=col.fill_value,
+                    format=col.format,
+                    meta=col.meta,
+                    copy=False,
+                )
             else:
-                qcol = QColumn(data=col.data, name=col.name, dtype=col.dtype, description=col.description,
-                               format=col.format, meta=col.meta, copy=False)
+                qcol = QColumn(
+                    data=col.data,
+                    name=col.name,
+                    dtype=col.dtype,
+                    description=col.description,
+                    format=col.format,
+                    meta=col.meta,
+                    copy=False,
+                )
             qcol.info = col.info
             qcol.info.indices = col.info.indices
             col = qcol
@@ -135,14 +160,23 @@ class LightCurve(QTimeSeries):
 
     # The constructor of the `TimeSeries` base class will enforce the presence
     # of these columns:
-    _required_columns = ['time', 'flux', 'flux_err']
+    _required_columns = ["time", "flux", "flux_err"]
 
     # The following keywords were removed in Lightkurve v2.0.
     # Their use will trigger a warning.
-    _deprecated_keywords = ('targetid', 'label', 'time_format', 'time_scale',
-                            'flux_unit')
-    _deprecated_column_keywords = ['centroid_col', 'centroid_row',
-                                   'cadenceno', 'quality']
+    _deprecated_keywords = (
+        "targetid",
+        "label",
+        "time_format",
+        "time_scale",
+        "flux_unit",
+    )
+    _deprecated_column_keywords = [
+        "centroid_col",
+        "centroid_row",
+        "cadenceno",
+        "quality",
+    ]
 
     # If an iterable is passed for ``time``, we will initialize an AstroPy
     # ``Time`` object using the following format and scale:
@@ -162,9 +196,11 @@ class LightCurve(QTimeSeries):
         # Lightkurve v1.x supported passing time, flux, and flux_err as
         # positional arguments. We support it here for backwards compatibility.
         if len(args) in [1, 2]:
-            warnings.warn("passing flux as a positional argument is deprecated"
-                          ", please use ``flux=...`` instead.",
-                          LightkurveDeprecationWarning)
+            warnings.warn(
+                "passing flux as a positional argument is deprecated"
+                ", please use ``flux=...`` instead.",
+                LightkurveDeprecationWarning,
+            )
             time = data
             flux = args[0]
             data = None
@@ -184,27 +220,30 @@ class LightCurve(QTimeSeries):
                 deprecated_column_kws[kw] = kwargs.pop(kw)
 
         # If `time` is passed as keyword argument, we populate it with integer numbers
-        if data is None or 'time' not in data.keys():
+        if data is None or "time" not in data.keys():
             if time is None and flux is not None:
                 time = np.arange(len(flux))
             # We are tolerant of missing time format
             if time is not None and not isinstance(time, (Time, TimeDelta)):
                 # Lightkurve v1.x supported specifying the time_format
                 # as a constructor kwarg
-                time = Time(time,
-                            format=deprecated_kws.get("time_format", self._default_time_format),
-                            scale=deprecated_kws.get("time_scale", self._default_time_scale))
+                time = Time(
+                    time,
+                    format=deprecated_kws.get("time_format", self._default_time_format),
+                    scale=deprecated_kws.get("time_scale", self._default_time_scale),
+                )
 
         # Also be tolerant of missing time format if time is passed via `data`
-        if data and 'time' in data.keys():
-            if not isinstance(data['time'], (Time, TimeDelta)):
-                data['time'] = Time(data['time'],
-                            format=deprecated_kws.get("time_format", self._default_time_format),
-                            scale=deprecated_kws.get("time_scale", self._default_time_scale))
+        if data and "time" in data.keys():
+            if not isinstance(data["time"], (Time, TimeDelta)):
+                data["time"] = Time(
+                    data["time"],
+                    format=deprecated_kws.get("time_format", self._default_time_format),
+                    scale=deprecated_kws.get("time_scale", self._default_time_scale),
+                )
 
         # Allow overriding the required columns
-        self._required_columns = kwargs.pop("_required_columns",
-                                            self._required_columns)
+        self._required_columns = kwargs.pop("_required_columns", self._required_columns)
 
         # Call the SampledTimeSeries constructor.
         # Disable required columns for now; we'll check those later.
@@ -221,17 +260,21 @@ class LightCurve(QTimeSeries):
             return
 
         # Load `time`, `flux`, and `flux_err` from the table as local variable names
-        time = self.columns['time']  # super().__init__() guarantees this is a column
-        if 'flux' in self.colnames:
+        time = self.columns["time"]  # super().__init__() guarantees this is a column
+        if "flux" in self.colnames:
             if flux is None:
-                flux = self.columns['flux']
+                flux = self.columns["flux"]
             else:
-                raise TypeError(f"'flux' has been given both in the `data` table and as a keyword argument")
-        if 'flux_err' in self.colnames:
+                raise TypeError(
+                    f"'flux' has been given both in the `data` table and as a keyword argument"
+                )
+        if "flux_err" in self.colnames:
             if flux_err is None:
-                flux_err = self.columns['flux_err']
+                flux_err = self.columns["flux_err"]
             else:
-                raise TypeError(f"'flux_err' has been given both in the `data` table and as a keyword argument")
+                raise TypeError(
+                    f"'flux_err' has been given both in the `data` table and as a keyword argument"
+                )
 
         # Ensure `flux` and `flux_err` are populated with NaNs if missing
         if flux is None and time is not None:
@@ -265,7 +308,7 @@ class LightCurve(QTimeSeries):
                 self.add_column(deprecated_column_kws[kw], name=kw)
 
         # Ensure flux and flux_err have the same units
-        if self['flux'].unit != self['flux'].unit:
+        if self["flux"].unit != self["flux"].unit:
             raise ValueError("flux and flux_err must have the same units")
 
         self._new_attributes_relax = False
@@ -280,11 +323,11 @@ class LightCurve(QTimeSeries):
             return self.__class__.__dict__[name].__get__(self)
         elif name in self.columns:
             return self[name]
-        elif ('_meta' in self.__dict__):
-            if (name in self.__dict__['_meta']):
-                return self.__dict__['_meta'][name]
-            elif (name.upper() in self.__dict__['_meta']):
-                return self.__dict__['_meta'][name.upper()]
+        elif "_meta" in self.__dict__:
+            if name in self.__dict__["_meta"]:
+                return self.__dict__["_meta"][name]
+            elif name.upper() in self.__dict__["_meta"]:
+                return self.__dict__["_meta"][name.upper()]
         raise AttributeError(f"object has no attribute {name}")
 
     def __setattr__(self, name, value, **kwargs):
@@ -292,25 +335,34 @@ class LightCurve(QTimeSeries):
         to_set_as_attr = False
         if name in self.__dict__:
             to_set_as_attr = True
-        elif (name == 'time'):
-            self['time'] = value # astropy will convert value to Time if needed
-        elif ('columns' in self.__dict__) and (name in self.__dict__['columns']):
+        elif name == "time":
+            self["time"] = value  # astropy will convert value to Time if needed
+        elif ("columns" in self.__dict__) and (name in self.__dict__["columns"]):
             self.replace_column(name, value)
-        elif ('_meta' in self.__dict__):
-            if (name in self.__dict__['_meta']):
-                self.__dict__['_meta'][name] = value
-            elif (name.upper() in self.__dict__['_meta']):
-                self.__dict__['_meta'][name.upper()] = value
+        elif "_meta" in self.__dict__:
+            if name in self.__dict__["_meta"]:
+                self.__dict__["_meta"][name] = value
+            elif name.upper() in self.__dict__["_meta"]:
+                self.__dict__["_meta"][name.upper()] = value
             else:
                 to_set_as_attr = True
         else:
             to_set_as_attr = True
         if to_set_as_attr:
-            if name not in self.__dict__ and not name.startswith("_") and not self._new_attributes_relax:
-                warnings.warn(("Lightkurve doesn't allow columns or meta values to be created via a new attribute name."
-                               "A new attribute is created. It will not be carried over when the object is copied."
-                               " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"),
-                              UserWarning, stacklevel=2)
+            if (
+                name not in self.__dict__
+                and not name.startswith("_")
+                and not self._new_attributes_relax
+            ):
+                warnings.warn(
+                    (
+                        "Lightkurve doesn't allow columns or meta values to be created via a new attribute name."
+                        "A new attribute is created. It will not be carried over when the object is copied."
+                        " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"
+                    ),
+                    UserWarning,
+                    stacklevel=2,
+                )
             super().__setattr__(name, value, **kwargs)
 
     def _base_repr_(self, html=False, descr_vals=None, **kwargs):
@@ -318,10 +370,10 @@ class LightCurve(QTimeSeries):
         if descr_vals is None:
             descr_vals = [self.__class__.__name__]
             if self.masked:
-                descr_vals.append('masked=True')
+                descr_vals.append("masked=True")
             if hasattr(self, "targetid"):
-                descr_vals.append(f'targetid={self.targetid}')
-            descr_vals.append('length={}'.format(len(self)))
+                descr_vals.append(f"targetid={self.targetid}")
+            descr_vals.append("length={}".format(len(self)))
         return super()._base_repr_(html=html, descr_vals=descr_vals, **kwargs)
 
     # Define `time`, `flux`, `flux_err` as class attributes to enable IDE
@@ -330,65 +382,69 @@ class LightCurve(QTimeSeries):
     @property
     def time(self) -> Time:
         """Time values stored as an AstroPy `~astropy.time.Time` object."""
-        return self['time']
+        return self["time"]
 
     @time.setter
     def time(self, time):
-        self['time'] = time
+        self["time"] = time
 
     @property
     def flux(self) -> Quantity:
         """Brightness values stored as an AstroPy `~astropy.units.Quantity` object."""
-        return self['flux']
+        return self["flux"]
 
     @flux.setter
     def flux(self, flux):
-        self['flux'] = flux
+        self["flux"] = flux
 
     @property
     def flux_err(self) -> Quantity:
         """Brightness uncertainties stored as an AstroPy `~astropy.units.Quantity` object."""
-        return self['flux_err']
+        return self["flux_err"]
 
     @flux_err.setter
     def flux_err(self, flux_err):
-        self['flux_err'] = flux_err
+        self["flux_err"] = flux_err
 
     # Define deprecated attributes for compatibility with Lightkurve v1.x:
 
     @property
-    @deprecated("2.0", alternative="time.format",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated(
+        "2.0", alternative="time.format", warning_type=LightkurveDeprecationWarning
+    )
     def time_format(self):
         return self.time.format
 
     @property
-    @deprecated("2.0", alternative="time.scale",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated(
+        "2.0", alternative="time.scale", warning_type=LightkurveDeprecationWarning
+    )
     def time_scale(self):
         return self.time.scale
 
     @property
-    @deprecated("2.0", alternative="time",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated("2.0", alternative="time", warning_type=LightkurveDeprecationWarning)
     def astropy_time(self):
         return self.time
 
     @property
-    @deprecated("2.0", alternative="flux.unit",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated(
+        "2.0", alternative="flux.unit", warning_type=LightkurveDeprecationWarning
+    )
     def flux_unit(self):
         return self.flux.unit
 
     @property
-    @deprecated("2.0", alternative="flux",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated("2.0", alternative="flux", warning_type=LightkurveDeprecationWarning)
     def flux_quantity(self):
         return self.flux
 
     @property
-    @deprecated("2.0", alternative="fits.open(lc.filename)",
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated(
+        "2.0",
+        alternative="fits.open(lc.filename)",
+        warning_type=LightkurveDeprecationWarning,
+    )
     def hdu(self):
         return fits.open(self.filename)
 
@@ -399,8 +455,8 @@ class LightCurve(QTimeSeries):
         and `lc.flux_err = lc.sap_flux_err`.  It is provided for backwards-
         compatibility with Lightkurve v1.x and will be removed soon."""
         lc = self.copy()
-        lc['flux'] = lc['sap_flux']
-        lc['flux_err'] = lc['sap_flux_err']
+        lc["flux"] = lc["sap_flux"]
+        lc["flux_err"] = lc["sap_flux_err"]
         return lc
 
     @property
@@ -410,21 +466,25 @@ class LightCurve(QTimeSeries):
         and `lc.flux_err = lc.pdcsap_flux_err`.  It is provided for backwards-
         compatibility with Lightkurve v1.x and will be removed soon."""
         lc = self.copy()
-        lc['flux'] = lc['pdcsap_flux']
-        lc['flux_err'] = lc['pdcsap_flux_err']
+        lc["flux"] = lc["pdcsap_flux"]
+        lc["flux_err"] = lc["pdcsap_flux_err"]
         return lc
 
     def __add__(self, other):
         newlc = self.copy()
         if isinstance(other, LightCurve):
             if len(self) != len(other):
-                raise ValueError("Cannot add LightCurve objects because "
-                                 "they do not have equal length ({} vs {})."
-                                 "".format(len(self), len(other)))
+                raise ValueError(
+                    "Cannot add LightCurve objects because "
+                    "they do not have equal length ({} vs {})."
+                    "".format(len(self), len(other))
+                )
             if np.any(self.time != other.time):
-                warnings.warn("Two LightCurve objects with inconsistent time "
-                              "values are being added.",
-                              LightkurveWarning)
+                warnings.warn(
+                    "Two LightCurve objects with inconsistent time "
+                    "values are being added.",
+                    LightkurveWarning,
+                )
             newlc.flux = self.flux + other.flux
             newlc.flux_err = np.hypot(self.flux_err, other.flux_err)
         else:
@@ -444,18 +504,26 @@ class LightCurve(QTimeSeries):
         newlc = self.copy()
         if isinstance(other, LightCurve):
             if len(self) != len(other):
-                raise ValueError("Cannot multiply LightCurve objects because "
-                                 "they do not have equal length ({} vs {})."
-                                 "".format(len(self), len(other)))
+                raise ValueError(
+                    "Cannot multiply LightCurve objects because "
+                    "they do not have equal length ({} vs {})."
+                    "".format(len(self), len(other))
+                )
             if np.any(self.time != other.time):
-                warnings.warn("Two LightCurve objects with inconsistent time "
-                              "values are being multiplied.",
-                              LightkurveWarning)
+                warnings.warn(
+                    "Two LightCurve objects with inconsistent time "
+                    "values are being multiplied.",
+                    LightkurveWarning,
+                )
             newlc.flux = self.flux * other.flux
             # Applying standard uncertainty propagation, cf.
             # https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae
-            newlc.flux_err = abs(newlc.flux) * np.hypot(self.flux_err / self.flux, other.flux_err / other.flux)
-        elif isinstance(other, (u.UnitBase, u.FunctionUnitBase)):  # cf. astropy/issues/6517
+            newlc.flux_err = abs(newlc.flux) * np.hypot(
+                self.flux_err / self.flux, other.flux_err / other.flux
+            )
+        elif isinstance(
+            other, (u.UnitBase, u.FunctionUnitBase)
+        ):  # cf. astropy/issues/6517
             newlc.flux = other * self.flux
             newlc.flux_err = other * self.flux_err
         else:
@@ -467,24 +535,30 @@ class LightCurve(QTimeSeries):
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        return self.__mul__(1. / other)
+        return self.__mul__(1.0 / other)
 
     def __rtruediv__(self, other):
         newlc = self.copy()
         if isinstance(other, LightCurve):
             if len(self) != len(other):
-                raise ValueError("Cannot divide LightCurve objects because "
-                                 "they do not have equal length ({} vs {})."
-                                 "".format(len(self), len(other)))
+                raise ValueError(
+                    "Cannot divide LightCurve objects because "
+                    "they do not have equal length ({} vs {})."
+                    "".format(len(self), len(other))
+                )
             if np.any(self.time != other.time):
-                warnings.warn("Two LightCurve objects with inconsistent time "
-                              "values are being divided.",
-                              LightkurveWarning)
+                warnings.warn(
+                    "Two LightCurve objects with inconsistent time "
+                    "values are being divided.",
+                    LightkurveWarning,
+                )
             newlc.flux = other.flux / self.flux
-            newlc.flux_err = abs(newlc.flux) * np.hypot(self.flux_err / self.flux, other.flux_err / other.flux)
+            newlc.flux_err = abs(newlc.flux) * np.hypot(
+                self.flux_err / self.flux, other.flux_err / other.flux
+            )
         else:
             newlc.flux = other / self.flux
-            newlc.flux_err = abs((other * self.flux_err) / (self.flux**2))
+            newlc.flux_err = abs((other * self.flux_err) / (self.flux ** 2))
         return newlc
 
     def __div__(self, other):
@@ -500,45 +574,50 @@ class LightCurve(QTimeSeries):
         """
         attrs = {}
         deprecated_properties = list(self._deprecated_keywords)
-        deprecated_properties += ['flux_quantity', 'SAP_FLUX', 'PDCSAP_FLUX',
-                                  'astropy_time', 'hdu']
+        deprecated_properties += [
+            "flux_quantity",
+            "SAP_FLUX",
+            "PDCSAP_FLUX",
+            "astropy_time",
+            "hdu",
+        ]
         for attr in dir(self):
-            if not attr.startswith('_') and attr not in deprecated_properties:
+            if not attr.startswith("_") and attr not in deprecated_properties:
                 try:
                     res = getattr(self, attr)
                 except Exception:
                     continue
                 if callable(res):
                     continue
-                attrs[attr] = {'res': res}
+                attrs[attr] = {"res": res}
                 if isinstance(res, int):
-                    attrs[attr]['print'] = '{}'.format(res)
-                    attrs[attr]['type'] = 'int'
+                    attrs[attr]["print"] = "{}".format(res)
+                    attrs[attr]["type"] = "int"
                 elif isinstance(res, np.ndarray):
-                    attrs[attr]['print'] = 'array {}'.format(res.shape)
-                    attrs[attr]['type'] = 'array'
+                    attrs[attr]["print"] = "array {}".format(res.shape)
+                    attrs[attr]["type"] = "array"
                 elif isinstance(res, list):
-                    attrs[attr]['print'] = 'list length {}'.format(len(res))
-                    attrs[attr]['type'] = 'list'
+                    attrs[attr]["print"] = "list length {}".format(len(res))
+                    attrs[attr]["type"] = "list"
                 elif isinstance(res, str):
-                    if res == '':
-                        attrs[attr]['print'] = '{}'.format('None')
+                    if res == "":
+                        attrs[attr]["print"] = "{}".format("None")
                     else:
-                        attrs[attr]['print'] = '{}'.format(res)
-                    attrs[attr]['type'] = 'str'
-                elif attr == 'wcs':
-                    attrs[attr]['print'] = 'astropy.wcs.wcs.WCS'
-                    attrs[attr]['type'] = 'other'
+                        attrs[attr]["print"] = "{}".format(res)
+                    attrs[attr]["type"] = "str"
+                elif attr == "wcs":
+                    attrs[attr]["print"] = "astropy.wcs.wcs.WCS"
+                    attrs[attr]["type"] = "other"
                 else:
-                    attrs[attr]['print'] = '{}'.format(type(res))
-                    attrs[attr]['type'] = 'other'
-        output = Table(names=['Attribute', 'Description'], dtype=[object, object])
+                    attrs[attr]["print"] = "{}".format(type(res))
+                    attrs[attr]["type"] = "other"
+        output = Table(names=["Attribute", "Description"], dtype=[object, object])
         idx = 0
-        types = ['int', 'str', 'list', 'array', 'other']
+        types = ["int", "str", "list", "array", "other"]
         for typ in types:
             for attr, dic in attrs.items():
-                if dic['type'] == typ:
-                    output.add_row([attr, dic['print']])
+                if dic["type"] == typ:
+                    output.add_row([attr, dic["print"]])
                     idx += 1
         output.pprint(max_lines=-1, max_width=-1)
 
@@ -559,15 +638,26 @@ class LightCurve(QTimeSeries):
             Light curve which has the other light curves appened to it.
         """
         if inplace:
-            raise ValueError("the `inplace` parameter is no longer supported "
-                             "as of Lightkurve v2.0")
-        if not hasattr(others, '__iter__'):
+            raise ValueError(
+                "the `inplace` parameter is no longer supported "
+                "as of Lightkurve v2.0"
+            )
+        if not hasattr(others, "__iter__"):
             others = (others,)
         # Need `join_type='inner'` until AstroPy supports masked Quantities
-        return vstack((self, *others), join_type='inner', metadata_conflicts='silent')
+        return vstack((self, *others), join_type="inner", metadata_conflicts="silent")
 
-    def flatten(self, window_length=101, polyorder=2, return_trend=False,
-                break_tolerance=5, niters=3, sigma=3, mask=None, **kwargs):
+    def flatten(
+        self,
+        window_length=101,
+        polyorder=2,
+        return_trend=False,
+        break_tolerance=5,
+        niters=3,
+        sigma=3,
+        mask=None,
+        **kwargs,
+    ):
         """Removes the low frequency trend using scipy's Savitzky-Golay filter.
 
         This method wraps `scipy.signal.savgol_filter`.
@@ -618,14 +708,18 @@ class LightCurve(QTimeSeries):
         # No NaNs
         mask &= np.isfinite(self.flux)
         # No outliers
-        mask &= np.nan_to_num(np.abs(self.flux - np.nanmedian(self.flux))) <= (np.nanstd(self.flux) * sigma)
+        mask &= np.nan_to_num(np.abs(self.flux - np.nanmedian(self.flux))) <= (
+            np.nanstd(self.flux) * sigma
+        )
         for iter in np.arange(0, niters):
             if break_tolerance is None:
                 break_tolerance = np.nan
             if polyorder >= window_length:
                 polyorder = window_length - 1
-                log.warning("polyorder must be smaller than window_length, "
-                            "using polyorder={}.".format(polyorder))
+                log.warning(
+                    "polyorder must be smaller than window_length, "
+                    "using polyorder={}.".format(polyorder)
+                )
             # Split the lightcurve into segments by finding large gaps in time
             dt = self.time.value[mask][1:] - self.time.value[mask][0:-1]
             with warnings.catch_warnings():  # Ignore warnings due to NaNs
@@ -644,17 +738,25 @@ class LightCurve(QTimeSeries):
                 else:
                     # Scipy outputs a warning here that is not useful, will be fixed in version 1.2
                     with warnings.catch_warnings():
-                        warnings.simplefilter('ignore', FutureWarning)
-                        trsig = savgol_filter(x=self.flux.value[mask][l:h],
-                                              window_length=window_length,
-                                              polyorder=polyorder,
-                                              **kwargs)
+                        warnings.simplefilter("ignore", FutureWarning)
+                        trsig = savgol_filter(
+                            x=self.flux.value[mask][l:h],
+                            window_length=window_length,
+                            polyorder=polyorder,
+                            **kwargs,
+                        )
                         trend_signal[l:h] = Quantity(trsig, trend_signal.unit)
             # Ignore outliers; note we add `1e-14` below to avoid detecting
             # outliers which are merely caused by numerical noise.
-            mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) <\
-                    (np.nanstd(self.flux[mask] - trend_signal) * sigma + Quantity(1e-14, self.flux.unit))
-            f = interp1d(self.time.value[mask][mask1], trend_signal[mask1], fill_value='extrapolate')
+            mask1 = np.nan_to_num(np.abs(self.flux[mask] - trend_signal)) < (
+                np.nanstd(self.flux[mask] - trend_signal) * sigma
+                + Quantity(1e-14, self.flux.unit)
+            )
+            f = interp1d(
+                self.time.value[mask][mask1],
+                trend_signal[mask1],
+                fill_value="extrapolate",
+            )
             trend_signal = Quantity(f(self.time.value), self.flux.unit)
             mask[mask] &= mask1
 
@@ -670,12 +772,23 @@ class LightCurve(QTimeSeries):
             return flatten_lc, trend_lc
         return flatten_lc
 
-    @deprecated_renamed_argument('transit_midpoint', 'epoch_time', '2.0',
-                                 warning_type=LightkurveDeprecationWarning)
-    @deprecated_renamed_argument('t0', 'epoch_time', '2.0',
-                                 warning_type=LightkurveDeprecationWarning)
-    def fold(self, period=None, epoch_time=None, epoch_phase=0,
-             wrap_phase=None, normalize_phase=False):
+    @deprecated_renamed_argument(
+        "transit_midpoint",
+        "epoch_time",
+        "2.0",
+        warning_type=LightkurveDeprecationWarning,
+    )
+    @deprecated_renamed_argument(
+        "t0", "epoch_time", "2.0", warning_type=LightkurveDeprecationWarning
+    )
+    def fold(
+        self,
+        period=None,
+        epoch_time=None,
+        epoch_phase=0,
+        wrap_phase=None,
+        normalize_phase=False,
+    ):
         """Returns a `FoldedLightCurve` object folded on a period and epoch.
 
         This method is identical to AstroPy's `~astropy.timeseries.TimeSeries.fold()`
@@ -719,26 +832,42 @@ class LightCurve(QTimeSeries):
         if period is not None and not isinstance(period, Quantity):
             period *= u.day
         if epoch_time is not None and not isinstance(epoch_time, Time):
-            epoch_time = Time(epoch_time, format=self.time.format, scale=self.time.scale)
-        if epoch_phase is not None and not isinstance(epoch_phase, Quantity) and not normalize_phase:
+            epoch_time = Time(
+                epoch_time, format=self.time.format, scale=self.time.scale
+            )
+        if (
+            epoch_phase is not None
+            and not isinstance(epoch_phase, Quantity)
+            and not normalize_phase
+        ):
             epoch_phase *= u.day
         if wrap_phase is not None and not isinstance(wrap_phase, Quantity):
             wrap_phase *= u.day
 
         # Warn if `epoch_time` appears to use the wrong format
         if epoch_time is not None and epoch_time.value > 2450000:
-            if self.time.format == 'bkjd':
-                warnings.warn('`epoch_time` appears to be given in JD, '
-                              'however the light curve time uses BKJD '
-                              '(i.e. JD - 2454833).', LightkurveWarning)
-            elif self.time.format == 'btjd':
-                warnings.warn('`epoch_time` appears to be given in JD, '
-                              'however the light curve time uses BTJD '
-                              '(i.e. JD - 2457000).', LightkurveWarning)
+            if self.time.format == "bkjd":
+                warnings.warn(
+                    "`epoch_time` appears to be given in JD, "
+                    "however the light curve time uses BKJD "
+                    "(i.e. JD - 2454833).",
+                    LightkurveWarning,
+                )
+            elif self.time.format == "btjd":
+                warnings.warn(
+                    "`epoch_time` appears to be given in JD, "
+                    "however the light curve time uses BTJD "
+                    "(i.e. JD - 2457000).",
+                    LightkurveWarning,
+                )
 
-        ts = super().fold(period=period, epoch_time=epoch_time,
-                          epoch_phase=epoch_phase, wrap_phase=wrap_phase,
-                          normalize_phase=normalize_phase)
+        ts = super().fold(
+            period=period,
+            epoch_time=epoch_time,
+            epoch_phase=epoch_phase,
+            wrap_phase=wrap_phase,
+            normalize_phase=normalize_phase,
+        )
 
         # The folded time would pass the `TimeSeries` validation check if
         # `normalize_phase=True`, so creating a `FoldedLightCurve` object
@@ -746,27 +875,29 @@ class LightCurve(QTimeSeries):
         # 1. Give the folded light curve a valid time column again
         with ts._delay_required_column_checks():
             folded_time = ts.time.copy()
-            ts.remove_column('time')
-            ts.add_column(self.time, name='time', index=0)
+            ts.remove_column("time")
+            ts.add_column(self.time, name="time", index=0)
         # 2. Create the folded object
         lc = FoldedLightCurve(data=ts)
         # 3. Restore the folded time
         with lc._delay_required_column_checks():
-            lc.remove_column('time')
-            lc.add_column(folded_time, name='time', index=0)
+            lc.remove_column("time")
+            lc.add_column(folded_time, name="time", index=0)
 
         # Add extra column and meta data specific to FoldedLightCurve
-        lc.add_column(self.time.copy(), name="time_original", index=len(self._required_columns))
-        lc.meta['PERIOD'] = period
-        lc.meta['EPOCH_TIME'] = epoch_time
-        lc.meta['EPOCH_PHASE'] = epoch_phase
-        lc.meta['WRAP_PHASE'] = wrap_phase
-        lc.meta['NORMALIZE_PHASE'] = normalize_phase
-        lc.sort('time')
+        lc.add_column(
+            self.time.copy(), name="time_original", index=len(self._required_columns)
+        )
+        lc.meta["PERIOD"] = period
+        lc.meta["EPOCH_TIME"] = epoch_time
+        lc.meta["EPOCH_PHASE"] = epoch_phase
+        lc.meta["WRAP_PHASE"] = wrap_phase
+        lc.meta["NORMALIZE_PHASE"] = normalize_phase
+        lc.sort("time")
 
         return lc
 
-    def normalize(self, unit='unscaled'):
+    def normalize(self, unit="unscaled"):
         """Returns a normalized version of the light curve.
 
         The normalized light curve is obtained by dividing the ``flux`` and
@@ -802,34 +933,42 @@ class LightCurve(QTimeSeries):
             If the median flux is negative or within half a standard deviation
             from zero.
         """
-        validate_method(unit, ['unscaled', 'percent', 'ppt', 'ppm'])
+        validate_method(unit, ["unscaled", "percent", "ppt", "ppm"])
         median_flux = np.nanmedian(self.flux)
         std_flux = np.nanstd(self.flux)
 
         # If the median flux is within half a standard deviation from zero, the
         # light curve is likely zero-centered and normalization makes no sense.
-        if (median_flux == 0) or (np.isfinite(std_flux) and (np.abs(median_flux) < 0.5*std_flux)):
-            warnings.warn("The light curve appears to be zero-centered "
-                          "(median={:.2e} +/- {:.2e}); `normalize()` will divide "
-                          "the light curve by a value close to zero, which is "
-                          "probably not what you want."
-                          "".format(median_flux, std_flux),
-                          LightkurveWarning)
+        if (median_flux == 0) or (
+            np.isfinite(std_flux) and (np.abs(median_flux) < 0.5 * std_flux)
+        ):
+            warnings.warn(
+                "The light curve appears to be zero-centered "
+                "(median={:.2e} +/- {:.2e}); `normalize()` will divide "
+                "the light curve by a value close to zero, which is "
+                "probably not what you want."
+                "".format(median_flux, std_flux),
+                LightkurveWarning,
+            )
         # If the median flux is negative, normalization will invert the light
         # curve and makes no sense.
         if median_flux < 0:
-            warnings.warn("The light curve has a negative median flux ({:.2e});"
-                          " `normalize()` will therefore divide by a negative "
-                          "number and invert the light curve, which is probably"
-                          "not what you want".format(median_flux),
-                          LightkurveWarning)
+            warnings.warn(
+                "The light curve has a negative median flux ({:.2e});"
+                " `normalize()` will therefore divide by a negative "
+                "number and invert the light curve, which is probably"
+                "not what you want".format(median_flux),
+                LightkurveWarning,
+            )
         # Warn if the light curve was already normalized before
-        if self.meta.get('NORMALIZED'):
-            warnings.warn("The light curve already appears to be in relative "
-                          "units; `normalize()` will convert the light curve "
-                          "into relative units for a second time, which is "
-                          "probably not what you want.".format(self.flux.unit),
-                          LightkurveWarning)
+        if self.meta.get("NORMALIZED"):
+            warnings.warn(
+                "The light curve already appears to be in relative "
+                "units; `normalize()` will convert the light curve "
+                "into relative units for a second time, which is "
+                "probably not what you want.".format(self.flux.unit),
+                LightkurveWarning,
+            )
 
         # Create a new light curve instance and normalize its values
         lc = self.copy()
@@ -841,21 +980,22 @@ class LightCurve(QTimeSeries):
             lc.flux_err *= u.dimensionless_unscaled
 
         # Set the desired relative (dimensionless) units
-        if unit == 'percent':
+        if unit == "percent":
             lc.flux = lc.flux.to(u.percent)
             lc.flux_err = lc.flux_err.to(u.percent)
-        elif unit == 'ppt':  # parts per thousand
+        elif unit == "ppt":  # parts per thousand
             # ppt is not included in astropy, so we define it here
-            ppt = u.def_unit(['ppt', 'parts per thousand'], u.Unit(1e-3))
+            ppt = u.def_unit(["ppt", "parts per thousand"], u.Unit(1e-3))
             lc.flux = lc.flux.to(ppt)
-        elif unit == 'ppm':  # parts per million
+        elif unit == "ppm":  # parts per million
             from astropy.units import cds
+
             lc.flux = lc.flux.to(cds.ppm)
 
-        lc.meta['NORMALIZED'] = True
+        lc.meta["NORMALIZED"] = True
         return lc
 
-    def remove_nans(self, column: str = 'flux'):
+    def remove_nans(self, column: str = "flux"):
         """Removes cadences where ``column`` is a NaN.
 
         Parameters
@@ -884,7 +1024,7 @@ class LightCurve(QTimeSeries):
         """
         return self[~np.isnan(self[column])]  # This will return a sliced copy
 
-    def fill_gaps(self, method: str = 'gaussian_noise'):
+    def fill_gaps(self, method: str = "gaussian_noise"):
         """Fill in gaps in time.
 
         By default, the gaps will be filled with random white Gaussian noise
@@ -904,12 +1044,12 @@ class LightCurve(QTimeSeries):
             have been filled.
         """
         lc = self.copy().remove_nans()
-        #nlc = lc.copy()
+        # nlc = lc.copy()
         newdata = {}
 
         # Find missing time points
         # Most precise method, taking into account time variation due to orbit
-        if hasattr(lc, 'cadenceno'):
+        if hasattr(lc, "cadenceno"):
             dt = lc.time.value - np.median(np.diff(lc.time.value)) * lc.cadenceno.value
             ncad = np.arange(lc.cadenceno.value[0], lc.cadenceno.value[-1] + 1, 1)
             in_original = np.in1d(ncad, lc.cadenceno.value)
@@ -920,14 +1060,14 @@ class LightCurve(QTimeSeries):
             ndt = np.append(ndt, dt)
             ncad, ndt = ncad[np.argsort(ncad)], ndt[np.argsort(ncad)]
             ntime = ndt + np.median(np.diff(lc.time.value)) * ncad
-            newdata['cadenceno'] = ncad
+            newdata["cadenceno"] = ncad
         else:
             # Less precise method
             dt = np.nanmedian(lc.time.value[1::] - lc.time.value[:-1:])
             ntime = [lc.time.value[0]]
             for t in lc.time.value[1::]:
                 prevtime = ntime[-1]
-                while (t - prevtime) > 1.2*dt:
+                while (t - prevtime) > 1.2 * dt:
                     ntime.append(prevtime + dt)
                     prevtime = ntime[-1]
                 ntime.append(t)
@@ -935,30 +1075,32 @@ class LightCurve(QTimeSeries):
             in_original = np.in1d(ntime, lc.time.value)
 
         # Fill in time points
-        newdata['time'] = Time(ntime, format=lc.time.format, scale=lc.time.scale)
+        newdata["time"] = Time(ntime, format=lc.time.format, scale=lc.time.scale)
         f = np.zeros(len(ntime))
         f[in_original] = np.copy(lc.flux)
         fe = np.zeros(len(ntime))
         fe[in_original] = np.copy(lc.flux_err)
 
         fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
-        if method == 'gaussian_noise':
+        if method == "gaussian_noise":
             try:
                 std = lc.estimate_cdpp().to(lc.flux.unit).value
             except:
                 std = np.nanstd(lc.flux.value)
-            f[~in_original] = np.random.normal(np.nanmean(lc.flux.value), std, (~in_original).sum())
+            f[~in_original] = np.random.normal(
+                np.nanmean(lc.flux.value), std, (~in_original).sum()
+            )
         else:
             raise NotImplementedError("No such method as {}".format(method))
 
-        newdata['flux'] = Quantity(f, lc.flux.unit)
-        newdata['flux_err'] = Quantity(fe, lc.flux_err.unit)
+        newdata["flux"] = Quantity(f, lc.flux.unit)
+        newdata["flux_err"] = Quantity(fe, lc.flux_err.unit)
 
-        if hasattr(lc, 'quality'):
+        if hasattr(lc, "quality"):
             quality = np.zeros(len(ntime), dtype=lc.quality.dtype)
             quality[in_original] = np.copy(lc.quality)
             quality[~in_original] += 65536
-            newdata['quality'] = quality
+            newdata["quality"] = quality
         """
         # TODO: add support for other columns
         for column in lc.columns:
@@ -972,8 +1114,9 @@ class LightCurve(QTimeSeries):
         """
         return LightCurve(data=newdata, meta=self.meta)
 
-    def remove_outliers(self, sigma=5., sigma_lower=None, sigma_upper=None,
-                        return_mask=False, **kwargs):
+    def remove_outliers(
+        self, sigma=5.0, sigma_lower=None, sigma_upper=None, return_mask=False, **kwargs
+    ):
         """Removes outlier data points using sigma-clipping.
 
         This method returns a new `LightCurve` object from which data points
@@ -1061,21 +1204,33 @@ class LightCurve(QTimeSeries):
         # First, we create the outlier mask using AstroPy's sigma_clip function
         with warnings.catch_warnings():  # Ignore warnings due to NaNs or Infs
             warnings.simplefilter("ignore")
-            outlier_mask = sigma_clip(data=self.flux,
-                                      sigma=sigma,
-                                      sigma_lower=sigma_lower,
-                                      sigma_upper=sigma_upper,
-                                      **kwargs).mask
+            outlier_mask = sigma_clip(
+                data=self.flux,
+                sigma=sigma,
+                sigma_lower=sigma_lower,
+                sigma_upper=sigma_upper,
+                **kwargs,
+            ).mask
         # Second, we return the masked light curve and optionally the mask itself
         if return_mask:
             return self.copy()[~outlier_mask], outlier_mask
         return self.copy()[~outlier_mask]
 
-    @deprecated_renamed_argument('binsize', new_name=None, since='2.0',
-                                 warning_type=LightkurveDeprecationWarning,
-                                 alternative='time_bin_size')
-    def bin(self, time_bin_size=None, time_bin_start=None, n_bins=None,
-            aggregate_func=None, binsize=None):
+    @deprecated_renamed_argument(
+        "binsize",
+        new_name=None,
+        since="2.0",
+        warning_type=LightkurveDeprecationWarning,
+        alternative="time_bin_size",
+    )
+    def bin(
+        self,
+        time_bin_size=None,
+        time_bin_start=None,
+        n_bins=None,
+        aggregate_func=None,
+        binsize=None,
+    ):
         """Bins a lightcurve in equally-spaced bins in time.
 
         If the original light curve contains flux uncertainties (``flux_err``),
@@ -1118,47 +1273,57 @@ class LightCurve(QTimeSeries):
             time_bin_size = (self.time[binsize] - self.time[0]).to(u.day)
 
         if time_bin_size is None:
-            time_bin_size = 0.5*u.day
+            time_bin_size = 0.5 * u.day
         if not isinstance(time_bin_size, Quantity):
             time_bin_size *= u.day
         if time_bin_start is None:
             time_bin_start = self.time[0]
         if not isinstance(time_bin_start, Time):
-            time_bin_start = Time(time_bin_start, format=self.time.format,
-                                  scale=self.time.scale)
+            time_bin_start = Time(
+                time_bin_start, format=self.time.format, scale=self.time.scale
+            )
 
         # Call AstroPy's aggregate_downsample
         with warnings.catch_warnings():
             # ignore uninteresting empty slice warnings
             warnings.simplefilter("ignore", (RuntimeWarning, AstropyUserWarning))
-            ts = aggregate_downsample(self,
-                                      time_bin_size=time_bin_size,
-                                      n_bins=n_bins,
-                                      time_bin_start=time_bin_start,
-                                      aggregate_func=aggregate_func)
+            ts = aggregate_downsample(
+                self,
+                time_bin_size=time_bin_size,
+                n_bins=n_bins,
+                time_bin_start=time_bin_start,
+                aggregate_func=aggregate_func,
+            )
 
             # If `flux_err` is populated, assume the errors combine as the root-mean-square
             if np.any(np.isfinite(self.flux_err)):
-                rmse_func = lambda x: np.sqrt(np.nansum(x**2))/len(np.atleast_1d(x)) \
-                                    if np.any(np.isfinite(x)) else np.nan
-                ts_err = aggregate_downsample(self,
-                                              time_bin_size=time_bin_size,
-                                              n_bins=n_bins,
-                                              time_bin_start=time_bin_start,
-                                              aggregate_func=rmse_func)
-                ts['flux_err'] = ts_err['flux_err']
+                rmse_func = (
+                    lambda x: np.sqrt(np.nansum(x ** 2)) / len(np.atleast_1d(x))
+                    if np.any(np.isfinite(x))
+                    else np.nan
+                )
+                ts_err = aggregate_downsample(
+                    self,
+                    time_bin_size=time_bin_size,
+                    n_bins=n_bins,
+                    time_bin_start=time_bin_start,
+                    aggregate_func=rmse_func,
+                )
+                ts["flux_err"] = ts_err["flux_err"]
             # If `flux_err` is unavailable, populate `flux_err` as nanstd(flux)
             else:
-                ts_err = aggregate_downsample(self,
-                                              time_bin_size=time_bin_size,
-                                              n_bins=n_bins,
-                                              time_bin_start=time_bin_start,
-                                              aggregate_func=np.nanstd)
-                ts['flux_err'] = ts_err['flux']
+                ts_err = aggregate_downsample(
+                    self,
+                    time_bin_size=time_bin_size,
+                    n_bins=n_bins,
+                    time_bin_start=time_bin_start,
+                    aggregate_func=np.nanstd,
+                )
+                ts["flux_err"] = ts_err["flux"]
 
         # Prepare a LightCurve object by ensuring there is a time column
         ts._required_columns = []
-        ts.add_column(ts.time_bin_start + ts.time_bin_size / 2., name="time")
+        ts.add_column(ts.time_bin_start + ts.time_bin_size / 2.0, name="time")
 
         # Ensure the required columns appear in the correct order
         for idx, colname in enumerate(self.__class__._required_columns):
@@ -1168,8 +1333,9 @@ class LightCurve(QTimeSeries):
 
         return self.__class__(ts)
 
-    def estimate_cdpp(self, transit_duration=13, savgol_window=101,
-                      savgol_polyorder=2, sigma=5.) -> float:
+    def estimate_cdpp(
+        self, transit_duration=13, savgol_window=101, savgol_polyorder=2, sigma=5.0
+    ) -> float:
         """Estimate the CDPP noise metric using the Savitzky-Golay (SG) method.
 
         A common estimate of the noise in a lightcurve is the scatter that
@@ -1223,11 +1389,14 @@ class LightCurve(QTimeSeries):
         svn+ssh://murzim/repo/so/trunk/Develop/jvc/common/compute_SG_noise.m
         """
         if not isinstance(transit_duration, int):
-            raise ValueError("transit_duration must be an integer in units "
-                             "number of cadences, got {}.".format(transit_duration))
+            raise ValueError(
+                "transit_duration must be an integer in units "
+                "number of cadences, got {}.".format(transit_duration)
+            )
 
-        detrended_lc = self.flatten(window_length=savgol_window,
-                                    polyorder=savgol_polyorder)
+        detrended_lc = self.flatten(
+            window_length=savgol_window, polyorder=savgol_polyorder
+        )
         cleaned_lc = detrended_lc.remove_outliers(sigma=sigma)
         with warnings.catch_warnings():  # ignore "already normalized" message
             warnings.filterwarnings("ignore", message=".*already.*")
@@ -1235,8 +1404,15 @@ class LightCurve(QTimeSeries):
         mean = running_mean(data=normalized_lc.flux, window_size=transit_duration)
         return np.std(mean)
 
-    def query_solar_system_objects(self, cadence_mask='outliers', radius=None,
-                                   sigma=3, location=None, cache=True, return_mask=False):
+    def query_solar_system_objects(
+        self,
+        cadence_mask="outliers",
+        radius=None,
+        sigma=3,
+        location=None,
+        cache=True,
+        return_mask=False,
+    ):
         """Returns a list of asteroids or comets which affected the light curve.
 
         Light curves of stars or galaxies are frequently affected by solar
@@ -1305,58 +1481,75 @@ class LightCurve(QTimeSeries):
             >>> df_sso = lc.query_solar_system_objects(cadence_mask='all')  # doctest: +SKIP
 
         """
-        for attr in ['ra', 'dec']:
-            if not hasattr(self, '{}'.format(attr)):
-                raise ValueError('Input does not have a `{}` attribute.'.format(attr))
+        for attr in ["ra", "dec"]:
+            if not hasattr(self, "{}".format(attr)):
+                raise ValueError("Input does not have a `{}` attribute.".format(attr))
 
         # Validate `cadence_mask`
         if isinstance(cadence_mask, str):
-            if cadence_mask == 'outliers':
+            if cadence_mask == "outliers":
                 cadence_mask = self.remove_outliers(sigma=sigma, return_mask=True)[1]
-            elif cadence_mask == 'all':
+            elif cadence_mask == "all":
                 cadence_mask = np.ones(len(self.time)).astype(bool)
             else:
-                raise ValueError('invalid `cadence_mask` string argument')
+                raise ValueError("invalid `cadence_mask` string argument")
         elif isinstance(cadence_mask, collections.abc.Sequence):
             cadence_mask = np.array(cadence_mask)
         elif isinstance(cadence_mask, (bool)):
             # for boundary case of a single element tuple, e.g., (True)
             cadence_mask = np.array([cadence_mask])
         elif not isinstance(cadence_mask, np.ndarray):
-            raise ValueError('the `cadence_mask` argument is missing or invalid')
+            raise ValueError("the `cadence_mask` argument is missing or invalid")
         # Avoid searching times with NaN flux; this is necessary because e.g.
         # `remove_outliers` includes NaNs in its mask.
         cadence_mask &= ~np.isnan(self.flux)
 
         # Validate `location`
         if location is None:
-            if hasattr(self, 'mission') and self.mission:
+            if hasattr(self, "mission") and self.mission:
                 location = self.mission.lower()
             else:
-                raise ValueError('you must pass a value for `location`.')
+                raise ValueError("you must pass a value for `location`.")
 
         # Validate `radius`
         if radius is None:
             # 15 pixels has been chosen as a reasonable default.
             # Comets have long tails which have tripped up users.
-            if (location == 'kepler') | (location == 'k2'):
-                radius = (4*15)*u.arcsecond.to(u.deg)
-            elif location == 'tess':
-                radius = (27*15)*u.arcsecond.to(u.deg)
+            if (location == "kepler") | (location == "k2"):
+                radius = (4 * 15) * u.arcsecond.to(u.deg)
+            elif location == "tess":
+                radius = (27 * 15) * u.arcsecond.to(u.deg)
             else:
-                radius = 15*u.arcsecond.to(u.deg)
+                radius = 15 * u.arcsecond.to(u.deg)
 
-        res = _query_solar_system_objects(ra=self.ra, dec=self.dec,
-                                          times=self.time.jd[cadence_mask],
-                                          location=location, radius=radius, cache=cache)
+        res = _query_solar_system_objects(
+            ra=self.ra,
+            dec=self.dec,
+            times=self.time.jd[cadence_mask],
+            location=location,
+            radius=radius,
+            cache=cache,
+        )
         if return_mask:
             return res, np.in1d(self.time.jd, res.epoch)
         return res
 
-    def _create_plot(self, method='plot', column='flux', ax=None, normalize=False,
-                     xlabel=None, ylabel=None, title='', style='lightkurve',
-                     show_colorbar=True, colorbar_label='', offset=None,
-                     clip_outliers=False, **kwargs) -> matplotlib.axes.Axes:
+    def _create_plot(
+        self,
+        method="plot",
+        column="flux",
+        ax=None,
+        normalize=False,
+        xlabel=None,
+        ylabel=None,
+        title="",
+        style="lightkurve",
+        show_colorbar=True,
+        colorbar_label="",
+        offset=None,
+        clip_outliers=False,
+        **kwargs,
+    ) -> matplotlib.axes.Axes:
         """Implements `plot()`, `scatter()`, and `errorbar()` to avoid code duplication.
 
         Parameters
@@ -1400,20 +1593,20 @@ class LightCurve(QTimeSeries):
             The matplotlib axes object.
         """
         # Configure the default style
-        if style is None or style == 'lightkurve':
+        if style is None or style == "lightkurve":
             style = MPLSTYLE
         # Default xlabel
         if xlabel is None:
-            if not hasattr(self.time, 'format'):
+            if not hasattr(self.time, "format"):
                 xlabel = "Phase"
-            elif self.time.format == 'bkjd':
-                xlabel = 'Time - 2454833 [BKJD days]'
-            elif self.time.format == 'btjd':
-                xlabel = 'Time - 2457000 [BTJD days]'
-            elif self.time.format == 'jd':
-                xlabel = 'Time [JD]'
+            elif self.time.format == "bkjd":
+                xlabel = "Time - 2454833 [BKJD days]"
+            elif self.time.format == "btjd":
+                xlabel = "Time - 2457000 [BTJD days]"
+            elif self.time.format == "jd":
+                xlabel = "Time [JD]"
             else:
-                xlabel = 'Time'
+                xlabel = "Time"
 
         # Default ylabel
         if ylabel is None:
@@ -1421,18 +1614,18 @@ class LightCurve(QTimeSeries):
                 ylabel = "Flux"
             else:
                 ylabel = f"{column}"
-            if normalize or (column == "flux" and self.meta.get('NORMALIZED')):
+            if normalize or (column == "flux" and self.meta.get("NORMALIZED")):
                 ylabel = "Normalized " + ylabel
-            elif (self[column].unit) and (self[column].unit.to_string() != ''):
+            elif (self[column].unit) and (self[column].unit.to_string() != ""):
                 ylabel += f" [{self[column].unit.to_string('latex_inline')}]"
 
         # Default legend label
-        if ('label' not in kwargs):
-            kwargs['label'] = self.meta.get('LABEL')
+        if "label" not in kwargs:
+            kwargs["label"] = self.meta.get("LABEL")
 
         flux = self[column]
         try:
-            flux_err = self[f'{column}_err']
+            flux_err = self[f"{column}_err"]
         except KeyError:
             flux_err = np.full(len(flux), np.nan)
 
@@ -1442,32 +1635,38 @@ class LightCurve(QTimeSeries):
                 lc_normed = self.normalize()
             else:
                 lc_tmp = self.copy()
-                lc_tmp['flux'] = flux
-                lc_tmp['flux_err'] = flux_err
+                lc_tmp["flux"] = flux
+                lc_tmp["flux_err"] = flux_err
                 lc_normed = lc_tmp.normalize()
             flux, flux_err = lc_normed.flux, lc_normed.flux_err
 
         # Apply offset if requested
         if offset:
-            flux += offset*flux.unit
+            flux += offset * flux.unit
 
         # Make the plot
         with plt.style.context(style):
             if ax is None:
                 fig, ax = plt.subplots(1)
-            if method == 'scatter':
+            if method == "scatter":
                 sc = ax.scatter(self.time.value, flux, **kwargs)
                 # Colorbars should only be plotted if the user specifies, and there is
                 # a color specified that is not a string (e.g. 'C1') and is iterable.
-                if show_colorbar and ('c' in kwargs) and \
-                   (not isinstance(kwargs['c'], str)) and hasattr(kwargs['c'], '__iter__'):
+                if (
+                    show_colorbar
+                    and ("c" in kwargs)
+                    and (not isinstance(kwargs["c"], str))
+                    and hasattr(kwargs["c"], "__iter__")
+                ):
                     cbar = plt.colorbar(sc, ax=ax)
                     cbar.set_label(colorbar_label)
                     cbar.ax.yaxis.set_tick_params(tick1On=False, tick2On=False)
                     cbar.ax.minorticks_off()
-            elif method == 'errorbar':
+            elif method == "errorbar":
                 if np.any(~np.isnan(flux_err)):
-                    ax.errorbar(x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs)
+                    ax.errorbar(
+                        x=self.time.value, y=flux.value, yerr=flux_err.value, **kwargs
+                    )
                 else:
                     log.warning(f"Column `{column}` has no associated errors.")
             else:
@@ -1476,8 +1675,8 @@ class LightCurve(QTimeSeries):
             ax.set_ylabel(ylabel)
             # Show the legend if labels were set
             legend_labels = ax.get_legend_handles_labels()
-            if (np.sum([len(a) for a in legend_labels]) != 0):
-                ax.legend(loc='best')
+            if np.sum([len(a) for a in legend_labels]) != 0:
+                ax.legend(loc="best")
 
             if clip_outliers and len(flux) > 0:
                 ymin, ymax = np.percentile(flux.value, [2.5, 97.5])
@@ -1524,9 +1723,11 @@ class LightCurve(QTimeSeries):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        return self._create_plot(method='plot', **kwargs)
+        return self._create_plot(method="plot", **kwargs)
 
-    def scatter(self, colorbar_label='', show_colorbar=True, **kwargs) -> matplotlib.axes.Axes:
+    def scatter(
+        self, colorbar_label="", show_colorbar=True, **kwargs
+    ) -> matplotlib.axes.Axes:
         """Plots the light curve using Matplotlib's `~matplotlib.pyplot.scatter` method.
 
         Parameters
@@ -1564,10 +1765,14 @@ class LightCurve(QTimeSeries):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        return self._create_plot(method='scatter', colorbar_label=colorbar_label,
-                                 show_colorbar=show_colorbar, **kwargs)
+        return self._create_plot(
+            method="scatter",
+            colorbar_label=colorbar_label,
+            show_colorbar=show_colorbar,
+            **kwargs,
+        )
 
-    def errorbar(self, linestyle='', **kwargs) -> matplotlib.axes.Axes:
+    def errorbar(self, linestyle="", **kwargs) -> matplotlib.axes.Axes:
         """Plots the light curve using Matplotlib's `~matplotlib.pyplot.errorbar` method.
 
         Parameters
@@ -1607,12 +1812,17 @@ class LightCurve(QTimeSeries):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        if 'ls' not in kwargs:
-            kwargs['linestyle'] = linestyle
-        return self._create_plot(method='errorbar', **kwargs)
+        if "ls" not in kwargs:
+            kwargs["linestyle"] = linestyle
+        return self._create_plot(method="errorbar", **kwargs)
 
-    def interact_bls(self, notebook_url='localhost:8888', minimum_period=None,
-                     maximum_period=None, resolution=2000):
+    def interact_bls(
+        self,
+        notebook_url="localhost:8888",
+        minimum_period=None,
+        maximum_period=None,
+        resolution=2000,
+    ):
         """Display an interactive Jupyter Notebook widget to find planets.
 
         The Box Least Squares (BLS) periodogram is a statistical tool used
@@ -1662,17 +1872,25 @@ class LightCurve(QTimeSeries):
         .. [1] https://docs.astropy.org/en/stable/timeseries/bls.html
         """
         from .interact_bls import show_interact_widget
-        return show_interact_widget(self, notebook_url=notebook_url, minimum_period=minimum_period,
-                                    maximum_period=maximum_period, resolution=resolution)
+
+        return show_interact_widget(
+            self,
+            notebook_url=notebook_url,
+            minimum_period=minimum_period,
+            maximum_period=maximum_period,
+            resolution=resolution,
+        )
 
     def to_table(self) -> Table:
         return Table(self)
 
-    @deprecated("2.0",
-                message='`to_timeseries()` has been deprecated. `LightCurve` is a '
-                        'sub-class of Astropy TimeSeries as of Lightkurve v2.0 '
-                        'and no longer needs to be converted.',
-                warning_type=LightkurveDeprecationWarning)
+    @deprecated(
+        "2.0",
+        message="`to_timeseries()` has been deprecated. `LightCurve` is a "
+        "sub-class of Astropy TimeSeries as of Lightkurve v2.0 "
+        "and no longer needs to be converted.",
+        warning_type=LightkurveDeprecationWarning,
+    )
     def to_timeseries(self):
         return self
 
@@ -1687,7 +1905,9 @@ class LightCurve(QTimeSeries):
             The AstroPy TimeSeries object.  The object must contain columns
             named 'time', 'flux', and 'flux_err'.
         """
-        return LightCurve(time=ts['time'].value, flux=ts['flux'], flux_err=ts['flux_err'])
+        return LightCurve(
+            time=ts["time"].value, flux=ts["flux"], flux_err=ts["flux_err"]
+        )
 
     def to_stingray(self):
         """Returns a `stingray.Lightcurve` object.
@@ -1704,10 +1924,16 @@ class LightCurve(QTimeSeries):
         try:
             from stingray import Lightcurve as StingrayLightcurve
         except ImportError:
-            raise ImportError("You need to install Stingray to use "
-                              "the LightCurve.to_stringray() method.")
-        return StingrayLightcurve(time=self.time.value, counts=self.flux,
-                                  err=self.flux_err, input_counts=False)
+            raise ImportError(
+                "You need to install Stingray to use "
+                "the LightCurve.to_stringray() method."
+            )
+        return StingrayLightcurve(
+            time=self.time.value,
+            counts=self.flux,
+            err=self.flux_err,
+            input_counts=False,
+        )
 
     @staticmethod
     def from_stingray(lc):
@@ -1745,6 +1971,7 @@ class LightCurve(QTimeSeries):
         if path_or_buf is None:
             use_stringio = True
             from io import StringIO
+
             path_or_buf = StringIO()
         result = self.write(path_or_buf, format="ascii.csv", **kwargs)
         if use_stringio:
@@ -1788,12 +2015,14 @@ class LightCurve(QTimeSeries):
             The power spectrum object extracted from the light curve.
         """
         supported_methods = ["ls", "bls", "lombscargle", "boxleastsquares"]
-        method = validate_method(method.replace(' ', ''), supported_methods)
+        method = validate_method(method.replace(" ", ""), supported_methods)
         if method in ["bls", "boxleastsquares"]:
             from .periodogram import BoxLeastSquaresPeriodogram
+
             return BoxLeastSquaresPeriodogram.from_lightcurve(lc=self, **kwargs)
         else:
             from .periodogram import LombScarglePeriodogram
+
             return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)
 
     def to_seismology(self, **kwargs):
@@ -1808,10 +2037,12 @@ class LightCurve(QTimeSeries):
             Object which can be used to estimate quick-look asteroseismic quantities.
         """
         from .seismology import Seismology
+
         return Seismology.from_lightcurve(self, **kwargs)
 
-    def to_fits(self, path=None, overwrite=False, flux_column_name='FLUX',
-                **extra_data):
+    def to_fits(
+        self, path=None, overwrite=False, flux_column_name="FLUX", **extra_data
+    ):
         """Converts the light curve to a FITS file in the Kepler/TESS file format.
 
         The FITS file will be returned as a `~astropy.io.fits.HDUList` object.
@@ -1838,13 +2069,22 @@ class LightCurve(QTimeSeries):
         hdu : `~astropy.io.fits.HDUList`
             Returns an `~astropy.io.fits.HDUList` object.
         """
-        typedir = {int: 'J', str: 'A', float: 'D', bool: 'L',
-                   np.int32: 'J', np.int32: 'K', np.float32: 'E', np.float64: 'D'}
+        typedir = {
+            int: "J",
+            str: "A",
+            float: "D",
+            bool: "L",
+            np.int32: "J",
+            np.int32: "K",
+            np.float32: "E",
+            np.float64: "D",
+        }
 
         def _header_template(extension):
             """Returns a template `fits.Header` object for a given extension."""
-            template_fn = os.path.join(PACKAGEDIR, "data",
-                                       "lc-ext{}-header.txt".format(extension))
+            template_fn = os.path.join(
+                PACKAGEDIR, "data", "lc-ext{}-header.txt".format(extension)
+            )
             return fits.Header.fromtextfile(template_fn)
 
         def _make_primary_hdu(extra_data=None):
@@ -1859,21 +2099,24 @@ class LightCurve(QTimeSeries):
 
             # Override the defaults where necessary
             from . import __version__
-            default = {'ORIGIN': "Unofficial data product",
-                         'DATE': datetime.datetime.now().strftime("%Y-%m-%d"),
-                         'CREATOR': "lightkurve.LightCurve.to_fits()",
-                         'PROCVER': str(__version__)}
+
+            default = {
+                "ORIGIN": "Unofficial data product",
+                "DATE": datetime.datetime.now().strftime("%Y-%m-%d"),
+                "CREATOR": "lightkurve.LightCurve.to_fits()",
+                "PROCVER": str(__version__),
+            }
 
             for kw in default:
-                hdu.header['{}'.format(kw).upper()] = default[kw]
+                hdu.header["{}".format(kw).upper()] = default[kw]
                 if default[kw] is None:
-                    log.warning('Value for {} is None.'.format(kw))
+                    log.warning("Value for {} is None.".format(kw))
 
             for kw in extra_data:
                 if isinstance(extra_data[kw], (str, float, int, bool, type(None))):
-                    hdu.header['{}'.format(kw).upper()] = extra_data[kw]
+                    hdu.header["{}".format(kw).upper()] = extra_data[kw]
                     if extra_data[kw] is None:
-                        log.warning('Value for {} is None.'.format(kw))
+                        log.warning("Value for {} is None.".format(kw))
             return hdu
 
         def _make_lightcurve_extension(extra_data=None):
@@ -1882,39 +2125,69 @@ class LightCurve(QTimeSeries):
             if extra_data is None:
                 extra_data = {}
             cols = []
-            if ~np.asarray(['TIME' in k.upper() for k in extra_data.keys()]).any():
-                cols.append(fits.Column(name='TIME', format='D', unit=self.time.format,
-                                        array=self.time.value))
-            if ~np.asarray([flux_column_name in k.upper() for k in extra_data.keys()]).any():
-                cols.append(fits.Column(name=flux_column_name, format='E',
-                                        unit='e-/s', array=self.flux))
-            if 'flux_err' in dir(self):
-                if ~(flux_column_name.upper() + '_ERR' in extra_data.keys()):
-                    cols.append(fits.Column(name=flux_column_name.upper() + '_ERR', format='E',
-                                            unit='e-/s', array=self.flux_err))
-            if 'cadenceno' in dir(self):
-                if ~np.asarray(['CADENCENO' in k.upper() for k in extra_data.keys()]).any():
-                    cols.append(fits.Column(name='CADENCENO', format='J',
-                                            array=self.cadenceno))
+            if ~np.asarray(["TIME" in k.upper() for k in extra_data.keys()]).any():
+                cols.append(
+                    fits.Column(
+                        name="TIME",
+                        format="D",
+                        unit=self.time.format,
+                        array=self.time.value,
+                    )
+                )
+            if ~np.asarray(
+                [flux_column_name in k.upper() for k in extra_data.keys()]
+            ).any():
+                cols.append(
+                    fits.Column(
+                        name=flux_column_name, format="E", unit="e-/s", array=self.flux
+                    )
+                )
+            if "flux_err" in dir(self):
+                if ~(flux_column_name.upper() + "_ERR" in extra_data.keys()):
+                    cols.append(
+                        fits.Column(
+                            name=flux_column_name.upper() + "_ERR",
+                            format="E",
+                            unit="e-/s",
+                            array=self.flux_err,
+                        )
+                    )
+            if "cadenceno" in dir(self):
+                if ~np.asarray(
+                    ["CADENCENO" in k.upper() for k in extra_data.keys()]
+                ).any():
+                    cols.append(
+                        fits.Column(name="CADENCENO", format="J", array=self.cadenceno)
+                    )
             for kw in extra_data:
                 if isinstance(extra_data[kw], (np.ndarray, list)):
-                    cols.append(fits.Column(name='{}'.format(kw).upper(),
-                                            format=typedir[extra_data[kw].dtype.type],
-                                            array=extra_data[kw]))
-            if 'SAP_QUALITY' not in extra_data:
-                cols.append(fits.Column(name='SAP_QUALITY',
-                                        format='J',
-                                        array=np.zeros(len(self.flux))))
+                    cols.append(
+                        fits.Column(
+                            name="{}".format(kw).upper(),
+                            format=typedir[extra_data[kw].dtype.type],
+                            array=extra_data[kw],
+                        )
+                    )
+            if "SAP_QUALITY" not in extra_data:
+                cols.append(
+                    fits.Column(
+                        name="SAP_QUALITY", format="J", array=np.zeros(len(self.flux))
+                    )
+                )
 
             coldefs = fits.ColDefs(cols)
             hdu = fits.BinTableHDU.from_columns(coldefs)
-            hdu.header['EXTNAME'] = 'LIGHTCURVE'
+            hdu.header["EXTNAME"] = "LIGHTCURVE"
             return hdu
 
         def _hdulist(**extra_data):
             """Returns an astropy.io.fits.HDUList object."""
-            list_out = fits.HDUList([_make_primary_hdu(extra_data=extra_data),
-                             _make_lightcurve_extension(extra_data=extra_data)])
+            list_out = fits.HDUList(
+                [
+                    _make_primary_hdu(extra_data=extra_data),
+                    _make_lightcurve_extension(extra_data=extra_data),
+                ]
+            )
             return list_out
 
         hdu = _hdulist(**extra_data)
@@ -1939,21 +2212,35 @@ class LightCurve(QTimeSeries):
         """
         allowed_methods = ["sff"]
         if method == "pld":
-            raise ValueError("The 'pld' method can only be used on "
-                             "`TargetPixelFile` objects, not `LightCurve` objects.")
+            raise ValueError(
+                "The 'pld' method can only be used on "
+                "`TargetPixelFile` objects, not `LightCurve` objects."
+            )
         if method not in allowed_methods:
-            raise ValueError(("Unrecognized method '{0}'\n"
-                              "allowed methods are: {1}")
-                             .format(method, allowed_methods))
+            raise ValueError(
+                ("Unrecognized method '{0}'\n" "allowed methods are: {1}").format(
+                    method, allowed_methods
+                )
+            )
         if method == "sff":
             from .correctors import SFFCorrector
+
             return SFFCorrector(self)
 
-    @deprecated_renamed_argument('t0', 'epoch_time', '2.0',
-                                 warning_type=LightkurveDeprecationWarning)
-    def plot_river(self, period, epoch_time=None, ax=None, bin_points=1,
-                   minimum_phase=-0.5, maximum_phase=0.5, method='mean',
-                   **kwargs) -> matplotlib.axes.Axes:
+    @deprecated_renamed_argument(
+        "t0", "epoch_time", "2.0", warning_type=LightkurveDeprecationWarning
+    )
+    def plot_river(
+        self,
+        period,
+        epoch_time=None,
+        ax=None,
+        bin_points=1,
+        minimum_phase=-0.5,
+        maximum_phase=0.5,
+        method="mean",
+        **kwargs,
+    ) -> matplotlib.axes.Axes:
         """Plot the light curve as a river plot.
 
         A river plot uses colors to represent the light curve values in
@@ -1995,7 +2282,7 @@ class LightCurve(QTimeSeries):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        if hasattr(self, 'time_original'):  # folded light curve
+        if hasattr(self, "time_original"):  # folded light curve
             time = self.time_original
         else:
             time = self.time
@@ -2011,17 +2298,20 @@ class LightCurve(QTimeSeries):
         if epoch_time is not None and not isinstance(epoch_time, (Time, Quantity)):
             epoch_time = Time(epoch_time, format=time.format, scale=time.scale)
 
-        method = validate_method(method, supported_methods=['mean', 'median', 'sigma'])
-        if (bin_points == 1) and (method in ['mean', 'median']):
+        method = validate_method(method, supported_methods=["mean", "median", "sigma"])
+        if (bin_points == 1) and (method in ["mean", "median"]):
             bin_func = lambda y, e: (y[0], e[0])
-        elif (bin_points == 1) and (method in ['sigma']):
-            bin_func = lambda y, e: ((y[0] - 1)/e[0], np.nan)
-        elif method == 'mean':
-            bin_func = lambda y, e: (np.nanmean(y), np.nansum(e**2)**0.5/len(e))
-        elif method == 'median':
-            bin_func = lambda y, e: (np.nanmedian(y), np.nansum(e**2)**0.5/len(e))
-        elif method == 'sigma':
-            bin_func = lambda y, e: ((np.nanmean(y) - 1)/(np.nansum(e**2)**0.5/len(e)), np.nan)
+        elif (bin_points == 1) and (method in ["sigma"]):
+            bin_func = lambda y, e: ((y[0] - 1) / e[0], np.nan)
+        elif method == "mean":
+            bin_func = lambda y, e: (np.nanmean(y), np.nansum(e ** 2) ** 0.5 / len(e))
+        elif method == "median":
+            bin_func = lambda y, e: (np.nanmedian(y), np.nansum(e ** 2) ** 0.5 / len(e))
+        elif method == "sigma":
+            bin_func = lambda y, e: (
+                (np.nanmean(y) - 1) / (np.nansum(e ** 2) ** 0.5 / len(e)),
+                np.nan,
+            )
 
         s = np.argsort(time.value)
         x, y, e = time.value[s], self.flux[s], self.flux_err[s]
@@ -2032,19 +2322,32 @@ class LightCurve(QTimeSeries):
         # Here `ph` is the phase of each time point x
         # cyc is the number of cycles that have occured at each time point x
         # since the phase 0 before x[0]
-        n = int(period.value/np.nanmedian(np.diff(x)) * (maximum_phase - minimum_phase)/bin_points)
+        n = int(
+            period.value
+            / np.nanmedian(np.diff(x))
+            * (maximum_phase - minimum_phase)
+            / bin_points
+        )
         if n == 1:
-            bin_points = int(maximum_phase - minimum_phase)/(2 / int(period.value/np.nanmedian(np.diff(x))))
-            warnings.warn('`bin_points` is too high to plot a phase curve, resetting to {}'.format(bin_points),
-                          LightkurveWarning)
+            bin_points = int(maximum_phase - minimum_phase) / (
+                2 / int(period.value / np.nanmedian(np.diff(x)))
+            )
+            warnings.warn(
+                "`bin_points` is too high to plot a phase curve, resetting to {}".format(
+                    bin_points
+                ),
+                LightkurveWarning,
+            )
             n = 2
-        ph = x/period.value % 1
-        cyc = np.asarray((x - x % period.value)/period.value, int)
+        ph = x / period.value % 1
+        cyc = np.asarray((x - x % period.value) / period.value, int)
         cyc -= np.min(cyc)
 
         phase = (epoch_time.value % period.value) / period.value
         ph = ((x - (phase * period.value)) / period.value) % 1
-        cyc = np.asarray((x - ((x - phase * period.value) % period.value))/period.value, int)
+        cyc = np.asarray(
+            (x - ((x - phase * period.value) % period.value)) / period.value, int
+        )
         cyc -= np.min(cyc)
         ph[ph > 0.5] -= 1
 
@@ -2053,7 +2356,7 @@ class LightCurve(QTimeSeries):
         bs = np.linspace(minimum_phase, maximum_phase, n + 1)
         cycs = np.arange(0, np.max(cyc) + 2)
 
-        ph_masks = [(ph > bs[jdx]) & (ph <= bs[jdx+1]) for jdx in range(n)]
+        ph_masks = [(ph > bs[jdx]) & (ph <= bs[jdx + 1]) for jdx in range(n)]
         qual_mask = np.isfinite(y)
         for cyc1 in np.unique(cyc):
             cyc_mask = cyc == cyc1
@@ -2063,52 +2366,63 @@ class LightCurve(QTimeSeries):
                 if not np.any(cyc_mask & ph_mask & qual_mask):
                     ar[jdx, cyc1] = np.nan
                 else:
-                    ar[jdx, cyc1] = bin_func(y[cyc_mask & ph_mask],
-                                             e[cyc_mask & ph_mask])[0]
+                    ar[jdx, cyc1] = bin_func(
+                        y[cyc_mask & ph_mask], e[cyc_mask & ph_mask]
+                    )[0]
 
         # If the method is average we need to denormalize the plot
-        if method in ['mean', 'median']:
+        if method in ["mean", "median"]:
             ar *= np.nanmedian(self.flux.value)
 
-        d = np.max([np.abs(np.nanmedian(ar) - np.nanpercentile(ar, 5)),
-                    np.abs(np.nanmedian(ar) - np.nanpercentile(ar, 95))])
-        vmin = kwargs.pop('vmin', np.nanmedian(ar) - d)
-        vmax = kwargs.pop('vmax', np.nanmedian(ar) + d)
-        if method in ['mean', 'median']:
-            cmap = kwargs.pop('cmap', 'viridis')
-        elif method == 'sigma':
-            cmap = kwargs.pop('cmap', 'coolwarm')
+        d = np.max(
+            [
+                np.abs(np.nanmedian(ar) - np.nanpercentile(ar, 5)),
+                np.abs(np.nanmedian(ar) - np.nanpercentile(ar, 95)),
+            ]
+        )
+        vmin = kwargs.pop("vmin", np.nanmedian(ar) - d)
+        vmax = kwargs.pop("vmax", np.nanmedian(ar) + d)
+        if method in ["mean", "median"]:
+            cmap = kwargs.pop("cmap", "viridis")
+        elif method == "sigma":
+            cmap = kwargs.pop("cmap", "coolwarm")
 
         with plt.style.context(MPLSTYLE):
             if ax is None:
-                _, ax = plt.subplots(figsize=(12, cyc.max()*0.1))
+                _, ax = plt.subplots(figsize=(12, cyc.max() * 0.1))
 
-            im = ax.pcolormesh(bs, cycs, ar.T, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
+            im = ax.pcolormesh(
+                bs, cycs, ar.T, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs
+            )
             cbar = plt.colorbar(im, ax=ax)
-            if method in ['mean', 'median']:
-                unit = '[Normalized Flux]'
+            if method in ["mean", "median"]:
+                unit = "[Normalized Flux]"
                 if self.flux.unit is not None:
-                    if (self.flux.unit != u.dimensionless_unscaled):
-                        unit = '[{}]'.format(self.flux.unit.to_string('latex'))
+                    if self.flux.unit != u.dimensionless_unscaled:
+                        unit = "[{}]".format(self.flux.unit.to_string("latex"))
                 if bin_points == 1:
                     cbar.set_label("Flux {}".format(unit))
                 else:
                     cbar.set_label("Average Flux in Bin {}".format(unit))
-            elif method == 'sigma':
+            elif method == "sigma":
                 if bin_points == 1:
-                    cbar.set_label("Flux in units of Standard Deviation "
-                                   "$(f - \overline{f})/(\sigma_f)$")
+                    cbar.set_label(
+                        "Flux in units of Standard Deviation "
+                        "$(f - \overline{f})/(\sigma_f)$"
+                    )
                 else:
-                    cbar.set_label("Average Flux in Bin in units of Standard Deviation "
-                                   "$(f - \overline{f})/(\sigma_f)$")
+                    cbar.set_label(
+                        "Average Flux in Bin in units of Standard Deviation "
+                        "$(f - \overline{f})/(\sigma_f)$"
+                    )
 
             ax.set_xlabel("Phase")
             ax.set_ylabel("Cycle")
             ax.set_ylim(cyc.max(), 0)
-            ax.set_title(self.meta.get('LABEL'))
-            a = cyc.max() * 0.1 / 12.
+            ax.set_title(self.meta.get("LABEL"))
+            a = cyc.max() * 0.1 / 12.0
             b = (cyc.max() - cyc.min()) / (bs.max() - bs.min())
-            ax.set_aspect(a/b)
+            ax.set_aspect(a / b)
         return ax
 
     def create_transit_mask(self, period, transit_time, duration):
@@ -2154,8 +2468,10 @@ class LightCurve(QTimeSeries):
         # Make sure all params have the same number of entries
         n_planets = len(period)
         if any(len(param) != n_planets for param in [duration, transit_time]):
-            raise ValueError("period, duration, and transit_time must have "
-                             "the same number of values.")
+            raise ValueError(
+                "period, duration, and transit_time must have "
+                "the same number of values."
+            )
 
         # Initialize an empty cadence mask
         in_transit = np.empty(len(self), dtype=bool)
@@ -2166,13 +2482,14 @@ class LightCurve(QTimeSeries):
             if isinstance(tt, Time):
                 # If a `Time` is passed, ensure it has the right format & scale
                 tt = Time(tt, format=self.time.format, scale=self.time.scale).value
-            hp = per / 2.
-            in_transit |= np.abs((self.time.value - tt + hp) % per - hp) < 0.5*dur
+            hp = per / 2.0
+            in_transit |= np.abs((self.time.value - tt + hp) % per - hp) < 0.5 * dur
 
         return in_transit
 
-    def search_neighbors(self, limit: int = 10, radius: float = 3600.,
-                         **search_criteria):
+    def search_neighbors(
+        self, limit: int = 10, radius: float = 3600.0, **search_criteria
+    ):
         """Search the data archive at MAST for the most nearby light curves.
 
         By default, the 10 nearest neighbors located within 3600 arcseconds
@@ -2210,25 +2527,28 @@ class LightCurve(QTimeSeries):
         from .search import search_lightcurve
 
         # By default, only return results from the same sector/quarter/campaign
-        if ('mission' not in search_criteria
-                and 'sector' not in search_criteria
-                and 'quarter' not in search_criteria
-                and 'campaign' not in search_criteria):
-            mission = self.meta.get('MISSION', None)
-            if mission == 'TESS':
-                search_criteria['sector'] = self.sector
-            elif mission == 'Kepler':
-                search_criteria['quarter'] = self.quarter
-            elif mission == 'K2':
-                search_criteria['campaign'] = self.campaign
+        if (
+            "mission" not in search_criteria
+            and "sector" not in search_criteria
+            and "quarter" not in search_criteria
+            and "campaign" not in search_criteria
+        ):
+            mission = self.meta.get("MISSION", None)
+            if mission == "TESS":
+                search_criteria["sector"] = self.sector
+            elif mission == "Kepler":
+                search_criteria["quarter"] = self.quarter
+            elif mission == "K2":
+                search_criteria["campaign"] = self.campaign
 
         # Note: we increase `limit` by one below to account for the fact that the
         # current light curve will be returned by the search operation
-        log.info(f"Started searching for up to {limit} neighbors within {radius} arcseconds.")
-        result = search_lightcurve(f"{self.ra} {self.dec}",
-                                   radius=radius,
-                                   limit=limit + 1,
-                                   **search_criteria)
+        log.info(
+            f"Started searching for up to {limit} neighbors within {radius} arcseconds."
+        )
+        result = search_lightcurve(
+            f"{self.ra} {self.dec}", radius=radius, limit=limit + 1, **search_criteria
+        )
 
         # Filter by distance > 0 to avoid returning the current light curve
         result = result[result.distance > 0]
@@ -2271,7 +2591,9 @@ class FoldedLightCurve(LightCurve):
             >>> f[f.odd_mask].scatter()  # doctest: +SKIP
             >>> f[f.even_mask].scatter()  # doctest: +SKIP
         """
-        cycle = (self.time_original - self.time.value * (self.period) - self.period * 0.5) / (self.period * 2)
+        cycle = (
+            self.time_original - self.time.value * (self.period) - self.period * 0.5
+        ) / (self.period * 2)
         return (cycle.value % 1) < 0.5
 
     @property
@@ -2286,10 +2608,10 @@ class FoldedLightCurve(LightCurve):
         """Helper function for plot, scatter, and errorbar.
         Ensures the xlabel is correctly set for folded light curves.
         """
-        if 'xlabel' not in kwargs:
-            kwargs['xlabel'] = "Phase"
+        if "xlabel" not in kwargs:
+            kwargs["xlabel"] = "Phase"
             if isinstance(self.time, TimeDelta):
-                kwargs['xlabel'] += f" [{self.time.format.upper()}]"
+                kwargs["xlabel"] += f" [{self.time.format.upper()}]"
         return kwargs
 
     def plot(self, **kwargs):
@@ -2363,7 +2685,9 @@ class FoldedLightCurve(LightCurve):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        ax = super(FoldedLightCurve, self).plot_river(period=self.period, epoch_time=self.epoch_time, **kwargs)
+        ax = super(FoldedLightCurve, self).plot_river(
+            period=self.period, epoch_time=self.epoch_time, **kwargs
+        )
         return ax
 
 
@@ -2371,11 +2695,22 @@ class KeplerLightCurve(LightCurve):
     """Subclass of :class:`LightCurve <lightkurve.lightcurve.LightCurve>`
     to represent data from NASA's Kepler and K2 mission."""
 
-    _deprecated_keywords = ('targetid', 'label',  'time_format', 'time_scale',
-                            'flux_unit', 'quality_bitmask', 'channel',
-                            'campaign', 'quarter', 'mission', 'ra', 'dec')
+    _deprecated_keywords = (
+        "targetid",
+        "label",
+        "time_format",
+        "time_scale",
+        "flux_unit",
+        "quality_bitmask",
+        "channel",
+        "campaign",
+        "quarter",
+        "mission",
+        "ra",
+        "dec",
+    )
 
-    _default_time_format = 'bkjd'
+    _default_time_format = "bkjd"
 
     @classmethod
     def read(cls, *args, **kwargs):
@@ -2406,11 +2741,17 @@ class KeplerLightCurve(LightCurve):
         """
         # Default to Kepler file format
         if kwargs.get("format") is None:
-            kwargs['format'] = "kepler"
+            kwargs["format"] = "kepler"
         return super().read(*args, **kwargs)
 
-    def to_fits(self, path=None, overwrite=False, flux_column_name='FLUX',
-                aperture_mask=None,**extra_data):
+    def to_fits(
+        self,
+        path=None,
+        overwrite=False,
+        flux_column_name="FLUX",
+        aperture_mask=None,
+        **extra_data,
+    ):
         """Writes the KeplerLightCurve to a FITS file.
 
         Parameters
@@ -2439,29 +2780,30 @@ class KeplerLightCurve(LightCurve):
             Returns an astropy.io.fits object if path is None
         """
         kepler_specific_data = {
-            'TELESCOP': "KEPLER",
-            'INSTRUME': "Kepler Photometer",
-            'OBJECT': '{}'.format(self.targetid),
-            'KEPLERID': self.targetid,
-            'CHANNEL': self.channel,
-            'MISSION': self.mission,
-            'RA_OBJ': self.ra,
-            'DEC_OBJ': self.dec,
-            'EQUINOX': 2000,
-            'DATE-OBS': Time(self.time[0]+2454833., format=('jd')).isot,
-            'SAP_QUALITY': self.quality,
-            'MOM_CENTR1': self.centroid_col,
-            'MOM_CENTR2': self.centroid_row}
+            "TELESCOP": "KEPLER",
+            "INSTRUME": "Kepler Photometer",
+            "OBJECT": "{}".format(self.targetid),
+            "KEPLERID": self.targetid,
+            "CHANNEL": self.channel,
+            "MISSION": self.mission,
+            "RA_OBJ": self.ra,
+            "DEC_OBJ": self.dec,
+            "EQUINOX": 2000,
+            "DATE-OBS": Time(self.time[0] + 2454833.0, format=("jd")).isot,
+            "SAP_QUALITY": self.quality,
+            "MOM_CENTR1": self.centroid_col,
+            "MOM_CENTR2": self.centroid_row,
+        }
 
         for kw in kepler_specific_data:
             if ~np.asarray([kw.lower == k.lower() for k in extra_data]).any():
                 extra_data[kw] = kepler_specific_data[kw]
-        hdu = super(KeplerLightCurve, self).to_fits(path=None,
-                                                    overwrite=overwrite,
-                                                    **extra_data)
+        hdu = super(KeplerLightCurve, self).to_fits(
+            path=None, overwrite=overwrite, **extra_data
+        )
 
-        hdu[0].header['QUARTER'] = self.meta.get('QUARTER')
-        hdu[0].header['CAMPAIGN'] = self.meta.get('CAMPAIGN')
+        hdu[0].header["QUARTER"] = self.meta.get("QUARTER")
+        hdu[0].header["CAMPAIGN"] = self.meta.get("CAMPAIGN")
 
         hdu = _make_aperture_extension(hdu, aperture_mask)
 
@@ -2475,11 +2817,22 @@ class TessLightCurve(LightCurve):
     """Subclass of :class:`LightCurve <lightkurve.lightcurve.LightCurve>`
     to represent data from NASA's TESS mission."""
 
-    _deprecated_keywords = ('targetid', 'label',  'time_format', 'time_scale',
-                            'flux_unit', 'quality_bitmask', 'sector',
-                            'camera', 'ccd', 'mission', 'ra', 'dec')
+    _deprecated_keywords = (
+        "targetid",
+        "label",
+        "time_format",
+        "time_scale",
+        "flux_unit",
+        "quality_bitmask",
+        "sector",
+        "camera",
+        "ccd",
+        "mission",
+        "ra",
+        "dec",
+    )
 
-    _default_time_format = 'btjd'
+    _default_time_format = "btjd"
 
     @classmethod
     def read(cls, *args, **kwargs):
@@ -2508,11 +2861,17 @@ class TessLightCurve(LightCurve):
         """
         # Default to TESS file format
         if kwargs.get("format") is None:
-            kwargs['format'] = "tess"
+            kwargs["format"] = "tess"
         return super().read(*args, **kwargs)
 
-    def to_fits(self, path=None, overwrite=False, flux_column_name='FLUX',
-                aperture_mask=None, **extra_data):
+    def to_fits(
+        self,
+        path=None,
+        overwrite=False,
+        flux_column_name="FLUX",
+        aperture_mask=None,
+        **extra_data,
+    ):
         """Writes the KeplerLightCurve to a FITS file.
 
         Parameters
@@ -2541,28 +2900,29 @@ class TessLightCurve(LightCurve):
             Returns an astropy.io.fits object if path is None
         """
         tess_specific_data = {
-            'OBJECT': '{}'.format(self.targetid),
-            'MISSION': self.meta.get('MISSION'),
-            'RA_OBJ': self.meta.get('RA'),
-            'TELESCOP': self.meta.get('MISSION'),
-            'CAMERA': self.meta.get('CAMERA'),
-            'CCD': self.meta.get('CCD'),
-            'SECTOR': self.meta.get('SECTOR'),
-            'TARGETID': self.meta.get('TARGETID'),
-            'DEC_OBJ': self.meta.get('DEC'),
-            'MOM_CENTR1': self.centroid_col,
-            'MOM_CENTR2': self.centroid_row}
+            "OBJECT": "{}".format(self.targetid),
+            "MISSION": self.meta.get("MISSION"),
+            "RA_OBJ": self.meta.get("RA"),
+            "TELESCOP": self.meta.get("MISSION"),
+            "CAMERA": self.meta.get("CAMERA"),
+            "CCD": self.meta.get("CCD"),
+            "SECTOR": self.meta.get("SECTOR"),
+            "TARGETID": self.meta.get("TARGETID"),
+            "DEC_OBJ": self.meta.get("DEC"),
+            "MOM_CENTR1": self.centroid_col,
+            "MOM_CENTR2": self.centroid_row,
+        }
 
         for kw in tess_specific_data:
             if ~np.asarray([kw.lower == k.lower() for k in extra_data]).any():
                 extra_data[kw] = tess_specific_data[kw]
-        hdu = super(TessLightCurve, self).to_fits(path=None,
-                                                    overwrite=overwrite,
-                                                    **extra_data)
+        hdu = super(TessLightCurve, self).to_fits(
+            path=None, overwrite=overwrite, **extra_data
+        )
 
         # We do this because the TESS file format is subtly different in the
         #    name of this column.
-        hdu[1].columns.change_name('SAP_QUALITY', 'QUALITY')
+        hdu[1].columns.change_name("SAP_QUALITY", "QUALITY")
 
         hdu = _make_aperture_extension(hdu, aperture_mask)
 
@@ -2573,6 +2933,7 @@ class TessLightCurve(LightCurve):
 
 
 # Helper functions
+
 
 def _boolean_mask_to_bitmask(aperture_mask):
     """Takes in an aperture_mask and returns a Kepler-style bitmask
@@ -2596,9 +2957,10 @@ def _boolean_mask_to_bitmask(aperture_mask):
     clean_mask = np.nan_to_num(aperture_mask)
 
     contains_bit2 = (clean_mask.astype(np.int) & 2).any()
-    all_zeros_or_ones = ( (clean_mask.dtype in ['float', 'int']) &
-                            ((set(np.unique(clean_mask)) - {0,1}) == set()) )
-    is_bool_mask = ( (aperture_mask.dtype == 'bool') | all_zeros_or_ones )
+    all_zeros_or_ones = (clean_mask.dtype in ["float", "int"]) & (
+        (set(np.unique(clean_mask)) - {0, 1}) == set()
+    )
+    is_bool_mask = (aperture_mask.dtype == "bool") | all_zeros_or_ones
 
     if is_bool_mask:
         out_mask = np.ones(aperture_mask.shape, dtype=np.uint8)
@@ -2607,10 +2969,13 @@ def _boolean_mask_to_bitmask(aperture_mask):
     elif contains_bit2:
         out_mask = aperture_mask.astype(np.uint8)
     else:
-        log.warn("The input aperture mask must be boolean or follow the \
-                Kepler-pipeline standard; returning None.")
+        log.warn(
+            "The input aperture mask must be boolean or follow the \
+                Kepler-pipeline standard; returning None."
+        )
         out_mask = None
     return out_mask
+
 
 def _make_aperture_extension(hdu_list, aperture_mask):
     """Returns an `ImageHDU` object containing the 'APERTURE' extension
@@ -2618,6 +2983,6 @@ def _make_aperture_extension(hdu_list, aperture_mask):
     if aperture_mask is not None:
         bitmask = _boolean_mask_to_bitmask(aperture_mask)
         hdu = fits.ImageHDU(bitmask)
-        hdu.header['EXTNAME'] = 'APERTURE'
+        hdu.header["EXTNAME"] = "APERTURE"
         hdu_list.append(hdu)
     return hdu_list

--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -20,7 +20,7 @@ from astropy.time import Time
 # LombScargle was moved from astropy.stats to astropy.timeseries in AstroPy v3.2
 try:
     from astropy.timeseries import LombScargle
-    from astropy.timeseries import implementations #for .main._is_regular
+    from astropy.timeseries import implementations  # for .main._is_regular
 except ImportError:
     from astropy.stats import LombScargle
     from astropy.stats.lombscargle import implementations
@@ -32,7 +32,7 @@ from .lightcurve import LightCurve
 
 log = logging.getLogger(__name__)
 
-__all__ = ['Periodogram', 'LombScarglePeriodogram', 'BoxLeastSquaresPeriodogram']
+__all__ = ["Periodogram", "LombScarglePeriodogram", "BoxLeastSquaresPeriodogram"]
 
 
 class Periodogram(object):
@@ -69,23 +69,31 @@ class Periodogram(object):
     power = None
     """The array of power values."""
 
-    def __init__(self, frequency, power, nyquist=None, label=None,
-                 targetid=None, default_view='frequency', meta={}):
+    def __init__(
+        self,
+        frequency,
+        power,
+        nyquist=None,
+        label=None,
+        targetid=None,
+        default_view="frequency",
+        meta={},
+    ):
         # Input validation
         if not isinstance(frequency, u.quantity.Quantity):
-            raise ValueError('frequency must be an `astropy.units.Quantity` object.')
+            raise ValueError("frequency must be an `astropy.units.Quantity` object.")
         if not isinstance(power, u.quantity.Quantity):
-            raise ValueError('power must be an `astropy.units.Quantity` object.')
+            raise ValueError("power must be an `astropy.units.Quantity` object.")
         # Frequency must have frequency units
         try:
             frequency.to(u.Hz)
         except u.UnitConversionError:
-            raise ValueError('Frequency must be in units of 1/time.')
+            raise ValueError("Frequency must be in units of 1/time.")
         # Frequency and power must have sensible shapes
         if frequency.shape[0] <= 1:
-            raise ValueError('frequency and power must have a length greater than 1.')
+            raise ValueError("frequency and power must have a length greater than 1.")
         if frequency.shape != power.shape:
-            raise ValueError('frequency and power must have the same length.')
+            raise ValueError("frequency and power must have the same length.")
 
         self.frequency = frequency
         self.power = power
@@ -99,7 +107,7 @@ class Periodogram(object):
         """Verifies whether `view` is is one of {"frequency", "period"} and
         raises a helpful `ValueError` if not.
         """
-        if view is None and hasattr(self, 'default_view'):
+        if view is None and hasattr(self, "default_view"):
             view = self.default_view
         return validate_method(view, ["frequency", "period"])
 
@@ -119,7 +127,7 @@ class Periodogram(object):
     @property
     def period(self):
         """The array of periods, i.e. 1/frequency."""
-        return 1. / self.frequency
+        return 1.0 / self.frequency
 
     @property
     def max_power(self):
@@ -134,9 +142,9 @@ class Periodogram(object):
     @property
     def period_at_max_power(self):
         """Period value corresponding to the highest peak in the periodogram."""
-        return 1. / self.frequency_at_max_power
+        return 1.0 / self.frequency_at_max_power
 
-    def bin(self, binsize=10, method='mean'):
+    def bin(self, binsize=10, method="mean"):
         """Bins the power spectrum.
 
         Parameters
@@ -156,23 +164,27 @@ class Periodogram(object):
         """
         # Input validation
         if binsize < 1:
-            raise ValueError('binsize must be larger than or equal to 1')
-        method = validate_method(method, ['mean', 'median'])
+            raise ValueError("binsize must be larger than or equal to 1")
+        method = validate_method(method, ["mean", "median"])
 
         m = int(len(self.power) / binsize)  # length of the binned arrays
-        if method == 'mean':
-            binned_freq = self.frequency[:m*binsize].reshape((m, binsize)).mean(1)
-            binned_power = self.power[:m*binsize].reshape((m, binsize)).mean(1)
-        elif method == 'median':
-            binned_freq = np.nanmedian(self.frequency[:m*binsize].reshape((m, binsize)), axis=1)
-            binned_power = np.nanmedian(self.power[:m*binsize].reshape((m, binsize)), axis=1)
+        if method == "mean":
+            binned_freq = self.frequency[: m * binsize].reshape((m, binsize)).mean(1)
+            binned_power = self.power[: m * binsize].reshape((m, binsize)).mean(1)
+        elif method == "median":
+            binned_freq = np.nanmedian(
+                self.frequency[: m * binsize].reshape((m, binsize)), axis=1
+            )
+            binned_power = np.nanmedian(
+                self.power[: m * binsize].reshape((m, binsize)), axis=1
+            )
 
         binned_pg = self.copy()
         binned_pg.frequency = binned_freq
         binned_pg.power = binned_power
         return binned_pg
 
-    def smooth(self, method='boxkernel', filter_width=0.1):
+    def smooth(self, method="boxkernel", filter_width=0.1):
         """Smooths the power spectrum using the 'boxkernel' or 'logmedian' method.
 
         If `method` is set to 'boxkernel', this method will smooth the power
@@ -226,38 +238,45 @@ class Periodogram(object):
             Returns a new `Periodogram` object in which the power spectrum
             has been smoothed.
         """
-        method = validate_method(method, ['boxkernel', 'logmedian'])
+        method = validate_method(method, ["boxkernel", "logmedian"])
 
-        if method == 'boxkernel':
-            if filter_width <= 0.:
-                raise ValueError("the `filter_width` parameter must be "
-                                 "larger than 0 for the 'boxkernel' method.")
+        if method == "boxkernel":
+            if filter_width <= 0.0:
+                raise ValueError(
+                    "the `filter_width` parameter must be "
+                    "larger than 0 for the 'boxkernel' method."
+                )
             try:
                 filter_width = u.Quantity(filter_width, self.frequency.unit)
             except u.UnitConversionError:
-                raise ValueError("the `filter_width` parameter must have "
-                                 "frequency units.")
+                raise ValueError(
+                    "the `filter_width` parameter must have " "frequency units."
+                )
 
             # Check to see if we have a grid of evenly spaced periods instead.
             if not self._is_evenly_spaced():
-                raise ValueError("the 'boxkernel' method requires the periodogram "
-                                 "to have a grid of evenly spaced frequencies.")
+                raise ValueError(
+                    "the 'boxkernel' method requires the periodogram "
+                    "to have a grid of evenly spaced frequencies."
+                )
 
             fs = np.mean(np.diff(self.frequency))
-            box_kernel = Box1DKernel(math.ceil((filter_width/fs).value))
+            box_kernel = Box1DKernel(math.ceil((filter_width / fs).value))
             smooth_power = convolve(self.power.value, box_kernel)
             smooth_pg = self.copy()
             smooth_pg.power = u.Quantity(smooth_power, self.power.unit)
             return smooth_pg
 
-        if method == 'logmedian':
+        if method == "logmedian":
             if isinstance(filter_width, astropy.units.quantity.Quantity):
-                raise ValueError("the 'logmedian' method requires a dimensionless "
-                                 "value for `filter_width` in log10(frequency) space.")
+                raise ValueError(
+                    "the 'logmedian' method requires a dimensionless "
+                    "value for `filter_width` in log10(frequency) space."
+                )
             count = np.zeros(len(self.frequency.value), dtype=int)
             bkg = np.zeros_like(self.frequency.value)
             x0 = np.log10(self.frequency[0].value)
-            corr_factor = (8.0 / 9.0)**3
+            corr_factor = (8.0 / 9.0) ** 3
             while x0 < np.log10(self.frequency[-1].value):
                 m = np.abs(np.log10(self.frequency.value) - x0) < filter_width
                 if len(bkg[m] > 0):
@@ -269,8 +288,18 @@ class Periodogram(object):
             smooth_pg.power = u.Quantity(bkg, self.power.unit)
             return smooth_pg
 
-    def plot(self, scale='linear', ax=None, xlabel=None, ylabel=None, title='',
-             style='lightkurve', view=None, unit=None, **kwargs):
+    def plot(
+        self,
+        scale="linear",
+        ax=None,
+        xlabel=None,
+        ylabel=None,
+        title="",
+        style="lightkurve",
+        view=None,
+        unit=None,
+        **kwargs
+    ):
         """Plots the Periodogram.
 
         Parameters
@@ -309,51 +338,52 @@ class Periodogram(object):
 
         if unit is None:
             unit = self.frequency.unit
-            if view == 'period':
+            if view == "period":
                 unit = self.period.unit
 
-        if style is None or style == 'lightkurve':
+        if style is None or style == "lightkurve":
             style = MPLSTYLE
         if ylabel is None:
             ylabel = "Power"
-            if self.power.unit.to_string() != '':
-                unit_label = self.power.unit.to_string('latex')
+            if self.power.unit.to_string() != "":
+                unit_label = self.power.unit.to_string("latex")
                 # The line below is a workaround for AstroPy bug #9218.
                 # It can be removed once the fix for that issue is widespread.
                 # See https://github.com/astropy/astropy/pull/9218
-                unit_label = re.sub(r"\^{([^}]+)}\^{([^}]+)}", r"^{\g<1>^{\g<2>}}", unit_label)
+                unit_label = re.sub(
+                    r"\^{([^}]+)}\^{([^}]+)}", r"^{\g<1>^{\g<2>}}", unit_label
+                )
                 ylabel += " [{}]".format(unit_label)
 
         # This will need to be fixed with housekeeping. Self.label currently doesnt exist.
-        if ('label' not in kwargs) and ('label' in dir(self)):
-            kwargs['label'] = self.label
+        if ("label" not in kwargs) and ("label" in dir(self)):
+            kwargs["label"] = self.label
 
         with plt.style.context(style):
             if ax is None:
                 fig, ax = plt.subplots()
 
             # Plot frequency and power
-            if view == 'frequency':
+            if view == "frequency":
                 ax.plot(self.frequency.to(unit), self.power, **kwargs)
                 if xlabel is None:
-                    xlabel = "Frequency [{}]".format(unit.to_string('latex'))
-            elif view == 'period':
+                    xlabel = "Frequency [{}]".format(unit.to_string("latex"))
+            elif view == "period":
                 ax.plot(self.period.to(unit), self.power, **kwargs)
                 if xlabel is None:
-                    xlabel = "Period [{}]".format(unit.to_string('latex'))
+                    xlabel = "Period [{}]".format(unit.to_string("latex"))
             ax.set_xlabel(xlabel)
             ax.set_ylabel(ylabel)
             # Show the legend if labels were set
             legend_labels = ax.get_legend_handles_labels()
-            if (np.sum([len(a) for a in legend_labels]) != 0):
-                ax.legend(loc='best')
+            if np.sum([len(a) for a in legend_labels]) != 0:
+                ax.legend(loc="best")
             ax.set_yscale(scale)
             ax.set_xscale(scale)
             ax.set_title(title)
         return ax
 
-
-    def flatten(self, method='logmedian', filter_width=0.01, return_trend=False):
+    def flatten(self, method="logmedian", filter_width=0.01, return_trend=False):
         """Estimates the Signal-To-Noise (SNR) spectrum by dividing out an
         estimate of the noise background.
 
@@ -391,9 +421,14 @@ class Periodogram(object):
         """
         bkg = self.smooth(method=method, filter_width=filter_width)
         snr_pg = self / bkg.power
-        snr = SNRPeriodogram(snr_pg.frequency, snr_pg.power,
-                             nyquist=self.nyquist, targetid=self.targetid,
-                             label=self.label, meta=self.meta)
+        snr = SNRPeriodogram(
+            snr_pg.frequency,
+            snr_pg.power,
+            nyquist=self.nyquist,
+            targetid=self.targetid,
+            label=self.label,
+            meta=self.meta,
+        )
         if return_trend:
             return snr, bkg
         return snr
@@ -406,9 +441,11 @@ class Periodogram(object):
         table : `~astropy.table.Table` object
             An AstroPy Table with columns 'frequency', 'period', and 'power'.
         """
-        return Table(data=(self.frequency, self.period, self.power),
-                     names=('frequency', 'period', 'power'),
-                     meta=self.meta)
+        return Table(
+            data=(self.frequency, self.period, self.power),
+            names=("frequency", "period", "power"),
+            meta=self.meta,
+        )
 
     def copy(self):
         """Returns a copy of the Periodogram object.
@@ -424,7 +461,7 @@ class Periodogram(object):
         return copy.deepcopy(self)
 
     def __repr__(self):
-        return('Periodogram(ID: {})'.format(self.label))
+        return "Periodogram(ID: {})".format(self.label)
 
     def __getitem__(self, key):
         copy_self = self.copy()
@@ -457,7 +494,7 @@ class Periodogram(object):
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        return self.__mul__(1./other)
+        return self.__mul__(1.0 / other)
 
     def __rtruediv__(self, other):
         copy_self = self.copy()
@@ -478,7 +515,7 @@ class Periodogram(object):
         """
         attrs = {}
         for attr in dir(self):
-            if not attr.startswith('_'):
+            if not attr.startswith("_"):
                 res = getattr(self, attr)
                 if callable(res):
                     continue
@@ -486,60 +523,62 @@ class Periodogram(object):
                 if isinstance(res, astropy.units.quantity.Quantity):
                     unit = res.unit
                     res = res.value
-                    attrs[attr] = {'res': res}
-                    attrs[attr]['unit'] = unit.to_string()
+                    attrs[attr] = {"res": res}
+                    attrs[attr]["unit"] = unit.to_string()
                 else:
-                    attrs[attr] = {'res': res}
-                    attrs[attr]['unit'] = ''
+                    attrs[attr] = {"res": res}
+                    attrs[attr]["unit"] = ""
 
-                if attr == 'hdu':
-                    attrs[attr] = {'res': res, 'type': 'list'}
+                if attr == "hdu":
+                    attrs[attr] = {"res": res, "type": "list"}
                     for idx, r in enumerate(res):
                         if idx == 0:
-                            attrs[attr]['print'] = '{}'.format(r.header['EXTNAME'])
+                            attrs[attr]["print"] = "{}".format(r.header["EXTNAME"])
                         else:
-                            attrs[attr]['print'] = '{}, {}'.format(
-                                attrs[attr]['print'], '{}'.format(r.header['EXTNAME']))
+                            attrs[attr]["print"] = "{}, {}".format(
+                                attrs[attr]["print"], "{}".format(r.header["EXTNAME"])
+                            )
                     continue
 
                 if isinstance(res, int):
-                    attrs[attr]['print'] = '{}'.format(res)
-                    attrs[attr]['type'] = 'int'
+                    attrs[attr]["print"] = "{}".format(res)
+                    attrs[attr]["type"] = "int"
                 elif isinstance(res, float):
-                    attrs[attr]['print'] = '{}'.format(np.round(res, 4))
-                    attrs[attr]['type'] = 'float'
+                    attrs[attr]["print"] = "{}".format(np.round(res, 4))
+                    attrs[attr]["type"] = "float"
                 elif isinstance(res, np.ndarray):
-                    attrs[attr]['print'] = 'array {}'.format(res.shape)
-                    attrs[attr]['type'] = 'array'
+                    attrs[attr]["print"] = "array {}".format(res.shape)
+                    attrs[attr]["type"] = "array"
                 elif isinstance(res, list):
-                    attrs[attr]['print'] = 'list length {}'.format(len(res))
-                    attrs[attr]['type'] = 'list'
+                    attrs[attr]["print"] = "list length {}".format(len(res))
+                    attrs[attr]["type"] = "list"
                 elif isinstance(res, str):
-                    if res == '':
-                        attrs[attr]['print'] = '{}'.format('None')
+                    if res == "":
+                        attrs[attr]["print"] = "{}".format("None")
                     else:
-                        attrs[attr]['print'] = '{}'.format(res)
-                    attrs[attr]['type'] = 'str'
-                elif attr == 'wcs':
-                    attrs[attr]['print'] = 'astropy.wcs.wcs.WCS'
-                    attrs[attr]['type'] = 'other'
+                        attrs[attr]["print"] = "{}".format(res)
+                    attrs[attr]["type"] = "str"
+                elif attr == "wcs":
+                    attrs[attr]["print"] = "astropy.wcs.wcs.WCS"
+                    attrs[attr]["type"] = "other"
                 else:
-                    attrs[attr]['print'] = '{}'.format(type(res))
-                    attrs[attr]['type'] = 'other'
+                    attrs[attr]["print"] = "{}".format(type(res))
+                    attrs[attr]["type"] = "other"
 
-        output = Table(names=['Attribute', 'Description', 'Units'],
-                       dtype=[object, object, object])
+        output = Table(
+            names=["Attribute", "Description", "Units"], dtype=[object, object, object]
+        )
         idx = 0
-        types = ['int', 'str', 'float', 'list', 'array', 'other']
+        types = ["int", "str", "float", "list", "array", "other"]
         for typ in types:
             for attr, dic in attrs.items():
-                if dic['type'] == typ:
-                    output.add_row([attr, dic['print'], dic['unit']])
+                if dic["type"] == typ:
+                    output.add_row([attr, dic["print"], dic["unit"]])
                     idx += 1
-        print('lightkurve.Periodogram properties:')
+        print("lightkurve.Periodogram properties:")
         output.pprint(max_lines=-1, max_width=-1)
 
-    def to_seismology(self,**kwargs):
+    def to_seismology(self, **kwargs):
         """Returns a `~lightkurve.seismology.Seismology` object to analyze the periodogram.
 
         Returns
@@ -548,6 +587,7 @@ class Periodogram(object):
             Helper object to run asteroseismology methods.
         """
         from .seismology import Seismology
+
         return Seismology(self)
 
 
@@ -557,11 +597,12 @@ class SNRPeriodogram(Periodogram):
     This class is nearly identical to the standard :class:`Periodogram` class,
     but has different plotting defaults.
     """
+
     def __init__(self, *args, **kwargs):
         super(SNRPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return 'SNRPeriodogram(ID: {})'.format(self.label)
+        return "SNRPeriodogram(ID: {})".format(self.label)
 
     def plot(self, **kwargs):
         """Plot the SNR spectrum using matplotlib's `plot` method.
@@ -578,31 +619,42 @@ class SNRPeriodogram(Periodogram):
             The matplotlib axes object.
         """
         ax = super(SNRPeriodogram, self).plot(**kwargs)
-        if 'ylabel' not in kwargs:
+        if "ylabel" not in kwargs:
             ax.set_ylabel("Signal to Noise Ratio (SNR)")
         return ax
+
 
 class LombScarglePeriodogram(Periodogram):
     """Subclass of :class:`Periodogram <lightkurve.periodogram.Periodogram>`
     representing a power spectrum generated using the Lomb Scargle method.
     """
+
     def __init__(self, *args, **kwargs):
         self._LS_object = kwargs.pop("ls_obj", None)
         self.nterms = kwargs.pop("nterms", 1)
-        self.ls_method = kwargs.pop("ls_method", 'fastchi2')
+        self.ls_method = kwargs.pop("ls_method", "fastchi2")
         super(LombScarglePeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('LombScarglePeriodogram(ID: {})'.format(self.label))
-
+        return "LombScarglePeriodogram(ID: {})".format(self.label)
 
     @staticmethod
-    def from_lightcurve(lc, minimum_frequency=None, maximum_frequency=None,
-                        minimum_period=None, maximum_period=None,
-                        frequency=None, period=None,
-                        nterms=1, nyquist_factor=1, oversample_factor=None,
-                        freq_unit=None, normalization="amplitude", ls_method='fast',
-                        **kwargs):
+    def from_lightcurve(
+        lc,
+        minimum_frequency=None,
+        maximum_frequency=None,
+        minimum_period=None,
+        maximum_period=None,
+        frequency=None,
+        period=None,
+        nterms=1,
+        nyquist_factor=1,
+        oversample_factor=None,
+        freq_unit=None,
+        normalization="amplitude",
+        ls_method="fast",
+        **kwargs
+    ):
         """Creates a `Periodogram` from a LightCurve using the Lomb-Scargle method.
 
         By default, the periodogram will be created for a regular grid of
@@ -731,83 +783,106 @@ class LombScarglePeriodogram(Periodogram):
             Returns a Periodogram object extracted from the lightcurve.
         """
         # Input validation
-        normalization = validate_method(normalization, ['psd', 'amplitude'])
+        normalization = validate_method(normalization, ["psd", "amplitude"])
         if np.isnan(lc.flux).any():
             lc = lc.remove_nans()
-            log.debug('Lightcurve contains NaN values.'
-                      'These are removed before creating the periodogram.')
+            log.debug(
+                "Lightcurve contains NaN values."
+                "These are removed before creating the periodogram."
+            )
 
         # Setting default frequency units
         if freq_unit is None:
-            freq_unit = 1/u.day if normalization == 'amplitude' else u.microhertz
+            freq_unit = 1 / u.day if normalization == "amplitude" else u.microhertz
 
         # Default oversample factor
         if oversample_factor is None:
-            oversample_factor = 5. if normalization == 'amplitude' else 1.
+            oversample_factor = 5.0 if normalization == "amplitude" else 1.0
 
         if "min_period" in kwargs:
-            warnings.warn("`min_period` keyword is deprecated, "
-                          "please use `minimum_period` instead.",
-                          LightkurveWarning)
+            warnings.warn(
+                "`min_period` keyword is deprecated, "
+                "please use `minimum_period` instead.",
+                LightkurveWarning,
+            )
             minimum_period = kwargs.pop("min_period", None)
         if "max_period" in kwargs:
-            warnings.warn("`max_period` keyword is deprecated, "
-                          "please use `maximum_period` instead.",
-                          LightkurveWarning)
+            warnings.warn(
+                "`max_period` keyword is deprecated, "
+                "please use `maximum_period` instead.",
+                LightkurveWarning,
+            )
             maximum_period = kwargs.pop("max_period", None)
         if "min_frequency" in kwargs:
-            warnings.warn("`min_frequency` keyword is deprecated, "
-                          "please use `minimum_frequency` instead.",
-                          LightkurveWarning)
+            warnings.warn(
+                "`min_frequency` keyword is deprecated, "
+                "please use `minimum_frequency` instead.",
+                LightkurveWarning,
+            )
             minimum_frequency = kwargs.pop("min_frequency", None)
         if "max_frequency" in kwargs:
-            warnings.warn("`max_frequency` keyword is deprecated, "
-                          "please use `maximum_frequency` instead.",
-                          LightkurveWarning)
+            warnings.warn(
+                "`max_frequency` keyword is deprecated, "
+                "please use `maximum_frequency` instead.",
+                LightkurveWarning,
+            )
             maximum_frequency = kwargs.pop("max_frequency", None)
 
         # Check if any values of period have been passed and set format accordingly
         if not all(b is None for b in [period, minimum_period, maximum_period]):
-            default_view = 'period'
+            default_view = "period"
         else:
-            default_view = 'frequency'
+            default_view = "frequency"
 
         # If period and frequency keywords have both been set, throw an error
-        if (not all(b is None for b in [period, minimum_period, maximum_period])) & \
-           (not all(b is None for b in [frequency, minimum_frequency, maximum_frequency])):
-            raise ValueError('You have input keyword arguments for both frequency and period. '
-                             'Please only use one.')
+        if (not all(b is None for b in [period, minimum_period, maximum_period])) & (
+            not all(
+                b is None for b in [frequency, minimum_frequency, maximum_frequency]
+            )
+        ):
+            raise ValueError(
+                "You have input keyword arguments for both frequency and period. "
+                "Please only use one."
+            )
 
         time = lc.time.copy()
 
         # Approximate Nyquist Frequency and frequency bin width in terms of days
-        nyquist = 0.5 * (1./(np.median(np.diff(time.value)))) * (1/cds.d)
-        fs = (1./(time[-1] - time[0])) / oversample_factor
+        nyquist = 0.5 * (1.0 / (np.median(np.diff(time.value)))) * (1 / cds.d)
+        fs = (1.0 / (time[-1] - time[0])) / oversample_factor
 
         # Convert these values to requested frequency unit
         nyquist = nyquist.to(freq_unit)
         fs = fs.to(freq_unit)
 
         # Warn if there is confusing input
-        if (frequency is not None) & (any([a is not None for a in [minimum_frequency, maximum_frequency]])):
-            log.warning("You have passed both a grid of frequencies "
-                        "and min_frequency/maximum_frequency arguments; "
-                        "the latter will be ignored.")
-        if (period is not None) & (any([a is not None for a in [minimum_period, maximum_period]])):
-            log.warning("You have passed a grid of periods "
-                        "and minimum_period/maximum_period arguments; "
-                        "the latter will be ignored.")
+        if (frequency is not None) & (
+            any([a is not None for a in [minimum_frequency, maximum_frequency]])
+        ):
+            log.warning(
+                "You have passed both a grid of frequencies "
+                "and min_frequency/maximum_frequency arguments; "
+                "the latter will be ignored."
+            )
+        if (period is not None) & (
+            any([a is not None for a in [minimum_period, maximum_period]])
+        ):
+            log.warning(
+                "You have passed a grid of periods "
+                "and minimum_period/maximum_period arguments; "
+                "the latter will be ignored."
+            )
 
         # Tidy up the period stuff...
         if maximum_period is not None:
             # minimum_frequency MUST be none by this point.
-            minimum_frequency = 1. / maximum_period
+            minimum_frequency = 1.0 / maximum_period
         if minimum_period is not None:
             # maximum_frequency MUST be none by this point.
-            maximum_frequency = 1. / minimum_period
+            maximum_frequency = 1.0 / minimum_period
         # If the user specified a period, copy it into the frequency.
-        if (period is not None):
-            frequency = 1. / period
+        if period is not None:
+            frequency = 1.0 / period
 
         # Do unit conversions if user input min/max frequency or period
         if frequency is None:
@@ -816,11 +891,15 @@ class LombScarglePeriodogram(Periodogram):
             if maximum_frequency is not None:
                 maximum_frequency = u.Quantity(maximum_frequency, freq_unit)
             if (minimum_frequency is not None) & (maximum_frequency is not None):
-                if (minimum_frequency > maximum_frequency):
-                    if default_view == 'frequency':
-                        raise ValueError('minimum_frequency cannot be larger than maximum_frequency')
-                    if default_view == 'period':
-                        raise ValueError('minimum_period cannot be larger than maximum_period')
+                if minimum_frequency > maximum_frequency:
+                    if default_view == "frequency":
+                        raise ValueError(
+                            "minimum_frequency cannot be larger than maximum_frequency"
+                        )
+                    if default_view == "period":
+                        raise ValueError(
+                            "minimum_period cannot be larger than maximum_period"
+                        )
             # If nothing has been passed in, set them to the defaults
             if minimum_frequency is None:
                 minimum_frequency = fs
@@ -828,50 +907,69 @@ class LombScarglePeriodogram(Periodogram):
                 maximum_frequency = nyquist * nyquist_factor
 
             # Create frequency grid evenly spaced in frequency
-            frequency = np.arange(minimum_frequency.value, maximum_frequency.value, fs.value)
+            frequency = np.arange(
+                minimum_frequency.value, maximum_frequency.value, fs.value
+            )
 
         # Convert to desired units
         frequency = u.Quantity(frequency, freq_unit)
 
         # Change to compatible ls method if sampling not even in frequency
-        if not implementations.main._is_regular(frequency) and ls_method in ['fastchi2','fast']:
+        if not implementations.main._is_regular(frequency) and ls_method in [
+            "fastchi2",
+            "fast",
+        ]:
             oldmethod = ls_method
-            ls_method = {'fastchi2':'chi2','fast':'slow'}[ls_method]
-            log.warning("The requested periodogram is not evenly sampled in frequency.\n"
-                        "Method has been changed from '{}' to '{}' to allow for this.".format(oldmethod,ls_method))
+            ls_method = {"fastchi2": "chi2", "fast": "slow"}[ls_method]
+            log.warning(
+                "The requested periodogram is not evenly sampled in frequency.\n"
+                "Method has been changed from '{}' to '{}' to allow for this.".format(
+                    oldmethod, ls_method
+                )
+            )
 
-        if (nterms > 1) and (ls_method not in ['fastchi2', 'chi2']):
-            warnings.warn("Building a Lomb Scargle Periodogram using the `slow` method. "
-                            "`nterms` has been set to >1, however this is not supported under the `{}` method. "
-                            "To run with higher nterms, set `ls_method` to either 'fastchi2', or 'chi2'. "
-                            "Please refer to the `astropy.timeseries.periodogram.LombScargle` documentation.".format(ls_method),
-                          LightkurveWarning)
+        if (nterms > 1) and (ls_method not in ["fastchi2", "chi2"]):
+            warnings.warn(
+                "Building a Lomb Scargle Periodogram using the `slow` method. "
+                "`nterms` has been set to >1, however this is not supported under the `{}` method. "
+                "To run with higher nterms, set `ls_method` to either 'fastchi2', or 'chi2'. "
+                "Please refer to the `astropy.timeseries.periodogram.LombScargle` documentation.".format(
+                    ls_method
+                ),
+                LightkurveWarning,
+            )
             nterms = 1
 
         if float(astropy.__version__[0]) >= 3:
-            LS = LombScargle(time, lc.flux,
-                             nterms=nterms, normalization='psd', **kwargs)
+            LS = LombScargle(
+                time, lc.flux, nterms=nterms, normalization="psd", **kwargs
+            )
             power = LS.power(frequency, method=ls_method)
         else:
-            LS = LombScargle(time, lc.flux,
-                             nterms=nterms, **kwargs)
-            power = LS.power(frequency, method=ls_method, normalization='psd')
+            LS = LombScargle(time, lc.flux, nterms=nterms, **kwargs)
+            power = LS.power(frequency, method=ls_method, normalization="psd")
 
-        if normalization == 'psd':  # Power spectral density
+        if normalization == "psd":  # Power spectral density
             # Rescale from the unnormalized power output by Astropy's
             # Lomb-Scargle function to units of flux_variance / [frequency unit]
             # that may be of more interest for asteroseismology.
-            power *=  2. / (len(time) * oversample_factor * fs)
-        elif normalization == 'amplitude':
-            power = np.sqrt(power) * np.sqrt(4./len(lc.time))
+            power *= 2.0 / (len(time) * oversample_factor * fs)
+        elif normalization == "amplitude":
+            power = np.sqrt(power) * np.sqrt(4.0 / len(lc.time))
 
         # Periodogram needs properties
-        return LombScarglePeriodogram(frequency=frequency, power=power, nyquist=nyquist,
-                                      targetid=lc.meta.get('TARGETID'),
-                                      label=lc.meta.get('LABEL'),
-                                      default_view=default_view, ls_obj=LS,
-                                      nterms=nterms, ls_method=ls_method,
-                                      meta=lc.meta)
+        return LombScarglePeriodogram(
+            frequency=frequency,
+            power=power,
+            nyquist=nyquist,
+            targetid=lc.meta.get("TARGETID"),
+            label=lc.meta.get("LABEL"),
+            default_view=default_view,
+            ls_obj=LS,
+            nterms=nterms,
+            ls_method=ls_method,
+            meta=lc.meta,
+        )
 
     def model(self, time, frequency=None):
         """Obtain the flux model for a given frequency and time
@@ -889,15 +987,17 @@ class LombScarglePeriodogram(Periodogram):
             Model object with the time and flux model
         """
         if self._LS_object is None:
-            raise ValueError('No `astropy` Lomb Scargle object exists.')
+            raise ValueError("No `astropy` Lomb Scargle object exists.")
         if frequency is None:
             frequency = self.frequency_at_max_power
         f = self._LS_object.model(time, frequency)
-        lc = LightCurve(time=time,
-                        flux=f,
-                        meta={'FREQUENCY':frequency},
-                        label='LS Model',
-                        targetid='{} LS Model'.format(self.targetid))
+        lc = LightCurve(
+            time=time,
+            flux=f,
+            meta={"FREQUENCY": frequency},
+            label="LS Model",
+            targetid="{} LS Model".format(self.targetid),
+        )
         return lc.normalize()
 
 
@@ -905,6 +1005,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
     """Subclass of :class:`Periodogram <lightkurve.periodogram.Periodogram>`
     representing a power spectrum generated using the Box Least Squares (BLS) method.
     """
+
     def __init__(self, *args, **kwargs):
         self.duration = kwargs.pop("duration", None)
         self.depth = kwargs.pop("depth", None)
@@ -919,7 +1020,7 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         super(BoxLeastSquaresPeriodogram, self).__init__(*args, **kwargs)
 
     def __repr__(self):
-        return('BoxLeastSquaresPeriodogram(ID: {})'.format(self.label))
+        return "BoxLeastSquaresPeriodogram(ID: {})".format(self.label)
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):
@@ -992,7 +1093,9 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         # Validate user input for `duration`
         duration = kwargs.pop("duration", [0.05, 0.10, 0.15, 0.20, 0.25, 0.33])
         if duration is not None and ~np.all(np.isfinite(duration)):
-            raise ValueError("`duration` parameter contains illegal nan or inf value(s)")
+            raise ValueError(
+                "`duration` parameter contains illegal nan or inf value(s)"
+            )
 
         # Validate user input for `period`
         period = kwargs.pop("period", None)
@@ -1002,43 +1105,59 @@ class BoxLeastSquaresPeriodogram(Periodogram):
             raise ValueError("`period` parameter contains illegal nan or inf value(s)")
         if minimum_period is None:
             if period is None:
-                minimum_period = np.max([np.median(np.diff(lc.time.value)) * 4,
-                                         np.max(duration) + np.median(np.diff(lc.time.value))])
+                minimum_period = np.max(
+                    [
+                        np.median(np.diff(lc.time.value)) * 4,
+                        np.max(duration) + np.median(np.diff(lc.time.value)),
+                    ]
+                )
             else:
                 minimum_period = np.min(period)
         if maximum_period is None:
             if period is None:
-                maximum_period = (np.max(lc.time.value) - np.min(lc.time.value)) / 3.
+                maximum_period = (np.max(lc.time.value) - np.min(lc.time.value)) / 3.0
             else:
                 maximum_period = np.max(period)
 
         # Validate user input for `time_unit`
-        time_unit = (kwargs.pop("time_unit", "day"))
+        time_unit = kwargs.pop("time_unit", "day")
         if time_unit not in dir(u):
-            raise ValueError('{} is not a valid value for `time_unit`'.format(time_unit))
+            raise ValueError(
+                "{} is not a valid value for `time_unit`".format(time_unit)
+            )
 
         # Validate user input for `frequency_factor`
         frequency_factor = kwargs.pop("frequency_factor", 10)
-        df = frequency_factor * np.min(duration) / (np.max(lc.time.value) - np.min(lc.time.value))**2
-        npoints = int(((1/minimum_period) - (1/maximum_period))/df)
+        df = (
+            frequency_factor
+            * np.min(duration)
+            / (np.max(lc.time.value) - np.min(lc.time.value)) ** 2
+        )
+        npoints = int(((1 / minimum_period) - (1 / maximum_period)) / df)
         if npoints > 1e7:
-            raise ValueError('`period` contains {} points.'
-                             'Periodogram is too large to evaluate. '
-                             'Consider setting `frequency_factor` to a higher value.'
-                             ''.format(np.round(npoints, 4)))
+            raise ValueError(
+                "`period` contains {} points."
+                "Periodogram is too large to evaluate. "
+                "Consider setting `frequency_factor` to a higher value."
+                "".format(np.round(npoints, 4))
+            )
         elif npoints > 1e5:
-            log.warning('`period` contains {} points.'
-                        'Periodogram is likely to be large, and slow to evaluate. '
-                        'Consider setting `frequency_factor` to a higher value.'
-                        ''.format(np.round(npoints, 4)))
+            log.warning(
+                "`period` contains {} points."
+                "Periodogram is likely to be large, and slow to evaluate. "
+                "Consider setting `frequency_factor` to a higher value."
+                "".format(np.round(npoints, 4))
+            )
 
         # Create BLS object and run the BLS search
         bls = BoxLeastSquares(lc.time, lc.flux, dy)
         if period is None:
-            period = bls.autoperiod(duration,
-                                    minimum_period=minimum_period,
-                                    maximum_period=maximum_period,
-                                    frequency_factor=frequency_factor)
+            period = bls.autoperiod(
+                duration,
+                minimum_period=minimum_period,
+                maximum_period=maximum_period,
+                frequency_factor=frequency_factor,
+            )
         result = bls.power(period, duration, **kwargs)
         if not isinstance(result.period, u.quantity.Quantity):
             result.period = u.Quantity(result.period, time_unit)
@@ -1047,20 +1166,22 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         if not isinstance(result.duration, u.quantity.Quantity):
             result.duration = u.Quantity(result.duration, time_unit)
 
-        return BoxLeastSquaresPeriodogram(frequency=1. / result.period,
-                                          power=result.power,
-                                          default_view='period',
-                                          label=lc.meta.get('LABEL'),
-                                          targetid=lc.meta.get('TARGETID'),
-                                          transit_time=result.transit_time,
-                                          duration=result.duration,
-                                          depth=result.depth,
-                                          bls_result=result,
-                                          snr=result.depth_snr,
-                                          bls_obj=bls,
-                                          time=lc.time,
-                                          flux=lc.flux,
-                                          time_unit=time_unit)
+        return BoxLeastSquaresPeriodogram(
+            frequency=1.0 / result.period,
+            power=result.power,
+            default_view="period",
+            label=lc.meta.get("LABEL"),
+            targetid=lc.meta.get("TARGETID"),
+            transit_time=result.transit_time,
+            duration=result.duration,
+            depth=result.depth,
+            bls_result=result,
+            snr=result.depth_snr,
+            bls_obj=bls,
+            time=lc.time,
+            flux=lc.flux,
+            time_unit=time_unit,
+        )
 
     def compute_stats(self, period=None, duration=None, transit_time=None):
         """Computes commonly used vetting statistics for a transit model.
@@ -1083,19 +1204,21 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         """
         if period is None:
             period = self.period_at_max_power
-            log.warning('No period specified. Using period at max power')
+            log.warning("No period specified. Using period at max power")
         if duration is None:
             duration = self.duration_at_max_power
-            log.warning('No duration specified. Using duration at max power')
+            log.warning("No duration specified. Using duration at max power")
         if transit_time is None:
             transit_time = self.transit_time_at_max_power
-            log.warning('No transit time specified. Using transit time at max power')
+            log.warning("No transit time specified. Using transit time at max power")
         if not isinstance(transit_time, Time):
-            transit_time = Time(transit_time, format=self.time.format, scale=self.time.scale)
+            transit_time = Time(
+                transit_time, format=self.time.format, scale=self.time.scale
+            )
 
-        return self._BLS_object.compute_stats(u.Quantity(period, 'd').value,
-                                              u.Quantity(duration, 'd').value,
-                                              transit_time)
+        return self._BLS_object.compute_stats(
+            u.Quantity(period, "d").value, u.Quantity(duration, "d").value, transit_time
+        )
 
     def get_transit_model(self, period=None, duration=None, transit_time=None):
         """Computes the transit model using the BLS, returns a lightkurve.LightCurve
@@ -1120,20 +1243,25 @@ class BoxLeastSquaresPeriodogram(Periodogram):
 
         if period is None:
             period = self.period_at_max_power
-            log.warning('No period specified. Using period at max power')
+            log.warning("No period specified. Using period at max power")
         if duration is None:
             duration = self.duration_at_max_power
-            log.warning('No duration specified. Using duration at max power')
+            log.warning("No duration specified. Using duration at max power")
         if transit_time is None:
             transit_time = self.transit_time_at_max_power
-            log.warning('No transit time specified. Using transit time at max power')
+            log.warning("No transit time specified. Using transit time at max power")
         if not isinstance(transit_time, Time):
-            transit_time = Time(transit_time, format=self.time.format, scale=self.time.scale)
+            transit_time = Time(
+                transit_time, format=self.time.format, scale=self.time.scale
+            )
 
-        model_flux = self._BLS_object.model(self.time, u.Quantity(period, 'd').value,
-                                            u.Quantity(duration, 'd').value,
-                                            transit_time)
-        model = LightCurve(time=self.time, flux=model_flux, label='Transit Model Flux')
+        model_flux = self._BLS_object.model(
+            self.time,
+            u.Quantity(period, "d").value,
+            u.Quantity(duration, "d").value,
+            transit_time,
+        )
+        model = LightCurve(time=self.time, flux=model_flux, label="Transit Model Flux")
         return model
 
     def get_transit_mask(self, period=None, duration=None, transit_time=None):
@@ -1154,7 +1282,9 @@ class BoxLeastSquaresPeriodogram(Periodogram):
         transit_mask : np.array of bool
             Mask that flags transits. Mask is ``True`` where there are transits.
         """
-        model = self.get_transit_model(period=period, duration=duration, transit_time=transit_time)
+        model = self.get_transit_model(
+            period=period, duration=duration, transit_time=transit_time
+        )
         return model.flux != np.median(model.flux)
 
     @property
@@ -1187,12 +1317,16 @@ class BoxLeastSquaresPeriodogram(Periodogram):
             The matplotlib axes object.
         """
         ax = super(BoxLeastSquaresPeriodogram, self).plot(**kwargs)
-        if 'ylabel' not in kwargs:
+        if "ylabel" not in kwargs:
             ax.set_ylabel("BLS Power")
         return ax
 
     def flatten(self, **kwargs):
-        raise NotImplementedError('`flatten` is not implemented for `BoxLeastSquaresPeriodogram`.')
+        raise NotImplementedError(
+            "`flatten` is not implemented for `BoxLeastSquaresPeriodogram`."
+        )
 
     def smooth(self, **kwargs):
-        raise NotImplementedError('`smooth` is not implemented for `BoxLeastSquaresPeriodogram`. ')
+        raise NotImplementedError(
+            "`smooth` is not implemented for `BoxLeastSquaresPeriodogram`. "
+        )

--- a/src/lightkurve/prf/prfmodel.py
+++ b/src/lightkurve/prf/prfmodel.py
@@ -11,7 +11,7 @@ import scipy.interpolate
 from ..utils import channel_to_module_output, plot_image
 
 
-__all__ = ['KeplerPRF', 'SimpleKeplerPRF']
+__all__ = ["KeplerPRF", "SimpleKeplerPRF"]
 
 
 class KeplerPRF(object):
@@ -63,15 +63,29 @@ class KeplerPRF(object):
         self.shape = shape
         self.column = column
         self.row = row
-        self.col_coord, self.row_coord, self.interpolate, self.supersampled_prf = self._prepare_prf()
+        (
+            self.col_coord,
+            self.row_coord,
+            self.interpolate,
+            self.supersampled_prf,
+        ) = self._prepare_prf()
 
-    def __call__(self, center_col, center_row, flux, scale_col, scale_row,
-                 rotation_angle):
-        return self.evaluate(center_col, center_row, flux,
-                             scale_col, scale_row, rotation_angle)
+    def __call__(
+        self, center_col, center_row, flux, scale_col, scale_row, rotation_angle
+    ):
+        return self.evaluate(
+            center_col, center_row, flux, scale_col, scale_row, rotation_angle
+        )
 
-    def evaluate(self, center_col, center_row, flux=1., scale_col=1., scale_row=1.,
-                 rotation_angle=0.):
+    def evaluate(
+        self,
+        center_col,
+        center_row,
+        flux=1.0,
+        scale_col=1.0,
+        scale_row=1.0,
+        rotation_angle=0.0,
+    ):
         """
         Interpolates the PRF model onto detector coordinates.
 
@@ -104,13 +118,20 @@ class KeplerPRF(object):
         rot_row = delta_row * cosa - delta_col * sina
         rot_col = delta_row * sina + delta_col * cosa
 
-        self.prf_model = flux * self.interpolate(rot_row.flatten() * scale_row,
-                                                 rot_col.flatten() * scale_col,
-                                                 grid=False).reshape(self.shape)
+        self.prf_model = flux * self.interpolate(
+            rot_row.flatten() * scale_row, rot_col.flatten() * scale_col, grid=False
+        ).reshape(self.shape)
         return self.prf_model
 
-    def gradient(self, center_col, center_row, flux=1., scale_col=1., scale_row=1.,
-                 rotation_angle=0.):
+    def gradient(
+        self,
+        center_col,
+        center_row,
+        flux=1.0,
+        scale_col=1.0,
+        scale_row=1.0,
+        rotation_angle=0.0,
+    ):
         """
         This function returns the gradient of the KeplerPRF model with
         respect to center_col, center_row, flux, scale_col, scale_row,
@@ -148,39 +169,57 @@ class KeplerPRF(object):
 
         # for a proof of the maths that follow, see the pdf attached
         # on pull request #198 in lightkurve GitHub repo.
-        deriv_flux = self.interpolate(rot_row.flatten() * scale_row,
-                                      rot_col.flatten() * scale_col,
-                                      grid=False).reshape(self.shape)
+        deriv_flux = self.interpolate(
+            rot_row.flatten() * scale_row, rot_col.flatten() * scale_col, grid=False
+        ).reshape(self.shape)
 
-        interp_dy = self.interpolate(rot_row.flatten() * scale_row,
-                                     rot_col.flatten() * scale_col,
-                                     grid=False, dy=1).reshape(self.shape)
+        interp_dy = self.interpolate(
+            rot_row.flatten() * scale_row,
+            rot_col.flatten() * scale_col,
+            grid=False,
+            dy=1,
+        ).reshape(self.shape)
 
-        interp_dx = self.interpolate(rot_row.flatten() * scale_row,
-                                     rot_col.flatten() * scale_col,
-                                     grid=False, dx=1).reshape(self.shape)
+        interp_dx = self.interpolate(
+            rot_row.flatten() * scale_row,
+            rot_col.flatten() * scale_col,
+            grid=False,
+            dx=1,
+        ).reshape(self.shape)
 
         scale_row_times_interp_dx = scale_row * interp_dx
         scale_col_times_interp_dy = scale_col * interp_dy
 
-        deriv_center_col = - flux * (cosa * scale_col_times_interp_dy - sina * scale_row_times_interp_dx)
-        deriv_center_row = - flux * (sina * scale_col_times_interp_dy + cosa * scale_row_times_interp_dx)
+        deriv_center_col = -flux * (
+            cosa * scale_col_times_interp_dy - sina * scale_row_times_interp_dx
+        )
+        deriv_center_row = -flux * (
+            sina * scale_col_times_interp_dy + cosa * scale_row_times_interp_dx
+        )
         deriv_scale_row = flux * interp_dx * rot_row
         deriv_scale_col = flux * interp_dy * rot_col
-        deriv_rotation_angle = flux * (interp_dy * scale_col * (delta_row * cosa - delta_col * sina)
-                                       - interp_dx * scale_row * (delta_row * sina + delta_col * cosa))
+        deriv_rotation_angle = flux * (
+            interp_dy * scale_col * (delta_row * cosa - delta_col * sina)
+            - interp_dx * scale_row * (delta_row * sina + delta_col * cosa)
+        )
 
-        return [deriv_center_col, deriv_center_row, deriv_flux,
-                deriv_scale_col, deriv_scale_row, deriv_rotation_angle]
+        return [
+            deriv_center_col,
+            deriv_center_row,
+            deriv_flux,
+            deriv_scale_col,
+            deriv_scale_row,
+            deriv_rotation_angle,
+        ]
 
     def _read_prf_calibration_file(self, path, ext):
         prf_cal_file = pyfits.open(path)
         data = prf_cal_file[ext].data
         # looks like these data below are the same for all prf calibration files
-        crval1p = prf_cal_file[ext].header['CRVAL1P']
-        crval2p = prf_cal_file[ext].header['CRVAL2P']
-        cdelt1p = prf_cal_file[ext].header['CDELT1P']
-        cdelt2p = prf_cal_file[ext].header['CDELT2P']
+        crval1p = prf_cal_file[ext].header["CRVAL1P"]
+        crval2p = prf_cal_file[ext].header["CRVAL2P"]
+        cdelt1p = prf_cal_file[ext].header["CDELT1P"]
+        cdelt2p = prf_cal_file[ext].header["CDELT2P"]
         prf_cal_file.close()
 
         return data, crval1p, crval2p, cdelt1p, cdelt2p
@@ -191,22 +230,34 @@ class KeplerPRF(object):
         module, output = channel_to_module_output(self.channel)
         # determine suitable PRF calibration file
         if module < 10:
-            prefix = 'kplr0'
+            prefix = "kplr0"
         else:
-            prefix = 'kplr'
+            prefix = "kplr"
         prfs_url_path = "http://archive.stsci.edu/missions/kepler/fpc/prf/"
-        prffile = prfs_url_path + prefix + str(module) + '.' + str(output) + '_2011265_prf.fits'
+        prffile = (
+            prfs_url_path
+            + prefix
+            + str(module)
+            + "."
+            + str(output)
+            + "_2011265_prf.fits"
+        )
 
         # read PRF images
         prfn = [0] * n_hdu
-        crval1p = np.zeros(n_hdu, dtype='float32')
-        crval2p = np.zeros(n_hdu, dtype='float32')
-        cdelt1p = np.zeros(n_hdu, dtype='float32')
-        cdelt2p = np.zeros(n_hdu, dtype='float32')
+        crval1p = np.zeros(n_hdu, dtype="float32")
+        crval2p = np.zeros(n_hdu, dtype="float32")
+        cdelt1p = np.zeros(n_hdu, dtype="float32")
+        cdelt2p = np.zeros(n_hdu, dtype="float32")
 
         for i in range(n_hdu):
-            prfn[i], crval1p[i], crval2p[i], cdelt1p[i], cdelt2p[i] = self._read_prf_calibration_file(
-                prffile, i+1)
+            (
+                prfn[i],
+                crval1p[i],
+                crval2p[i],
+                cdelt1p[i],
+                cdelt2p[i],
+            ) = self._read_prf_calibration_file(prffile, i + 1)
 
         prfn = np.array(prfn)
         PRFcol = np.arange(0.5, np.shape(prfn[0])[1] + 0.5)
@@ -216,22 +267,23 @@ class KeplerPRF(object):
 
         # interpolate the calibrated PRF shape to the target position
         rowdim, coldim = self.shape[0], self.shape[1]
-        prf = np.zeros(np.shape(prfn[0]), dtype='float32')
-        ref_column = self.column + .5 * coldim
-        ref_row = self.row + .5 * rowdim
+        prf = np.zeros(np.shape(prfn[0]), dtype="float32")
+        ref_column = self.column + 0.5 * coldim
+        ref_row = self.row + 0.5 * rowdim
 
         for i in range(n_hdu):
-            prf_weight = math.sqrt((ref_column - crval1p[i]) ** 2
-                                   + (ref_row - crval2p[i]) ** 2)
+            prf_weight = math.sqrt(
+                (ref_column - crval1p[i]) ** 2 + (ref_row - crval2p[i]) ** 2
+            )
             if prf_weight < min_prf_weight:
                 prf_weight = min_prf_weight
             prf += prfn[i] / prf_weight
 
-        prf /= (np.nansum(prf) * cdelt1p[0] * cdelt2p[0])
+        prf /= np.nansum(prf) * cdelt1p[0] * cdelt2p[0]
 
         # location of the data image centered on the PRF image (in PRF pixel units)
-        col_coord = np.arange(self.column + .5, self.column + coldim + .5)
-        row_coord = np.arange(self.row + .5, self.row + rowdim + .5)
+        col_coord = np.arange(self.column + 0.5, self.column + coldim + 0.5)
+        row_coord = np.arange(self.row + 0.5, self.row + rowdim + 0.5)
         # x-axis correspond to row-axis in scipy.RectBivariate
         # not to be confused with our convention, in which the
         # x-axis correspond to the column-axis
@@ -241,9 +293,17 @@ class KeplerPRF(object):
 
     def plot(self, *params, **kwargs):
         pflux = self.evaluate(*params)
-        plot_image(pflux, title='Kepler PRF Model, Channel: {}'.format(self.channel),
-                   extent=(self.column, self.column + self.shape[1],
-                           self.row, self.row + self.shape[0]), **kwargs)
+        plot_image(
+            pflux,
+            title="Kepler PRF Model, Channel: {}".format(self.channel),
+            extent=(
+                self.column,
+                self.column + self.shape[1],
+                self.row,
+                self.row + self.shape[0],
+            ),
+            **kwargs
+        )
 
 
 class SimpleKeplerPRF(KeplerPRF):
@@ -255,10 +315,10 @@ class SimpleKeplerPRF(KeplerPRF):
     and angle are fixed to 1.0 and 0, respectivelly.
     """
 
-    def __call__(self, center_col, center_row, flux=1.):
+    def __call__(self, center_col, center_row, flux=1.0):
         return self.evaluate(center_col, center_row, flux)
 
-    def evaluate(self, center_col, center_row, flux=1.):
+    def evaluate(self, center_col, center_row, flux=1.0):
         """
         Interpolates the PRF model onto detector coordinates.
 
@@ -304,7 +364,7 @@ class SimpleKeplerPRF(KeplerPRF):
         delta_row = self.row_coord - center_row
 
         deriv_flux = self.interpolate(delta_row, delta_col)
-        deriv_center_col = - flux * self.interpolate(delta_row, delta_col, dy=1)
-        deriv_center_row = - flux * self.interpolate(delta_row, delta_col, dx=1)
+        deriv_center_col = -flux * self.interpolate(delta_row, delta_col, dy=1)
+        deriv_center_row = -flux * self.interpolate(delta_row, delta_col, dx=1)
 
         return [deriv_center_col, deriv_center_row, deriv_flux]

--- a/src/lightkurve/prf/tpfmodel.py
+++ b/src/lightkurve/prf/tpfmodel.py
@@ -51,11 +51,22 @@ from .prfmodel import KeplerPRF
 from ..utils import plot_image
 
 
-__all__ = ['GaussianPrior', 'UniformPrior', 'FixedValuePrior',
-           'StarPrior', 'BackgroundPrior', 'FocusPrior', 'MotionPrior',
-           'StarParameters', 'BackgroundParameters', 'FocusParameters',
-           'MotionParameters', 'TPFModelParameters',
-           'TPFModel', 'PRFPhotometry']
+__all__ = [
+    "GaussianPrior",
+    "UniformPrior",
+    "FixedValuePrior",
+    "StarPrior",
+    "BackgroundPrior",
+    "FocusPrior",
+    "MotionPrior",
+    "StarParameters",
+    "BackgroundParameters",
+    "FocusParameters",
+    "MotionParameters",
+    "TPFModelParameters",
+    "TPFModel",
+    "PRFPhotometry",
+]
 
 
 log = logging.getLogger(__name__)
@@ -81,6 +92,7 @@ class FixedValuePrior(Prior):
     >>> fp(0.5)
     inf
     """
+
     def __init__(self, value, name=None):
         self.value = np.asarray([value]).reshape(-1)
         self.name = name
@@ -110,6 +122,7 @@ class FixedValuePrior(Prior):
 
 class PriorContainer(object):
     """Container object to hold parameter priors for PRF photometry."""
+
     def _parse_prior(self, prior):
         if isinstance(prior, Prior):
             return prior
@@ -129,6 +142,7 @@ class StarPrior(PriorContainer):
               row=GaussianPrior(mean=row, var=err_row**2),
               flux=GaussianPrior(mean=flux, var=err_flux**2))
     """
+
     def __init__(self, col, row, flux=UniformPrior(lb=0, ub=1e10), targetid=None):
         self.col = self._parse_prior(col)
         self.row = self._parse_prior(row)
@@ -136,16 +150,17 @@ class StarPrior(PriorContainer):
         self.targetid = targetid
 
     def __repr__(self):
-        return ('<StarPrior(\n  col={}\n  row={}\n  flux={}\n  targetid={})>'
-                ''.format(self.col, self.row, self.flux, self.targetid))
+        return "<StarPrior(\n  col={}\n  row={}\n  flux={}\n  targetid={})>" "".format(
+            self.col, self.row, self.flux, self.targetid
+        )
 
     def evaluate(self, col, row, flux):
         """Evaluate the prior probability of a star of a given flux being at
         a given row and col.
         """
-        logp = (self.col.evaluate(col) +
-                self.row.evaluate(row) +
-                self.flux.evaluate(flux))
+        logp = (
+            self.col.evaluate(col) + self.row.evaluate(row) + self.flux.evaluate(flux)
+        )
         return logp
 
 
@@ -157,11 +172,12 @@ class BackgroundPrior(PriorContainer):
     flux : oktopus ``Prior`` object
         Prior on the background flux in electrons/second per pixel.
     """
+
     def __init__(self, flux=FixedValuePrior(value=0)):
         self.flux = self._parse_prior(flux)
 
     def __repr__(self):
-        return ('<BackgroundPrior(\n  flux={})>'.format(self.flux))
+        return "<BackgroundPrior(\n  flux={})>".format(self.flux)
 
     def evaluate(self, flux):
         """Returns the prior probability for a given background flux value."""
@@ -178,50 +194,61 @@ class FocusPrior(PriorContainer):
     rotation_angle : oktopus ``Prior`` object
         Rotation angle in radians. Typically zero.
     """
-    def __init__(self,
-                 scale_col=GaussianPrior(mean=1, var=0.0001),
-                 scale_row=GaussianPrior(mean=1, var=0.0001),
-                 rotation_angle=UniformPrior(lb=-3.1415, ub=3.1415)):
+
+    def __init__(
+        self,
+        scale_col=GaussianPrior(mean=1, var=0.0001),
+        scale_row=GaussianPrior(mean=1, var=0.0001),
+        rotation_angle=UniformPrior(lb=-3.1415, ub=3.1415),
+    ):
         self.scale_col = self._parse_prior(scale_col)
         self.scale_row = self._parse_prior(scale_row)
         self.rotation_angle = self._parse_prior(rotation_angle)
 
     def __repr__(self):
-        return ('<FocusPrior(\n  scale_col={}\n  scale_row={}\n  rotation_angle={})>'
-                ''.format(self.scale_col, self.scale_row, self.rotation_angle))
+        return (
+            "<FocusPrior(\n  scale_col={}\n  scale_row={}\n  rotation_angle={})>"
+            "".format(self.scale_col, self.scale_row, self.rotation_angle)
+        )
 
     def evaluate(self, scale_col, scale_row, rotation_angle):
         """Returns the prior probability for a gien set of focus parameters."""
-        logp = (self.scale_col.evaluate(scale_col) +
-                self.scale_row.evaluate(scale_row) +
-                self.rotation_angle.evaluate(rotation_angle))
+        logp = (
+            self.scale_col.evaluate(scale_col)
+            + self.scale_row.evaluate(scale_row)
+            + self.rotation_angle.evaluate(rotation_angle)
+        )
         return logp
 
 
 class MotionPrior(PriorContainer):
-    """Container class to capture a user's beliefs about the telescope motion.
-    """
-    def __init__(self, shift_col=GaussianPrior(mean=0, var=1.**2),
-                 shift_row=GaussianPrior(mean=0, var=1.**2)):
+    """Container class to capture a user's beliefs about the telescope motion."""
+
+    def __init__(
+        self,
+        shift_col=GaussianPrior(mean=0, var=1.0 ** 2),
+        shift_row=GaussianPrior(mean=0, var=1.0 ** 2),
+    ):
         self.shift_col = self._parse_prior(shift_col)
         self.shift_row = self._parse_prior(shift_row)
 
     def __repr__(self):
-        return ('<MotionPrior(\n  shift_col={}\n  shift_row={})>'
-                ''.format(self.shift_col, self.shift_row))
+        return "<MotionPrior(\n  shift_col={}\n  shift_row={})>" "".format(
+            self.shift_col, self.shift_row
+        )
 
     def evaluate(self, shift_col, shift_row):
         """Returns the prior probability for a gien set of motion parameters."""
-        logp = (self.shift_col.evaluate(shift_col) +
-                self.shift_row.evaluate(shift_row))
+        logp = self.shift_col.evaluate(shift_col) + self.shift_row.evaluate(shift_row)
         return logp
 
 
 class StarParameters(object):
-    """Container class to hold the parameters of a star in a ``TPFModel``.
-    """
-    def __init__(self, col, row, flux, err_col=None, err_row=None, err_flux=None,
-                 targetid=None):
+    """Container class to hold the parameters of a star in a ``TPFModel``."""
+
+    def __init__(
+        self, col, row, flux, err_col=None, err_row=None, err_flux=None, targetid=None
+    ):
         self.col = col
         self.row = row
         self.flux = flux
@@ -229,51 +256,57 @@ class StarParameters(object):
 
     def __repr__(self):
         r = "<StarParameters(\n  col={}\n  row={}\n  flux={}\n  targetid={})>".format(
-                    self.col, self.row, self.flux, self.targetid)
+            self.col, self.row, self.flux, self.targetid
+        )
         return r
 
 
 class BackgroundParameters(object):
-    """Container class to hold the parameters of the background in a ``TPFModel``.
-    """
-    def __init__(self, flux=0., err_flux=None, fitted=True):
+    """Container class to hold the parameters of the background in a ``TPFModel``."""
+
+    def __init__(self, flux=0.0, err_flux=None, fitted=True):
         self.flux = flux
         self.err_flux = err_flux
         self.fitted = fitted
 
     def __repr__(self):
         r = "<BackgroundParameters(\n  flux={}\n  fitted={})>".format(
-                    self.flux, self.fitted)
+            self.flux, self.fitted
+        )
         return r
 
 
 class FocusParameters(object):
-    """Container class to hold the parameters of the telescope focus in a ``TPFModel``.
-    """
-    def __init__(self, scale_col=1., scale_row=1., rotation_angle=0., fitted=False):
+    """Container class to hold the parameters of the telescope focus in a ``TPFModel``."""
+
+    def __init__(self, scale_col=1.0, scale_row=1.0, rotation_angle=0.0, fitted=False):
         self.scale_col = scale_col
         self.scale_row = scale_row
         self.rotation_angle = rotation_angle
         self.fitted = fitted
 
     def __repr__(self):
-        return ("<FocusParameters(\n  scale_col={}\n  scale_row={}\n  "
-                "rotation_angle={}\n  fitted={})>"
-                "".format(self.scale_col, self.scale_row,
-                          self.rotation_angle, self.fitted))
+        return (
+            "<FocusParameters(\n  scale_col={}\n  scale_row={}\n  "
+            "rotation_angle={}\n  fitted={})>"
+            "".format(self.scale_col, self.scale_row, self.rotation_angle, self.fitted)
+        )
 
 
 class MotionParameters(object):
-    """Container class to hold the parameters of the telescope motion in a ``TPFModel``.
-    """
-    def __init__(self, shift_col=0., shift_row=0., fitted=False):
+    """Container class to hold the parameters of the telescope motion in a ``TPFModel``."""
+
+    def __init__(self, shift_col=0.0, shift_row=0.0, fitted=False):
         self.shift_col = shift_col
         self.shift_row = shift_row
         self.fitted = fitted
 
     def __repr__(self):
-        return "<MotionParameters(\n  shift_col={}\n  shift_row={}\n  fitted={})>".format(
-                    self.shift_col, self.shift_row, self.fitted)
+        return (
+            "<MotionParameters(\n  shift_col={}\n  shift_row={}\n  fitted={})>".format(
+                self.shift_col, self.shift_row, self.fitted
+            )
+        )
 
 
 class TPFModelParameters(object):
@@ -290,8 +323,14 @@ class TPFModelParameters(object):
     motion : ``MotionParameters`` object
         Parameters related to the telescope motion.
     """
-    def __init__(self, stars=None, background=BackgroundParameters(),
-                 focus=FocusParameters(), motion=MotionParameters()):
+
+    def __init__(
+        self,
+        stars=None,
+        background=BackgroundParameters(),
+        focus=FocusParameters(),
+        motion=MotionParameters(),
+    ):
         if stars is None:
             stars = []
         self.stars = stars
@@ -300,18 +339,21 @@ class TPFModelParameters(object):
         self.motion = motion
 
     def __repr__(self):
-        out = super(TPFModelParameters, self).__repr__() + '\n'
-        out += ''.join(['  {}\n'.format(str(star).replace('\n', '\n  '))
-                        for star in self.stars])
-        out += '  ' + str(self.background).replace('\n', '\n  ') + '\n'
-        out += '  ' + str(self.focus).replace('\n', '\n  ') + '\n'
-        out += '  ' + str(self.motion).replace('\n', '\n  ') + '\n'
-        if 'residual_image' in vars(self):
-            out += '  residual_image:\n    {}'.format(self.residual_image[0][0:4])[:-1]
-            out += '...\n'
-        if 'predicted_image' in vars(self):
-            out += '  predicted_image:\n    {}'.format(self.predicted_image[0][0:4])[:-1]
-            out += '...\n'
+        out = super(TPFModelParameters, self).__repr__() + "\n"
+        out += "".join(
+            ["  {}\n".format(str(star).replace("\n", "\n  ")) for star in self.stars]
+        )
+        out += "  " + str(self.background).replace("\n", "\n  ") + "\n"
+        out += "  " + str(self.focus).replace("\n", "\n  ") + "\n"
+        out += "  " + str(self.motion).replace("\n", "\n  ") + "\n"
+        if "residual_image" in vars(self):
+            out += "  residual_image:\n    {}".format(self.residual_image[0][0:4])[:-1]
+            out += "...\n"
+        if "predicted_image" in vars(self):
+            out += "  predicted_image:\n    {}".format(self.predicted_image[0][0:4])[
+                :-1
+            ]
+            out += "...\n"
         return out
 
     def to_array(self):
@@ -350,9 +392,9 @@ class TPFModelParameters(object):
         next_idx = 0
         stars = []
         for staridx in range(len(self.stars)):
-            star = StarParameters(col=array[next_idx],
-                                  row=array[next_idx + 1],
-                                  flux=array[next_idx + 2])
+            star = StarParameters(
+                col=array[next_idx], row=array[next_idx + 1], flux=array[next_idx + 2]
+            )
             stars.append(star)
             next_idx += 3
 
@@ -365,21 +407,24 @@ class TPFModelParameters(object):
         if not self.focus.fitted:
             focus = self.focus
         else:
-            focus = FocusParameters(scale_col=array[next_idx],
-                                    scale_row=array[next_idx + 1],
-                                    rotation_angle=array[next_idx + 2],
-                                    fitted=True)
+            focus = FocusParameters(
+                scale_col=array[next_idx],
+                scale_row=array[next_idx + 1],
+                rotation_angle=array[next_idx + 2],
+                fitted=True,
+            )
             next_idx += 3
 
         if not self.motion.fitted:
             motion = self.motion
         else:
-            motion = MotionParameters(shift_col=array[next_idx],
-                                      shift_row=array[next_idx + 1],
-                                      fitted=True)
+            motion = MotionParameters(
+                shift_col=array[next_idx], shift_row=array[next_idx + 1], fitted=True
+            )
 
-        return TPFModelParameters(stars=stars, background=background,
-                                  focus=focus, motion=motion)
+        return TPFModelParameters(
+            stars=stars, background=background, focus=focus, motion=motion
+        )
 
 
 class TPFModel(object):
@@ -404,12 +449,18 @@ class TPFModel(object):
     fit_motion : bool
         If False, the telescope motion parameters will be kept fixed.
     """
-    def __init__(self, star_priors=None,
-                 background_prior=BackgroundPrior(),
-                 focus_prior=FocusPrior(),
-                 motion_prior=MotionPrior(),
-                 prfmodel=None,
-                 fit_background=True, fit_focus=False, fit_motion=False):
+
+    def __init__(
+        self,
+        star_priors=None,
+        background_prior=BackgroundPrior(),
+        focus_prior=FocusPrior(),
+        motion_prior=MotionPrior(),
+        prfmodel=None,
+        fit_background=True,
+        fit_focus=False,
+        fit_motion=False,
+    ):
         if star_priors is None:
             star_priors = []
         if prfmodel is None:
@@ -425,15 +476,20 @@ class TPFModel(object):
         self._params = self.get_initial_guesses()
 
     def __repr__(self):
-        out = super(TPFModel, self).__repr__() + '\n'
-        out += ''.join(['  {}\n'.format(str(star).replace('\n', '\n  '))
-                        for star in self.star_priors])
-        out += '  ' + str(self.background_prior).replace('\n', '\n  ') + '\n'
-        out += '  ' + str(self.focus_prior).replace('\n', '\n  ') + '\n'
-        out += '  ' + str(self.motion_prior).replace('\n', '\n  ') + '\n'
-        out += '  ' + str(self.prfmodel).replace('\n', '\n  ') + '\n'
-        out += '  fit_background={}\n  fit_focus={}\n  fit_motion={}\n'.format(
-                        self.fit_background, self.fit_focus, self.fit_motion)
+        out = super(TPFModel, self).__repr__() + "\n"
+        out += "".join(
+            [
+                "  {}\n".format(str(star).replace("\n", "\n  "))
+                for star in self.star_priors
+            ]
+        )
+        out += "  " + str(self.background_prior).replace("\n", "\n  ") + "\n"
+        out += "  " + str(self.focus_prior).replace("\n", "\n  ") + "\n"
+        out += "  " + str(self.motion_prior).replace("\n", "\n  ") + "\n"
+        out += "  " + str(self.prfmodel).replace("\n", "\n  ") + "\n"
+        out += "  fit_background={}\n  fit_focus={}\n  fit_motion={}\n".format(
+            self.fit_background, self.fit_focus, self.fit_motion
+        )
         return out
 
     def get_initial_guesses(self):
@@ -443,22 +499,31 @@ class TPFModel(object):
         """
         initial_star_guesses = []
         for star in self.star_priors:
-            initial_star_guesses.append(StarParameters(col=star.col.mean,
-                                                       row=star.row.mean,
-                                                       flux=star.flux.mean))
-        background = BackgroundParameters(flux=self.background_prior.flux.mean,
-                                          fitted=self.fit_background)
-        focus = FocusParameters(scale_col=self.focus_prior.scale_col.mean,
-                                scale_row=self.focus_prior.scale_row.mean,
-                                rotation_angle=self.focus_prior.rotation_angle.mean,
-                                fitted=self.fit_focus)
-        motion = MotionParameters(shift_col=self.motion_prior.shift_col.mean,
-                                  shift_row=self.motion_prior.shift_row.mean,
-                                  fitted=self.fit_motion)
-        initial_params = TPFModelParameters(stars=initial_star_guesses,
-                                            background=background,
-                                            focus=focus,
-                                            motion=motion)
+            initial_star_guesses.append(
+                StarParameters(
+                    col=star.col.mean, row=star.row.mean, flux=star.flux.mean
+                )
+            )
+        background = BackgroundParameters(
+            flux=self.background_prior.flux.mean, fitted=self.fit_background
+        )
+        focus = FocusParameters(
+            scale_col=self.focus_prior.scale_col.mean,
+            scale_row=self.focus_prior.scale_row.mean,
+            rotation_angle=self.focus_prior.rotation_angle.mean,
+            fitted=self.fit_focus,
+        )
+        motion = MotionParameters(
+            shift_col=self.motion_prior.shift_col.mean,
+            shift_row=self.motion_prior.shift_row.mean,
+            fitted=self.fit_motion,
+        )
+        initial_params = TPFModelParameters(
+            stars=initial_star_guesses,
+            background=background,
+            focus=focus,
+            motion=motion,
+        )
         return initial_params
 
     def predict(self, params=None):
@@ -478,12 +543,16 @@ class TPFModel(object):
             params = self.get_initial_guesses()
         star_images = []
         for star in params.stars:
-            star_images.append(self.prfmodel(center_col=star.col + params.motion.shift_col,
-                                             center_row=star.row + params.motion.shift_row,
-                                             flux=star.flux,
-                                             scale_col=params.focus.scale_col,
-                                             scale_row=params.focus.scale_row,
-                                             rotation_angle=params.focus.rotation_angle))
+            star_images.append(
+                self.prfmodel(
+                    center_col=star.col + params.motion.shift_col,
+                    center_row=star.row + params.motion.shift_row,
+                    flux=star.flux,
+                    scale_col=params.focus.scale_col,
+                    scale_row=params.focus.scale_row,
+                    rotation_angle=params.focus.rotation_angle,
+                )
+            )
         synthetic_image = np.sum(star_images, axis=0) + params.background.flux
         return synthetic_image
 
@@ -504,9 +573,11 @@ class TPFModel(object):
         params = self._params.from_array(params_array)
         grad = []
         for star in params.stars:
-            grad.append(self.prfmodel.gradient(center_col=star.col,
-                                               center_row=star.row,
-                                               flux=star.flux))
+            grad.append(
+                self.prfmodel.gradient(
+                    center_col=star.col, center_row=star.row, flux=star.flux
+                )
+            )
         # We assume the background gradient is proportional to one
         grad.append([np.ones(self.prfmodel.shape)])
         # We assume the gradient of other parameters is one
@@ -528,12 +599,15 @@ class TPFModel(object):
         if self.fit_background:
             logp += self.background_prior.evaluate(params.background.flux)
         if self.fit_focus:
-            logp += self.focus_prior.evaluate(params.focus.scale_col,
-                                              params.focus.scale_row,
-                                              params.focus.rotation_angle)
+            logp += self.focus_prior.evaluate(
+                params.focus.scale_col,
+                params.focus.scale_row,
+                params.focus.rotation_angle,
+            )
         if self.fit_motion:
-            logp += self.motion_prior.evaluate(params.motion.shift_col,
-                                               params.motion.shift_row)
+            logp += self.motion_prior.evaluate(
+                params.motion.shift_col, params.motion.shift_row
+            )
         return logp
 
     def _logp_prior(self, params_array):
@@ -545,8 +619,15 @@ class TPFModel(object):
         params = self._params.from_array(params_array)
         return self.logp_prior(params)
 
-    def fit(self, data, loss_function=PoissonPosterior, method='powell',
-            pos_corr1=None, pos_corr2=None, **kwargs):
+    def fit(
+        self,
+        data,
+        loss_function=PoissonPosterior,
+        method="powell",
+        pos_corr1=None,
+        pos_corr2=None,
+        **kwargs
+    ):
         """Fits the model to the data.
 
         Parameters
@@ -575,7 +656,9 @@ class TPFModel(object):
         with warnings.catch_warnings():
             # Ignore RuntimeWarnings trigged by invalid values
             warnings.simplefilter("ignore", RuntimeWarning)
-            fit = loss.fit(x0=self.get_initial_guesses().to_array(), method=method, **kwargs)
+            fit = loss.fit(
+                x0=self.get_initial_guesses().to_array(), method=method, **kwargs
+            )
         result = self._params.from_array(fit.x)
         # NOTE: uncertainties are not available for now because `self.gradient` is unfinished;
         # hence, the line below is commented out for now:
@@ -589,27 +672,49 @@ class TPFModel(object):
     def plot(self, *params, **kwargs):
         """Plots an image of the model for a given point in the parameter space."""
         img = self.predict(*params)
-        plot_image(img,
-                   title='TPF Model',
-                   extent=(self.prfmodel.column, self.prfmodel.column + self.prfmodel.shape[1],
-                           self.prfmodel.row, self.prfmodel.row + self.prfmodel.shape[0]),
-                   **kwargs)
+        plot_image(
+            img,
+            title="TPF Model",
+            extent=(
+                self.prfmodel.column,
+                self.prfmodel.column + self.prfmodel.shape[1],
+                self.prfmodel.row,
+                self.prfmodel.row + self.prfmodel.shape[0],
+            ),
+            **kwargs
+        )
 
     def plot_diagnostics(self, data, figsize=(12, 4), *params, **kwargs):
         """Plots an image of the model for a given point in the parameter space."""
         fig, ax = plt.subplots(nrows=1, ncols=3, figsize=figsize)
         fit = self.fit(data)
-        extent = (self.prfmodel.column, self.prfmodel.column + self.prfmodel.shape[1],
-                  self.prfmodel.row, self.prfmodel.row + self.prfmodel.shape[0])
-        plot_image(data, ax=ax[0],
-                   title='Observed Data, Channel: {}'.format(self.prfmodel.channel),
-                   extent=extent, **kwargs)
-        plot_image(fit.predicted_image, ax=ax[1],
-                   title='Predicted Image, Channel: {}'.format(self.prfmodel.channel),
-                   extent=extent, **kwargs)
-        plot_image(fit.residual_image, ax=ax[2],
-                   title='Residual Image, Channel: {}'.format(self.prfmodel.channel),
-                   extent=extent, **kwargs)
+        extent = (
+            self.prfmodel.column,
+            self.prfmodel.column + self.prfmodel.shape[1],
+            self.prfmodel.row,
+            self.prfmodel.row + self.prfmodel.shape[0],
+        )
+        plot_image(
+            data,
+            ax=ax[0],
+            title="Observed Data, Channel: {}".format(self.prfmodel.channel),
+            extent=extent,
+            **kwargs
+        )
+        plot_image(
+            fit.predicted_image,
+            ax=ax[1],
+            title="Predicted Image, Channel: {}".format(self.prfmodel.channel),
+            extent=extent,
+            **kwargs
+        )
+        plot_image(
+            fit.residual_image,
+            ax=ax[2],
+            title="Residual Image, Channel: {}".format(self.prfmodel.channel),
+            extent=extent,
+            **kwargs
+        )
         return fit
 
 
@@ -625,11 +730,14 @@ class PRFPhotometry(object):
     model : instance of TPFModel
         Model which will be fit to the data
     """
+
     def __init__(self, model):
         self.model = model
         self.results = []
 
-    def run(self, tpf_flux, cadences=None, pos_corr1=None, pos_corr2=None, parallel=True):
+    def run(
+        self, tpf_flux, cadences=None, pos_corr1=None, pos_corr2=None, parallel=True
+    ):
         """Fits the model to the flux data.
 
         Parameters
@@ -653,34 +761,42 @@ class PRFPhotometry(object):
         # needed to fit a single cadence.  This will enable parallel processing below.
         tpf_flux = np.asarray(tpf_flux)  # Ensure the flux data can be indexed
         if pos_corr1 is None or pos_corr2 is None:
-            args = zip([self.model]*len(cadences),
-                      tpf_flux[cadences])
+            args = zip([self.model] * len(cadences), tpf_flux[cadences])
         else:
-            args = zip([self.model]*len(cadences),
-                      tpf_flux[cadences],
-                       pos_corr1[cadences],
-                       pos_corr2[cadences])
+            args = zip(
+                [self.model] * len(cadences),
+                tpf_flux[cadences],
+                pos_corr1[cadences],
+                pos_corr2[cadences],
+            )
         # Set up a mapping function
         if parallel:
             import multiprocessing
+
             pool = multiprocessing.Pool()
             mymap = pool.imap
         else:
             import itertools
+
             mymap = itertools.imap
         # Now fit all cadences using the mapping function and the list of arguments
         self.results = []
-        for result in tqdm(mymap(fit_one_cadence, args), desc='Fitting cadences', total=len(cadences)):
+        for result in tqdm(
+            mymap(fit_one_cadence, args), desc="Fitting cadences", total=len(cadences)
+        ):
             self.results.append(result)
         if parallel:
             pool.close()
         # Parse results
-        self.lightcurves = [self._parse_lightcurve(star_idx)
-                            for star_idx in range(len(self.model.star_priors))]
+        self.lightcurves = [
+            self._parse_lightcurve(star_idx)
+            for star_idx in range(len(self.model.star_priors))
+        ]
 
     def _parse_lightcurve(self, star_idx):
         # Create a lightcurve
         from .. import LightCurve
+
         flux = []
         for cadence in range(len(self.results)):
             flux.append(self.results[cadence].stars[star_idx].flux)
@@ -689,6 +805,7 @@ class PRFPhotometry(object):
     def _parse_background(self):
         # Create a lightcurve
         from .. import LightCurve
+
         bgflux = []
         for cadence in range(len(self.results)):
             bgflux.append(self.results[cadence].background.flux)
@@ -699,25 +816,25 @@ class PRFPhotometry(object):
         fig, ax = plt.subplots(10, sharex=True, figsize=(6, 12))
         x = range(len(self.results))
         ax[0].plot(x, [r.stars[star_idx].flux for r in self.results])
-        ax[0].set_ylabel('Flux')
+        ax[0].set_ylabel("Flux")
         ax[1].plot(x, [r.stars[star_idx].col for r in self.results])
-        ax[1].set_ylabel('Col')
+        ax[1].set_ylabel("Col")
         ax[2].plot(x, [r.stars[star_idx].row for r in self.results])
-        ax[2].set_ylabel('Row')
+        ax[2].set_ylabel("Row")
         ax[3].plot(x, [r.motion.shift_col for r in self.results])
-        ax[3].set_ylabel('Shift col')
+        ax[3].set_ylabel("Shift col")
         ax[4].plot(x, [r.motion.shift_row for r in self.results])
-        ax[4].set_ylabel('Shift row')
+        ax[4].set_ylabel("Shift row")
         ax[5].plot(x, [r.background.flux for r in self.results])
-        ax[5].set_ylabel('Background')
+        ax[5].set_ylabel("Background")
         ax[6].plot(x, [r.focus.scale_col for r in self.results])
-        ax[6].set_ylabel('Focus col')
+        ax[6].set_ylabel("Focus col")
         ax[7].plot(x, [r.focus.scale_row for r in self.results])
-        ax[7].set_ylabel('Focus row')
+        ax[7].set_ylabel("Focus row")
         ax[8].plot(x, [r.focus.rotation_angle for r in self.results])
-        ax[8].set_ylabel('Focus angle')
+        ax[8].set_ylabel("Focus angle")
         ax[9].plot(x, [r.loss_value for r in self.results])
-        ax[9].set_ylabel('Loss')
+        ax[9].set_ylabel("Loss")
 
 
 def fit_one_cadence(arg):

--- a/src/lightkurve/seismology/__init__.py
+++ b/src/lightkurve/seismology/__init__.py
@@ -3,10 +3,17 @@ quick-look asteroseismic analyses."""
 
 # Do not export the modules in this subpackage to the root namespace, important
 # because `lightkurve.utils` collides with `lightkurve.seismology.utils`.
-__all__ = ['Seismology', 'SeismologyQuantity',
-           'estimate_numax_acf2d', 'diagnose_numax_acf2d',
-           'estimate_deltanu_acf2d', 'diagnose_deltanu_acf2d',
-           'estimate_radius', 'estimate_mass', 'estimate_logg']
+__all__ = [
+    "Seismology",
+    "SeismologyQuantity",
+    "estimate_numax_acf2d",
+    "diagnose_numax_acf2d",
+    "estimate_deltanu_acf2d",
+    "diagnose_deltanu_acf2d",
+    "estimate_radius",
+    "estimate_mass",
+    "estimate_logg",
+]
 
 from .core import *
 from .utils import *

--- a/src/lightkurve/seismology/deltanu_estimators.py
+++ b/src/lightkurve/seismology/deltanu_estimators.py
@@ -12,7 +12,7 @@ from .utils import SeismologyQuantity
 from . import utils
 from .. import MPLSTYLE
 
-__all__ = ['estimate_deltanu_acf2d', 'diagnose_deltanu_acf2d']
+__all__ = ["estimate_deltanu_acf2d", "diagnose_deltanu_acf2d"]
 
 
 def estimate_deltanu_acf2d(periodogram, numax):
@@ -79,47 +79,68 @@ def estimate_deltanu_acf2d(periodogram, numax):
     """
     # The frequency grid must be evenly spaced
     if not periodogram._is_evenly_spaced():
-        raise ValueError("the ACF 2D method requires that the periodogram "
-                         "has a grid of uniformly spaced frequencies.")
+        raise ValueError(
+            "the ACF 2D method requires that the periodogram "
+            "has a grid of uniformly spaced frequencies."
+        )
 
     # Run some checks on the passed in numaxs
     # Ensure input numax is in the correct units
     numax = u.Quantity(numax, periodogram.frequency.unit)
     fs = np.median(np.diff(periodogram.frequency.value))
     if numax.value < fs:
-        raise ValueError("The input numax can not be lower than"
-                         " a single frequency bin.")
+        raise ValueError(
+            "The input numax can not be lower than" " a single frequency bin."
+        )
     if numax.value > np.nanmax(periodogram.frequency.value):
-        raise ValueError("The input numax can not be higher than"
-                         "the highest frequency value in the periodogram.")
+        raise ValueError(
+            "The input numax can not be higher than"
+            "the highest frequency value in the periodogram."
+        )
 
     # Calculate deltanu using the method by Stello et al. 2009
     # Make sure that this relation only ever happens in microhertz space
-    deltanu_emp = u.Quantity((0.294 * u.Quantity(numax, u.microhertz).value ** 0.772)*u.microhertz,
-                        periodogram.frequency.unit).value
+    deltanu_emp = u.Quantity(
+        (0.294 * u.Quantity(numax, u.microhertz).value ** 0.772) * u.microhertz,
+        periodogram.frequency.unit,
+    ).value
 
-    window_width = 2*int(np.floor(utils.get_fwhm(periodogram, numax.value)))
-    aacf = utils.autocorrelate(periodogram, numax=numax.value, window_width=window_width)
-    acf = (np.abs(aacf**2)/np.abs(aacf[0]**2)) / (3/(2*len(aacf)))
+    window_width = 2 * int(np.floor(utils.get_fwhm(periodogram, numax.value)))
+    aacf = utils.autocorrelate(
+        periodogram, numax=numax.value, window_width=window_width
+    )
+    acf = (np.abs(aacf ** 2) / np.abs(aacf[0] ** 2)) / (3 / (2 * len(aacf)))
     fs = np.median(np.diff(periodogram.frequency.value))
-    lags = np.linspace(0., len(acf)*fs, len(acf))
+    lags = np.linspace(0.0, len(acf) * fs, len(acf))
 
-    #Select a 25% region region around the empirical deltanu
-    sel = (lags > deltanu_emp - .25*deltanu_emp) & (lags < deltanu_emp + .25*deltanu_emp)
+    # Select a 25% region region around the empirical deltanu
+    sel = (lags > deltanu_emp - 0.25 * deltanu_emp) & (
+        lags < deltanu_emp + 0.25 * deltanu_emp
+    )
 
-    #Run a peak finder on this region
-    peaks, _ = find_peaks(acf[sel], distance=np.floor(deltanu_emp/2. / fs))
+    # Run a peak finder on this region
+    peaks, _ = find_peaks(acf[sel], distance=np.floor(deltanu_emp / 2.0 / fs))
 
-    #Select the peak closest to the empirical value
-    best_deltanu_value = lags[sel][peaks][np.argmin(np.abs(lags[sel][peaks] - deltanu_emp))]
+    # Select the peak closest to the empirical value
+    best_deltanu_value = lags[sel][peaks][
+        np.argmin(np.abs(lags[sel][peaks] - deltanu_emp))
+    ]
     best_deltanu = u.Quantity(best_deltanu_value, periodogram.frequency.unit)
-    diagnostics = {'lags':lags, 'acf':acf, 'peaks':peaks, 'sel':sel,
-                   'numax':numax, 'deltanu_emp':deltanu_emp}
-    result = SeismologyQuantity(best_deltanu,
-                                name="deltanu",
-                                method="ACF2D",
-                                diagnostics=diagnostics,
-                                diagnostics_plot_method=diagnose_deltanu_acf2d)
+    diagnostics = {
+        "lags": lags,
+        "acf": acf,
+        "peaks": peaks,
+        "sel": sel,
+        "numax": numax,
+        "deltanu_emp": deltanu_emp,
+    }
+    result = SeismologyQuantity(
+        best_deltanu,
+        name="deltanu",
+        method="ACF2D",
+        diagnostics=diagnostics,
+        diagnostics_plot_method=diagnose_deltanu_acf2d,
+    )
     return result
 
 
@@ -152,69 +173,140 @@ def diagnose_deltanu_acf2d(deltanu, periodogram):
         fig, axs = plt.subplots(2, figsize=(8.485, 8))
 
         ax = axs[0]
-        periodogram.plot(ax=ax, label='')
-        ax.axvline(deltanu.diagnostics['numax'].value, c='r', linewidth=1,
-                   alpha=.4, ls=':')
-        ax.text(deltanu.diagnostics['numax'].value, periodogram.power.value.max()*0.45,
-                '{} ({:.1f} {})'.format(r'$\nu_{\rm max}$', deltanu.diagnostics['numax'].value, deltanu.diagnostics['numax'].unit.to_string('latex')),
-                rotation=90, ha='right', color='r', alpha=0.5, fontsize=8)
-        ax.text(.025, .9, 'Input Power Spectrum', horizontalalignment='left',
-                transform=ax.transAxes, fontsize=11)
+        periodogram.plot(ax=ax, label="")
+        ax.axvline(
+            deltanu.diagnostics["numax"].value, c="r", linewidth=1, alpha=0.4, ls=":"
+        )
+        ax.text(
+            deltanu.diagnostics["numax"].value,
+            periodogram.power.value.max() * 0.45,
+            "{} ({:.1f} {})".format(
+                r"$\nu_{\rm max}$",
+                deltanu.diagnostics["numax"].value,
+                deltanu.diagnostics["numax"].unit.to_string("latex"),
+            ),
+            rotation=90,
+            ha="right",
+            color="r",
+            alpha=0.5,
+            fontsize=8,
+        )
+        ax.text(
+            0.025,
+            0.9,
+            "Input Power Spectrum",
+            horizontalalignment="left",
+            transform=ax.transAxes,
+            fontsize=11,
+        )
 
-        window_width = 2*int(np.floor(utils.get_fwhm(periodogram, deltanu.diagnostics['numax'].value)))
+        window_width = 2 * int(
+            np.floor(utils.get_fwhm(periodogram, deltanu.diagnostics["numax"].value))
+        )
         frequency_spacing = np.median(np.diff(periodogram.frequency.value))
-        spread = int(window_width/2/frequency_spacing)  # spread in indices
+        spread = int(window_width / 2 / frequency_spacing)  # spread in indices
 
-        a = np.argmin(np.abs(periodogram.frequency.value - deltanu.diagnostics['numax'].value)) + spread
-        b = np.argmin(np.abs(periodogram.frequency.value - deltanu.diagnostics['numax'].value)) - spread
+        a = (
+            np.argmin(
+                np.abs(periodogram.frequency.value - deltanu.diagnostics["numax"].value)
+            )
+            + spread
+        )
+        b = (
+            np.argmin(
+                np.abs(periodogram.frequency.value - deltanu.diagnostics["numax"].value)
+            )
+            - spread
+        )
 
-        a = [periodogram.frequency.value[a] if a < len(periodogram.frequency)
-             else periodogram.frequency.value[-1]][0]
-        b = [periodogram.frequency.value[b] if b > 0
-             else periodogram.frequency.value[0]][0]
+        a = [
+            periodogram.frequency.value[a]
+            if a < len(periodogram.frequency)
+            else periodogram.frequency.value[-1]
+        ][0]
+        b = [
+            periodogram.frequency.value[b] if b > 0 else periodogram.frequency.value[0]
+        ][0]
 
-        ax.axvline(a, c='r', linewidth=2, alpha=.4, ls='--')
-        ax.axvline(b, c='r', linewidth=2, alpha=.4, ls='--')
+        ax.axvline(a, c="r", linewidth=2, alpha=0.4, ls="--")
+        ax.axvline(b, c="r", linewidth=2, alpha=0.4, ls="--")
 
         h = periodogram.power.value.max() * 0.9
 
-        ax.annotate("", xy=(a, h), xytext=(a - (a-b), h),
-                        arrowprops=dict(arrowstyle="<->", color='r', alpha=0.5), va='bottom')
-        ax.text(a - (a-b)/2, h, r"2 $\times$ FWHM", color='r', alpha=0.7, fontsize=10, va='bottom', ha='center')
-        ax.set_xlim(b - ((a-b)*0.2), a + ((a-b)*0.2))
+        ax.annotate(
+            "",
+            xy=(a, h),
+            xytext=(a - (a - b), h),
+            arrowprops=dict(arrowstyle="<->", color="r", alpha=0.5),
+            va="bottom",
+        )
+        ax.text(
+            a - (a - b) / 2,
+            h,
+            r"2 $\times$ FWHM",
+            color="r",
+            alpha=0.7,
+            fontsize=10,
+            va="bottom",
+            ha="center",
+        )
+        ax.set_xlim(b - ((a - b) * 0.2), a + ((a - b) * 0.2))
 
         ax = axs[1]
-        ax.plot(deltanu.diagnostics['lags'][2:], deltanu.diagnostics['acf'][2:])
-        ax.set_xlabel("Frequency Lag [{}]".format(periodogram.frequency.unit.to_string('latex')))
-        ax.set_ylabel(r'Scaled Auto Correlation', fontsize=11)
+        ax.plot(deltanu.diagnostics["lags"][2:], deltanu.diagnostics["acf"][2:])
+        ax.set_xlabel(
+            "Frequency Lag [{}]".format(periodogram.frequency.unit.to_string("latex"))
+        )
+        ax.set_ylabel(r"Scaled Auto Correlation", fontsize=11)
 
-        axin = inset_axes(ax, width="50%",height="50%", loc="upper right")
+        axin = inset_axes(ax, width="50%", height="50%", loc="upper right")
         axin.set_yticks([])
-        axin.plot(deltanu.diagnostics['lags'][deltanu.diagnostics['sel']],
-                  deltanu.diagnostics['acf'][deltanu.diagnostics['sel']])
-        axin.scatter(deltanu.diagnostics['lags'][deltanu.diagnostics['sel']][deltanu.diagnostics['peaks']],
-                     deltanu.diagnostics['acf'][deltanu.diagnostics['sel']][deltanu.diagnostics['peaks']],
-                     c='r', s=5)
+        axin.plot(
+            deltanu.diagnostics["lags"][deltanu.diagnostics["sel"]],
+            deltanu.diagnostics["acf"][deltanu.diagnostics["sel"]],
+        )
+        axin.scatter(
+            deltanu.diagnostics["lags"][deltanu.diagnostics["sel"]][
+                deltanu.diagnostics["peaks"]
+            ],
+            deltanu.diagnostics["acf"][deltanu.diagnostics["sel"]][
+                deltanu.diagnostics["peaks"]
+            ],
+            c="r",
+            s=5,
+        )
 
-        mea_label = r'Measured {} {:.1f} {}'.format(
-                        r'$\Delta\nu$',
-                        deltanu.value,
-                        periodogram.frequency.unit.to_string('latex'))
-        ax.axvline(deltanu.value,c='r', linewidth=2, alpha=.4, label=mea_label)
+        mea_label = r"Measured {} {:.1f} {}".format(
+            r"$\Delta\nu$", deltanu.value, periodogram.frequency.unit.to_string("latex")
+        )
+        ax.axvline(deltanu.value, c="r", linewidth=2, alpha=0.4, label=mea_label)
 
-        emp_label = r'Empirical {} {:.1f} {}'.format(
-                        r'$\Delta\nu$',
-                        deltanu.diagnostics['deltanu_emp'],
-                        periodogram.frequency.unit.to_string('latex'))
-        ax.axvline(deltanu.diagnostics['deltanu_emp'], c='b', linewidth=2,
-                   alpha=.4, ls='--', label=emp_label)
+        emp_label = r"Empirical {} {:.1f} {}".format(
+            r"$\Delta\nu$",
+            deltanu.diagnostics["deltanu_emp"],
+            periodogram.frequency.unit.to_string("latex"),
+        )
+        ax.axvline(
+            deltanu.diagnostics["deltanu_emp"],
+            c="b",
+            linewidth=2,
+            alpha=0.4,
+            ls="--",
+            label=emp_label,
+        )
 
-        axin.axvline(deltanu.value,c='r', linewidth=2, alpha=.4)
-        axin.axvline(deltanu.diagnostics['deltanu_emp'], c='b', linewidth=2,
-                     alpha=.4, ls='--')
-        ax.text(.025, .9, 'Scaled Auto Correlation Within 2 FWHM',
-                    horizontalalignment='left',
-                    transform=ax.transAxes, fontsize=11)
+        axin.axvline(deltanu.value, c="r", linewidth=2, alpha=0.4)
+        axin.axvline(
+            deltanu.diagnostics["deltanu_emp"], c="b", linewidth=2, alpha=0.4, ls="--"
+        )
+        ax.text(
+            0.025,
+            0.9,
+            "Scaled Auto Correlation Within 2 FWHM",
+            horizontalalignment="left",
+            transform=ax.transAxes,
+            fontsize=11,
+        )
 
-        ax.legend(loc='lower right', fontsize=10)
+        ax.legend(loc="lower right", fontsize=10)
         return ax

--- a/src/lightkurve/seismology/stellar_estimators.py
+++ b/src/lightkurve/seismology/stellar_estimators.py
@@ -8,17 +8,19 @@ from astropy import constants as const
 
 from .utils import SeismologyQuantity
 
-__all__ = ['estimate_radius', 'estimate_mass', 'estimate_logg']
+__all__ = ["estimate_radius", "estimate_mass", "estimate_logg"]
 
 
 """Global parameters for the sun"""
-NUMAX_SOL = ufloat(3090, 30) # microhertz | Huber et al. 2011
-DELTANU_SOL = ufloat(135.1, 0.1) # microhertz | Huber et al. 2011
-TEFF_SOL = ufloat(5772., 0.8) # Kelvin    | Prsa et al. 2016
-G_SOL = ((const.G * const.M_sun)/(const.R_sun)**2).to(u.cm/u.second**2) #cms^2
+NUMAX_SOL = ufloat(3090, 30)  # microhertz | Huber et al. 2011
+DELTANU_SOL = ufloat(135.1, 0.1)  # microhertz | Huber et al. 2011
+TEFF_SOL = ufloat(5772.0, 0.8)  # Kelvin    | Prsa et al. 2016
+G_SOL = ((const.G * const.M_sun) / (const.R_sun) ** 2).to(u.cm / u.second ** 2)  # cms^2
 
 
-def estimate_radius(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_err=None):
+def estimate_radius(
+    numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_err=None
+):
     """Returns a stellar radius estimate based on the scaling relations.
 
     The two global observable seismic parameters, numax and deltanu, along with
@@ -36,10 +38,10 @@ def estimate_radius(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff
     This code structure borrows from work done in Bellinger et al. (2019), which
     also functions as an accessible explanation of seismic scaling relations.
 
-    If no value of effective temperature is given, this function will check the 
+    If no value of effective temperature is given, this function will check the
     meta data of the `Periodogram` object used to create the `Seismology` object.
-    These data will often contain an effective tempearture from the Kepler Input 
-    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+    These data will often contain an effective tempearture from the Kepler Input
+    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
     or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
     catalogues are estimated using photometry, and so have large associated uncertainties
     (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -73,7 +75,7 @@ def estimate_radius(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff
     """
     numax = u.Quantity(numax, u.microhertz).value
     deltanu = u.Quantity(deltanu, u.microhertz).value
-    teff = u.Quantity(teff, u. Kelvin).value
+    teff = u.Quantity(teff, u.Kelvin).value
 
     if all(b is not None for b in [numax_err, deltanu_err, teff_err]):
         numax_err = u.Quantity(numax_err, u.microhertz).value
@@ -87,15 +89,23 @@ def estimate_radius(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff
         udeltanu = ufloat(deltanu, 0)
         uteff = ufloat(teff, 0)
 
-    uR = (unumax / NUMAX_SOL) * (udeltanu / DELTANU_SOL)**(-2.) * (uteff / TEFF_SOL)**(0.5)
-    result = SeismologyQuantity(uR.n * u.solRad,
-                                error=uR.s * u.solRad,
-                                name="radius",
-                                method="Uncorrected Scaling Relations")
+    uR = (
+        (unumax / NUMAX_SOL)
+        * (udeltanu / DELTANU_SOL) ** (-2.0)
+        * (uteff / TEFF_SOL) ** (0.5)
+    )
+    result = SeismologyQuantity(
+        uR.n * u.solRad,
+        error=uR.s * u.solRad,
+        name="radius",
+        method="Uncorrected Scaling Relations",
+    )
     return result
 
 
-def estimate_mass(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_err=None):
+def estimate_mass(
+    numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_err=None
+):
     """Calculates mass using the asteroseismic scaling relations.
 
     The two global observable seismic parameters, numax and deltanu, along with
@@ -113,10 +123,10 @@ def estimate_mass(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_e
     This code structure borrows from work done in Bellinger et al. (2019), which
     also functions as an accessible explanation of seismic scaling relations.
 
-    If no value of effective temperature is given, this function will check the 
+    If no value of effective temperature is given, this function will check the
     meta data of the `Periodogram` object used to create the `Seismology` object.
-    These data will often contain an effective tempearture from the Kepler Input 
-    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+    These data will often contain an effective tempearture from the Kepler Input
+    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
     or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
     catalogues are estimated using photometry, and so have large associated uncertainties
     (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -135,7 +145,7 @@ def estimate_mass(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_e
         degree. If not given an astropy unit, assumed to be in units of
         microhertz.
     teff : float
-        The effective temperature of the star. In units of Kelvin. 
+        The effective temperature of the star. In units of Kelvin.
     numax_err : float
         Error on numax. Assumed to be same units as numax
     deltanu_err : float
@@ -165,11 +175,17 @@ def estimate_mass(numax, deltanu, teff, numax_err=None, deltanu_err=None, teff_e
         udeltanu = ufloat(deltanu, 0)
         uteff = ufloat(teff, 0)
 
-    uM = (unumax / NUMAX_SOL)**3. * (udeltanu / DELTANU_SOL)**(-4.) * (uteff / TEFF_SOL)**(1.5)
-    result = SeismologyQuantity(uM.n * u.solMass,
-                                error=uM.s * u.solMass,
-                                name="mass",
-                                method="Uncorrected Scaling Relations")
+    uM = (
+        (unumax / NUMAX_SOL) ** 3.0
+        * (udeltanu / DELTANU_SOL) ** (-4.0)
+        * (uteff / TEFF_SOL) ** (1.5)
+    )
+    result = SeismologyQuantity(
+        uM.n * u.solMass,
+        error=uM.s * u.solMass,
+        name="mass",
+        method="Uncorrected Scaling Relations",
+    )
     return result
 
 
@@ -196,10 +212,10 @@ def estimate_logg(numax, teff, numax_err=None, teff_err=None):
     This code structure borrows from work done in Bellinger et al. (2019), which
     also functions as an accessible explanation of seismic scaling relations.
 
-    If no value of effective temperature is given, this function will check the 
+    If no value of effective temperature is given, this function will check the
     meta data of the `Periodogram` object used to create the `Seismology` object.
-    These data will often contain an effective tempearture from the Kepler Input 
-    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract), 
+    These data will often contain an effective tempearture from the Kepler Input
+    Catalogue (KIC, https://ui.adsabs.harvard.edu/abs/2011AJ....142..112B/abstract),
     or from the EPIC or TIC for K2 and TESS respectively. The temperature values in these
     catalogues are estimated using photometry, and so have large associated uncertainties
     (roughly 200 K, see KIC). For more better results, spectroscopic measurements of
@@ -237,11 +253,13 @@ def estimate_logg(numax, teff, numax_err=None, teff_err=None):
         unumax = ufloat(numax, 0)
         uteff = ufloat(teff, 0)
 
-    ug = G_SOL.value * (unumax / NUMAX_SOL) * (uteff / TEFF_SOL)**0.5
+    ug = G_SOL.value * (unumax / NUMAX_SOL) * (uteff / TEFF_SOL) ** 0.5
     ulogg = umath.log(ug, 10)
 
-    result = SeismologyQuantity(ulogg.n * u.dex,
-                                error=ulogg.s * u.dex,
-                                name="logg",
-                                method="Uncorrected Scaling Relations")
+    result = SeismologyQuantity(
+        ulogg.n * u.dex,
+        error=ulogg.s * u.dex,
+        name="logg",
+        method="Uncorrected Scaling Relations",
+    )
     return result

--- a/src/lightkurve/seismology/utils.py
+++ b/src/lightkurve/seismology/utils.py
@@ -4,7 +4,7 @@ import copy
 from astropy import units as u
 from astropy.units import Quantity
 
-__all__ = ['SeismologyQuantity']
+__all__ = ["SeismologyQuantity"]
 
 
 class SeismologyQuantity(Quantity):
@@ -18,8 +18,16 @@ class SeismologyQuantity(Quantity):
         * diagnostics;
         * diagnostics_plot_method.
     """
-    def __new__(cls, quantity, name=None, error=None, method=None,
-                 diagnostics=None, diagnostics_plot_method=None):
+
+    def __new__(
+        cls,
+        quantity,
+        name=None,
+        error=None,
+        method=None,
+        diagnostics=None,
+        diagnostics_plot_method=None,
+    ):
         # Note: Quantity is peculiar to sub-class because it inherits from numpy ndarray;
         # see https://docs.astropy.org/en/stable/units/quantity.html#subclassing-quantity.
         self = Quantity.__new__(cls, quantity.value)
@@ -34,16 +42,19 @@ class SeismologyQuantity(Quantity):
     def __repr__(self):
         try:
             return "{}: {} {} (method: {})".format(
-                self.name, '{:.2f}'.format(self.value),
-                self.unit.__str__(), self.method)
+                self.name, "{:.2f}".format(self.value), self.unit.__str__(), self.method
+            )
         except AttributeError:  # Math operations appear to remove Seismic attributes for now
             return super().__repr__()
 
     def _repr_latex_(self):
         try:
             return "{}: {} {} (method: {})".format(
-                    self.name, '${:.2f}$'.format(self.value),
-                    self.unit._repr_latex_(), self.method)
+                self.name,
+                "${:.2f}$".format(self.value),
+                self.unit._repr_latex_(),
+                self.method,
+            )
         except AttributeError:  # Math operations appear to remove Seismic attributes for now
             return super()._repr_latex_()
 
@@ -82,15 +93,17 @@ def get_fwhm(periodogram, numax):
     fwhm: float
         The estimate full-width-half-maximum of the seismic mode envelope
     """
-    #Calculate the index FWHM for a given numax
-    if u.Quantity(periodogram.frequency[-1], u.microhertz) > u.Quantity(500., u.microhertz):
+    # Calculate the index FWHM for a given numax
+    if u.Quantity(periodogram.frequency[-1], u.microhertz) > u.Quantity(
+        500.0, u.microhertz
+    ):
         fwhm = 0.25 * numax
     else:
-        fwhm = 0.66 * numax**0.88
+        fwhm = 0.66 * numax ** 0.88
     return fwhm
 
 
-def autocorrelate(periodogram, numax, window_width=25., frequency_spacing=None):
+def autocorrelate(periodogram, numax, window_width=25.0, frequency_spacing=None):
     """An autocorrelation function (ACF) for seismic mode envelopes.
 
     We autocorrelate a region with a width of `window_width` (in microhertz)
@@ -124,12 +137,18 @@ def autocorrelate(periodogram, numax, window_width=25., frequency_spacing=None):
     if frequency_spacing is None:
         frequency_spacing = np.median(np.diff(periodogram.frequency.value))
 
-    spread = int(window_width/2/frequency_spacing)                           # Find the spread in indices
-    x = int(numax / frequency_spacing)                                 # Find the index value of numax
-    x0 = int((periodogram.frequency[0].value/frequency_spacing))              # Transform in case the index isn't from 0
+    spread = int(window_width / 2 / frequency_spacing)  # Find the spread in indices
+    x = int(numax / frequency_spacing)  # Find the index value of numax
+    x0 = int(
+        (periodogram.frequency[0].value / frequency_spacing)
+    )  # Transform in case the index isn't from 0
     xt = x - x0
-    p_sel = copy.deepcopy(periodogram.power[xt-spread:xt+spread].value)       # Make the window selection
-    p_sel -= np.nanmean(p_sel)    #Make it so that the selection has zero mean.
+    p_sel = copy.deepcopy(
+        periodogram.power[xt - spread : xt + spread].value
+    )  # Make the window selection
+    p_sel -= np.nanmean(p_sel)  # Make it so that the selection has zero mean.
 
-    C = np.correlate(p_sel, p_sel, mode='full')[len(p_sel)-1:]     #Correlated the resulting SNR space with itself
+    C = np.correlate(p_sel, p_sel, mode="full")[
+        len(p_sel) - 1 :
+    ]  # Correlated the resulting SNR space with itself
     return C

--- a/src/lightkurve/time.py
+++ b/src/lightkurve/time.py
@@ -7,9 +7,10 @@ class TimeBKJD(TimeNumeric):
     Barycentric Kepler Julian Date time format.
     This represents the number of days since January 1, 2009 12:00:00 UTC.
     BKJD is the format in which times are recorded in Kepler data products.
-    See Section 2.3.2 in the Kepler Archive Manual for details. 
+    See Section 2.3.2 in the Kepler Archive Manual for details.
     """
-    name = 'bkjd'
+
+    name = "bkjd"
     BKJDREF = 2454833  # Barycentric Kepler Julian Date offset
 
     def set_jds(self, val1, val2):
@@ -32,7 +33,8 @@ class TimeBTJD(TimeNumeric):
     This represents the number of days since JD 2457000.0.
     BTJD is the format in which times are recorded in TESS data products.
     """
-    name = 'btjd'
+
+    name = "btjd"
     BTJDREF = 2457000  # Barycentric TESS Julian Date offset
 
     def set_jds(self, val1, val2):

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -14,18 +14,27 @@ import astropy
 from astropy.utils.data import download_file
 from astropy.units.quantity import Quantity
 import astropy.units as u
-from astropy.visualization import (PercentileInterval, ImageNormalize,
-                                   SqrtStretch, LinearStretch)
+from astropy.visualization import (
+    PercentileInterval,
+    ImageNormalize,
+    SqrtStretch,
+    LinearStretch,
+)
 from astropy.time import Time
 
 
 log = logging.getLogger(__name__)
 
 
-__all__ = ['LightkurveError', 'LightkurveWarning',
-           'KeplerQualityFlags', 'TessQualityFlags',
-           'bkjd_to_astropy_time', 'btjd_to_astropy_time',
-           'show_citation_instructions']
+__all__ = [
+    "LightkurveError",
+    "LightkurveWarning",
+    "KeplerQualityFlags",
+    "TessQualityFlags",
+    "bkjd_to_astropy_time",
+    "btjd_to_astropy_time",
+    "show_citation_instructions",
+]
 
 
 class QualityFlags(object):
@@ -93,18 +102,22 @@ class QualityFlags(object):
                 bitmask = cls.OPTIONS[bitmask]
             except KeyError:
                 valid_options = tuple(cls.OPTIONS.keys())
-                raise ValueError("quality_bitmask='{}' is not supported, "
-                                 "expected one of {}"
-                                 "".format(bitmask, valid_options))
+                raise ValueError(
+                    "quality_bitmask='{}' is not supported, "
+                    "expected one of {}"
+                    "".format(bitmask, valid_options)
+                )
         # The bitmask is applied using the bitwise AND operator
         quality_mask = (quality_array & bitmask) == 0
         # Log the quality masking as info or warning
         n_cadences = len(quality_array)
         n_cadences_masked = (~quality_mask).sum()
-        percent_masked = 100. * n_cadences_masked / n_cadences
-        logmsg = "{:.0f}% ({}/{}) of the cadences will be ignored due to the " \
-                 "quality mask (quality_bitmask={})." \
-                 "".format(percent_masked, n_cadences_masked, n_cadences, bitmask)
+        percent_masked = 100.0 * n_cadences_masked / n_cadences
+        logmsg = (
+            "{:.0f}% ({}/{}) of the cadences will be ignored due to the "
+            "quality mask (quality_bitmask={})."
+            "".format(percent_masked, n_cadences_masked, n_cadences, bitmask)
+        )
         if percent_masked > 20:
             log.warning("Warning: " + logmsg)
         else:
@@ -122,6 +135,7 @@ class KeplerQualityFlags(QualityFlags):
     .. [1] Kepler: A Search for Terrestrial Planets. Kepler Archive Manual.
         http://archive.stsci.edu/kepler/manuals/archive_manual.pdf
     """
+
     AttitudeTweak = 1
     SafeMode = 2
     CoarsePoint = 4
@@ -145,19 +159,35 @@ class KeplerQualityFlags(QualityFlags):
     ThrusterFiring = 1048576
 
     #: DEFAULT bitmask identifies all cadences which are definitely useless.
-    DEFAULT_BITMASK = (AttitudeTweak | SafeMode | CoarsePoint | EarthPoint |
-                       Desat | ManualExclude | DetectorAnomaly | NoData | ThrusterFiring)
+    DEFAULT_BITMASK = (
+        AttitudeTweak
+        | SafeMode
+        | CoarsePoint
+        | EarthPoint
+        | Desat
+        | ManualExclude
+        | DetectorAnomaly
+        | NoData
+        | ThrusterFiring
+    )
     #: HARD bitmask is conservative and may identify cadences which are useful.
-    HARD_BITMASK = (DEFAULT_BITMASK | SensitivityDropout | ApertureCosmic |
-                    CollateralCosmic | PossibleThrusterFiring)
+    HARD_BITMASK = (
+        DEFAULT_BITMASK
+        | SensitivityDropout
+        | ApertureCosmic
+        | CollateralCosmic
+        | PossibleThrusterFiring
+    )
     #: HARDEST bitmask identifies cadences with any flag set. Its use is not recommended.
     HARDEST_BITMASK = 2096639
 
     #: Dictionary which provides friendly names for the various bitmasks.
-    OPTIONS = {'none': 0,
-               'default': DEFAULT_BITMASK,
-               'hard': HARD_BITMASK,
-               'hardest': HARDEST_BITMASK}
+    OPTIONS = {
+        "none": 0,
+        "default": DEFAULT_BITMASK,
+        "hard": HARD_BITMASK,
+        "hardest": HARDEST_BITMASK,
+    }
 
     #: Pretty string descriptions for each flag
     STRINGS = {
@@ -180,7 +210,7 @@ class KeplerQualityFlags(QualityFlags):
         131072: "Rolling band in optimal aperture",
         262144: "Rolling band in full mask",
         524288: "Possible thruster firing",
-        1048576: "Thruster firing"
+        1048576: "Thruster firing",
     }
 
 
@@ -194,6 +224,7 @@ class TessQualityFlags(QualityFlags):
     .. [1] TESS Science Data Products Description Document (EXP-TESS-ARC-ICD-0014)
         https://archive.stsci.edu/missions/tess/doc/EXP-TESS-ARC-ICD-TM-0014.pdf
     """
+
     AttitudeTweak = 1
     SafeMode = 2
     CoarsePoint = 4
@@ -211,19 +242,23 @@ class TessQualityFlags(QualityFlags):
     Straylight2 = 4096
 
     #: DEFAULT bitmask identifies all cadences which are definitely useless.
-    DEFAULT_BITMASK = (AttitudeTweak | SafeMode | CoarsePoint | EarthPoint |
-                       Desat | ManualExclude)
+    DEFAULT_BITMASK = (
+        AttitudeTweak | SafeMode | CoarsePoint | EarthPoint | Desat | ManualExclude
+    )
     #: HARD bitmask is conservative and may identify cadences which are useful.
-    HARD_BITMASK = (DEFAULT_BITMASK | ApertureCosmic |
-                    CollateralCosmic | Straylight | Straylight2)
+    HARD_BITMASK = (
+        DEFAULT_BITMASK | ApertureCosmic | CollateralCosmic | Straylight | Straylight2
+    )
     #: HARDEST bitmask identifies cadences with any flag set. Its use is not recommended.
     HARDEST_BITMASK = 8191
 
     #: Dictionary which provides friendly names for the various bitmasks.
-    OPTIONS = {'none': 0,
-               'default': DEFAULT_BITMASK,
-               'hard': HARD_BITMASK,
-               'hardest': HARDEST_BITMASK}
+    OPTIONS = {
+        "none": 0,
+        "default": DEFAULT_BITMASK,
+        "hard": HARD_BITMASK,
+        "hardest": HARDEST_BITMASK,
+    }
 
     #: Pretty string descriptions for each flag
     STRINGS = {
@@ -239,8 +274,9 @@ class TessQualityFlags(QualityFlags):
         512: "Impulsive outlier",
         1024: "Cosmic ray in collateral data",
         2048: "Straylight",
-        4096: "Straylight2"
+        4096: "Straylight2",
     }
+
 
 def channel_to_module_output(channel):
     """Returns a (module, output) pair given a CCD channel number.
@@ -289,34 +325,36 @@ def _get_channel_lookup_array():
     """Returns a lookup table which maps (module, output) onto channel."""
     # In the array below, channel == array[module][output]
     # Note: modules 1, 5, 21, 25 are the FGS guide star CCDs.
-    return np.array([
-        [0,     0,    0,    0,    0],
-        [1,    85,    0,    0,    0],
-        [2,     1,    2,    3,    4],
-        [3,     5,    6,    7,    8],
-        [4,     9,   10,   11,   12],
-        [5,    86,    0,    0,    0],
-        [6,    13,   14,   15,   16],
-        [7,    17,   18,   19,   20],
-        [8,    21,   22,   23,   24],
-        [9,    25,   26,   27,   28],
-        [10,   29,   30,   31,   32],
-        [11,   33,   34,   35,   36],
-        [12,   37,   38,   39,   40],
-        [13,   41,   42,   43,   44],
-        [14,   45,   46,   47,   48],
-        [15,   49,   50,   51,   52],
-        [16,   53,   54,   55,   56],
-        [17,   57,   58,   59,   60],
-        [18,   61,   62,   63,   64],
-        [19,   65,   66,   67,   68],
-        [20,   69,   70,   71,   72],
-        [21,   87,    0,    0,    0],
-        [22,   73,   74,   75,   76],
-        [23,   77,   78,   79,   80],
-        [24,   81,   82,   83,   84],
-        [25,   88,    0,    0,    0],
-    ])
+    return np.array(
+        [
+            [0, 0, 0, 0, 0],
+            [1, 85, 0, 0, 0],
+            [2, 1, 2, 3, 4],
+            [3, 5, 6, 7, 8],
+            [4, 9, 10, 11, 12],
+            [5, 86, 0, 0, 0],
+            [6, 13, 14, 15, 16],
+            [7, 17, 18, 19, 20],
+            [8, 21, 22, 23, 24],
+            [9, 25, 26, 27, 28],
+            [10, 29, 30, 31, 32],
+            [11, 33, 34, 35, 36],
+            [12, 37, 38, 39, 40],
+            [13, 41, 42, 43, 44],
+            [14, 45, 46, 47, 48],
+            [15, 49, 50, 51, 52],
+            [16, 53, 54, 55, 56],
+            [17, 57, 58, 59, 60],
+            [18, 61, 62, 63, 64],
+            [19, 65, 66, 67, 68],
+            [20, 69, 70, 71, 72],
+            [21, 87, 0, 0, 0],
+            [22, 73, 74, 75, 76],
+            [23, 77, 78, 79, 80],
+            [24, 81, 82, 83, 84],
+            [25, 88, 0, 0, 0],
+        ]
+    )
 
 
 def running_mean(data, window_size):
@@ -361,7 +399,7 @@ def bkjd_to_astropy_time(bkjd) -> Time:
     # Some data products have missing time values;
     # we need to set these to zero or `Time` cannot be instantiated.
     bkjd[~np.isfinite(bkjd)] = 0
-    return Time(bkjd, format='bkjd', scale='tdb')
+    return Time(bkjd, format="bkjd", scale="tdb")
 
 
 def btjd_to_astropy_time(btjd) -> Time:
@@ -386,13 +424,23 @@ def btjd_to_astropy_time(btjd) -> Time:
     """
     btjd = np.atleast_1d(btjd)
     btjd[~np.isfinite(btjd)] = 0
-    return Time(btjd, format='btjd', scale='tdb')
+    return Time(btjd, format="btjd", scale="tdb")
 
 
-def plot_image(image, ax=None, scale='linear', origin='lower',
-               xlabel='Pixel Column Number', ylabel='Pixel Row Number',
-               clabel='Flux ($e^{-}s^{-1}$)', title=None, show_colorbar=True,
-               vmin=None, vmax=None, **kwargs):
+def plot_image(
+    image,
+    ax=None,
+    scale="linear",
+    origin="lower",
+    xlabel="Pixel Column Number",
+    ylabel="Pixel Row Number",
+    clabel="Flux ($e^{-}s^{-1}$)",
+    title=None,
+    show_colorbar=True,
+    vmin=None,
+    vmax=None,
+    **kwargs
+):
     """Utility function to plot a 2D image
 
     Parameters
@@ -439,7 +487,9 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
             warnings.simplefilter("ignore", RuntimeWarning)  # ignore image NaN values
             mask = np.nan_to_num(image) > 0
             if mask.any() > 0:
-                vmin_default, vmax_default = PercentileInterval(95.).get_limits(image[mask])
+                vmin_default, vmax_default = PercentileInterval(95.0).get_limits(
+                    image[mask]
+                )
             else:
                 vmin_default, vmax_default = 0, 0
             if vmin is None:
@@ -449,15 +499,18 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 
     norm = None
     if scale is not None:
-        if scale == 'linear':
-            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch(), clip=False)
-        elif scale == 'sqrt':
-            norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch(), clip=False)
-        elif scale == 'log':
+        if scale == "linear":
+            norm = ImageNormalize(
+                vmin=vmin, vmax=vmax, stretch=LinearStretch(), clip=False
+            )
+        elif scale == "sqrt":
+            norm = ImageNormalize(
+                vmin=vmin, vmax=vmax, stretch=SqrtStretch(), clip=False
+            )
+        elif scale == "log":
             # To use log scale we need to guarantee that vmin > 0, so that
             # we avoid division by zero and/or negative values.
-            norm = LogNorm(vmin=max(vmin, sys.float_info.epsilon), vmax=vmax,
-                           clip=True)
+            norm = LogNorm(vmin=max(vmin, sys.float_info.epsilon), vmax=vmax, clip=True)
         else:
             raise ValueError("scale {} is not available.".format(scale))
     cax = ax.imshow(image, origin=origin, norm=norm, **kwargs)
@@ -473,25 +526,29 @@ def plot_image(image, ax=None, scale='linear', origin='lower',
 
 class LightkurveError(Exception):
     """Class for Lightkurve exceptions."""
+
     pass
 
 
 class LightkurveWarning(Warning):
     """Class for all Lightkurve warnings."""
+
     pass
 
 
 class LightkurveDeprecationWarning(LightkurveWarning):
     """Class for all Lightkurve deprecation warnings."""
+
     pass
 
 
 def suppress_stdout(f, *args, **kwargs):
     """A simple decorator to suppress function print outputs."""
+
     @wraps(f)
     def wrapper(*args, **kwargs):
         # redirect output to `null`
-        with open(os.devnull, 'w') as devnull:
+        with open(os.devnull, "w") as devnull:
             old_out = sys.stdout
             sys.stdout = devnull
             try:
@@ -499,6 +556,7 @@ def suppress_stdout(f, *args, **kwargs):
             # restore to default
             finally:
                 sys.stdout = old_out
+
     return wrapper
 
 
@@ -520,8 +578,10 @@ def validate_method(method, supported_methods):
     method = method.lower()
     if method in supported_methods:
         return method
-    raise ValueError("method '{}' is not supported; "
-                     "must be one of {}".format(method, supported_methods))
+    raise ValueError(
+        "method '{}' is not supported; "
+        "must be one of {}".format(method, supported_methods)
+    )
 
 
 def centroid_quadratic(data, mask=None):
@@ -572,21 +632,25 @@ def centroid_quadratic(data, mask=None):
     if xx > (data.shape[1] - 2):
         xx = data.shape[1] - 2
 
-    z_ = data[yy-1:yy+2, xx-1:xx+2]
+    z_ = data[yy - 1 : yy + 2, xx - 1 : xx + 2]
 
     # Next, we will fit the coefficients of the bivariate quadratic with the
     # help of a design matrix (A) as defined by Eqn 20 in Vakili & Hogg
     # (arxiv:1610.05873). The design matrix contains a
     # column of ones followed by pixel coordinates: x, y, x**2, xy, y**2.
-    A = np.array([[1, -1, -1, 1,  1, 1],
-                  [1,  0, -1, 0,  0, 1],
-                  [1,  1, -1, 1, -1, 1],
-                  [1, -1,  0, 1,  0, 0],
-                  [1,  0,  0, 0,  0, 0],
-                  [1,  1,  0, 1,  0, 0],
-                  [1, -1,  1, 1, -1, 1],
-                  [1,  0,  1, 0,  0, 1],
-                  [1,  1,  1, 1,  1, 1]])
+    A = np.array(
+        [
+            [1, -1, -1, 1, 1, 1],
+            [1, 0, -1, 0, 0, 1],
+            [1, 1, -1, 1, -1, 1],
+            [1, -1, 0, 1, 0, 0],
+            [1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 1, 0, 0],
+            [1, -1, 1, 1, -1, 1],
+            [1, 0, 1, 0, 0, 1],
+            [1, 1, 1, 1, 1, 1],
+        ]
+    )
     # We also pre-compute $(A^t A)^-1 A^t$, cf. Eqn 21 in Vakili & Hogg.
     At = A.transpose()
     # In Python 3 this can become `Aprime = np.linalg.inv(At @ A) @ At`
@@ -602,13 +666,14 @@ def centroid_quadratic(data, mask=None):
     det = 4 * d * f - e ** 2
     if abs(det) < 1e-6:
         return np.nan, np.nan  # No solution
-    xm = - (2 * f * b - c * e) / det
-    ym = - (2 * d * c - b * e) / det
+    xm = -(2 * f * b - c * e) / det
+    ym = -(2 * d * c - b * e) / det
     return xx + xm, yy + ym
 
 
-def _query_solar_system_objects(ra, dec, times, radius=0.1, location='kepler',
-                                cache=True):
+def _query_solar_system_objects(
+    ra, dec, times, radius=0.1, location="kepler", cache=True
+):
     """Returns a list of asteroids/comets given a position and time.
 
     This function relies on The Virtual Observatory Sky Body Tracker (SkyBot)
@@ -639,32 +704,38 @@ def _query_solar_system_objects(ra, dec, times, radius=0.1, location='kepler',
     # and it is only required for this specific feature.
     import pandas as pd
 
-    if (location.lower() == 'kepler') or (location.lower() == 'k2'):
-        location = 'C55'
-    elif location.lower() == 'tess':
-        location = 'C57'
+    if (location.lower() == "kepler") or (location.lower() == "k2"):
+        location = "C55"
+    elif location.lower() == "tess":
+        location = "C57"
 
-    url = 'http://vo.imcce.fr/webservices/skybot/skybotconesearch_query.php?'
-    url += '-mime=text&'
-    url += '-ra={}&'.format(ra)
-    url += '-dec={}&'.format(dec)
-    url += '-bd={}&'.format(radius)
-    url += '-loc={}&'.format(location)
+    url = "http://vo.imcce.fr/webservices/skybot/skybotconesearch_query.php?"
+    url += "-mime=text&"
+    url += "-ra={}&".format(ra)
+    url += "-dec={}&".format(dec)
+    url += "-bd={}&".format(radius)
+    url += "-loc={}&".format(location)
 
     df = None
     times = np.atleast_1d(times)
-    for time in tqdm(times, desc='Querying for SSOs'):
-        url_queried = url + 'EPOCH={}'.format(time)
+    for time in tqdm(times, desc="Querying for SSOs"):
+        url_queried = url + "EPOCH={}".format(time)
         response = download_file(url_queried, cache=cache)
-        if open(response).read(10) == '# Flag: -1':  # error code detected?
-            raise IOError("SkyBot Solar System query failed.\n"
-                          "URL used:\n" + url_queried + "\n"
-                          "Response received:\n" + open(response).read())
-        res = pd.read_csv(response, delimiter='|', skiprows=2)
+        if open(response).read(10) == "# Flag: -1":  # error code detected?
+            raise IOError(
+                "SkyBot Solar System query failed.\n"
+                "URL used:\n" + url_queried + "\n"
+                "Response received:\n" + open(response).read()
+            )
+        res = pd.read_csv(response, delimiter="|", skiprows=2)
         if len(res) > 0:
-            res['epoch'] = time
-            res.rename({'# Num ':'Num', ' Name ':'Name', ' Class ':'Class', ' Mv ':'Mv'}, inplace=True, axis='columns')
-            res = res[['Num', 'Name', 'Class', 'Mv', 'epoch']].reset_index(drop=True)
+            res["epoch"] = time
+            res.rename(
+                {"# Num ": "Num", " Name ": "Name", " Class ": "Class", " Mv ": "Mv"},
+                inplace=True,
+                axis="columns",
+            )
+            res = res[["Num", "Name", "Class", "Mv", "epoch"]].reset_index(drop=True)
             if df is None:
                 df = res
             else:
@@ -677,14 +748,16 @@ def _query_solar_system_objects(ra, dec, times, radius=0.1, location='kepler',
 def show_citation_instructions():
     """Show citation instructions."""
     from . import PACKAGEDIR, __citation__
+
     if not is_notebook():
         print(__citation__)
     else:
         from pathlib import Path
         from IPython.display import HTML
         import astroquery
-        templatefile = Path(PACKAGEDIR, 'data', 'show_citation_instructions.html')
-        template = open(templatefile, 'r').read()
+
+        templatefile = Path(PACKAGEDIR, "data", "show_citation_instructions.html")
+        template = open(templatefile, "r").read()
         template = template.replace("LIGHTKURVE_CITATION", __citation__)
         template = template.replace("ASTROPY_CITATION", astropy.__citation__)
         template = template.replace("ASTROQUERY_CITATION", astroquery.__citation__)
@@ -704,17 +777,17 @@ def _get_notebook_environment():
     """
     try:
         ipy = str(type(get_ipython())).lower()
-        if 'zmqshell' in ipy:
-            return 'jupyter'
-        if 'colab' in ipy:
-            return 'colab'
+        if "zmqshell" in ipy:
+            return "jupyter"
+        if "colab" in ipy:
+            return "colab"
     except NameError:
         pass  # get_ipython() is not a builtin
-    return 'terminal'
+    return "terminal"
 
 
 def is_notebook():
     """Returns `True` if we are running in a notebook."""
-    if _get_notebook_environment() in ['jupyter', 'colab']:
+    if _get_notebook_environment() in ["jupyter", "colab"]:
         return True
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,11 @@ def pytest_runtest_setup(item):
     """Our tests will often run in headless virtual environments. For this
     reason, we enforce the use of matplotlib's robust Agg backend, because it
     does not require a graphical display.
-    
+
     This avoids errors such as:
         c:\hostedtoolcache\windows\python\3.7.5\x64\lib\tkinter\__init__.py:2023: TclError
         This probably means that tk wasn't installed properly.
     """
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")

--- a/tests/correctors/test_cbvcorrector.py
+++ b/tests/correctors/test_cbvcorrector.py
@@ -2,8 +2,12 @@
 """
 
 import pytest
-from numpy.testing import (assert_almost_equal, assert_array_equal,
-                           assert_allclose, assert_raises)
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_equal,
+    assert_allclose,
+    assert_raises,
+)
 
 import warnings
 import numpy as np
@@ -18,220 +22,279 @@ from lightkurve import TessLightCurve, KeplerLightCurve
 from lightkurve import search_lightcurve
 from lightkurve import LightkurveWarning
 from lightkurve.correctors.designmatrix import DesignMatrix
-from lightkurve.correctors.cbvcorrector import download_kepler_cbvs, download_tess_cbvs, \
-    CotrendingBasisVectors, KeplerCotrendingBasisVectors, \
-    TessCotrendingBasisVectors
+from lightkurve.correctors.cbvcorrector import (
+    download_kepler_cbvs,
+    download_tess_cbvs,
+    CotrendingBasisVectors,
+    KeplerCotrendingBasisVectors,
+    TessCotrendingBasisVectors,
+)
 from lightkurve.correctors.cbvcorrector import CBVCorrector
 
 
-#*******************************************************************************
-#*******************************************************************************
-#*******************************************************************************
+# *******************************************************************************
+# *******************************************************************************
+# *******************************************************************************
 # CotrendingBasisVectors unit tests
 def test_CotrendingBasisVectors_nonretrieval():
-    """ Tests CotrendingBasisVectors class without requiring remote data
-    """
+    """Tests CotrendingBasisVectors class without requiring remote data"""
 
-    #***
+    # ***
     # Constructor
     # Create some generic CotrendingBasisVectors objects
 
     # Generic CotrendingBasisVectors object
-    dataTbl = Table([[1, 2, 3], [False, True, False], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]], 
-        names=('CADENCENO', 'GAP', 'VECTOR_1', 'VECTOR_3'))
-    cbvTime = Time([443.51090033, 443.53133457, 443.55176891], format='bkjd')
+    dataTbl = Table(
+        [[1, 2, 3], [False, True, False], [2.0, 3.0, 4.0], [3.0, 4.0, 5.0]],
+        names=("CADENCENO", "GAP", "VECTOR_1", "VECTOR_3"),
+    )
+    cbvTime = Time([443.51090033, 443.53133457, 443.55176891], format="bkjd")
     cbvs = CotrendingBasisVectors(data=dataTbl, time=cbvTime)
     assert isinstance(cbvs, CotrendingBasisVectors)
     assert cbvs.cbv_indices == [1, 3]
     assert np.all(cbvs.time.value == [443.51090033, 443.53133457, 443.55176891])
-    
+
     # Auto-initiate 'GAP' and 'CADENCENO'
-    dataTbl = Table([[2.0, 3.0, 4.0], [3.0, 4.0, 5.0]], 
-            names=('VECTOR_3', 'VECTOR_12'))
-    cbvTime = Time([443.51090033, 443.53133457, 443.55176891], format='bkjd')
+    dataTbl = Table([[2.0, 3.0, 4.0], [3.0, 4.0, 5.0]], names=("VECTOR_3", "VECTOR_12"))
+    cbvTime = Time([443.51090033, 443.53133457, 443.55176891], format="bkjd")
     cbvs = CotrendingBasisVectors(data=dataTbl, time=cbvTime)
     assert isinstance(cbvs, CotrendingBasisVectors)
     assert cbvs.cbv_indices == [3, 12]
     assert np.all(cbvs.gap_indicators == [False, False, False])
     assert np.all(cbvs.cadenceno == [0, 1, 2])
 
-    
-    #***
+    # ***
     # _to_designmatrix
     # Make sure CBVs are the columns in the returned 2-dim array
-    dataTbl = Table([[1, 2, 3], [False, True, False], 
-            [1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], 
-            names=('CADENCENO', 'GAP', 'VECTOR_1', 'VECTOR_2', 'VECTOR_3'))
-    cbvTime = Time([1569.44053967, 1569.44192856, 1569.44331746], format='btjd')
+    dataTbl = Table(
+        [
+            [1, 2, 3],
+            [False, True, False],
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+        ],
+        names=("CADENCENO", "GAP", "VECTOR_1", "VECTOR_2", "VECTOR_3"),
+    )
+    cbvTime = Time([1569.44053967, 1569.44192856, 1569.44331746], format="btjd")
     cbvs = CotrendingBasisVectors(dataTbl, cbvTime)
-    cbv_dm_name = 'test cbv set'
+    cbv_dm_name = "test cbv set"
     # CBV index 5 does not exists and should be ingored
-    cbv_designmatrix = cbvs.to_designmatrix(cbv_indices=[1,3,5], name=cbv_dm_name)
-    assert cbv_designmatrix.shape == (3,2)
-    assert np.all(cbv_designmatrix['VECTOR_1'] == np.array([1.0, 2.0, 3.0]))
-    assert np.all(cbv_designmatrix['VECTOR_3'] == np.array([7.0, 8.0, 9.0]))
+    cbv_designmatrix = cbvs.to_designmatrix(cbv_indices=[1, 3, 5], name=cbv_dm_name)
+    assert cbv_designmatrix.shape == (3, 2)
+    assert np.all(cbv_designmatrix["VECTOR_1"] == np.array([1.0, 2.0, 3.0]))
+    assert np.all(cbv_designmatrix["VECTOR_3"] == np.array([7.0, 8.0, 9.0]))
     assert cbv_designmatrix.name == cbv_dm_name
     # CBV #2 was not requested, so make sure it is not present
     with pytest.raises(KeyError):
-        cbv_designmatrix['VECTOR_2']
-    
-    #***
+        cbv_designmatrix["VECTOR_2"]
+
+    # ***
     # plot
-    ax = cbvs.plot(cbv_indices=[1,2], ax=None)
+    ax = cbvs.plot(cbv_indices=[1, 2], ax=None)
     assert isinstance(ax, matplotlib.axes.Axes)
-    
+
     # There is no CBV # 5 so the third cbv_indices entry will be ignored
-    ax = cbvs.plot(cbv_indices=[1,2,5], ax=ax)
+    ax = cbvs.plot(cbv_indices=[1, 2, 5], ax=ax)
     assert isinstance(ax, matplotlib.axes.Axes)
-    
+
     # CBVs use 1-based indexing. Throw error if requesting CBV index 0
     with pytest.raises(ValueError):
-        ax = cbvs.plot(cbv_indices=[0,1,2], ax=ax)
+        ax = cbvs.plot(cbv_indices=[0, 1, 2], ax=ax)
 
     # Only 'all' or specific CBV indices can be requested
     with pytest.raises(ValueError):
-        ax = cbvs.plot('Doh!')
+        ax = cbvs.plot("Doh!")
 
-    
-    #***
+    # ***
     # align
     # Set up some cadenceno such that both CBV is trimmed and NaNs inserted
-    sample_lc = TessLightCurve(time=[1,2,3,4,6,7], flux=[1,2,3,4,6,7],
-            flux_err=[0.1,0.1, 0.1, 0.1, 0.1, 0.1], cadenceno=[1,2,3,4,6,7])
-    dataTbl = Table([[1, 2, 3, 5, 6], [False, True, False, False, False], 
-            [1.0, 2.0, 3.0, 5.0, 6.0 ]], 
-        names=('CADENCENO', 'GAP', 'VECTOR_1'))
-    cbvTime = Time([1569.43915078, 1569.44053967, 1569.44192856,
-           1569.44470635, 1569.44609524], format='btjd')
+    sample_lc = TessLightCurve(
+        time=[1, 2, 3, 4, 6, 7],
+        flux=[1, 2, 3, 4, 6, 7],
+        flux_err=[0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+        cadenceno=[1, 2, 3, 4, 6, 7],
+    )
+    dataTbl = Table(
+        [
+            [1, 2, 3, 5, 6],
+            [False, True, False, False, False],
+            [1.0, 2.0, 3.0, 5.0, 6.0],
+        ],
+        names=("CADENCENO", "GAP", "VECTOR_1"),
+    )
+    cbvTime = Time(
+        [1569.43915078, 1569.44053967, 1569.44192856, 1569.44470635, 1569.44609524],
+        format="btjd",
+    )
     cbvs = CotrendingBasisVectors(dataTbl, cbvTime)
     cbvs = cbvs.align(sample_lc)
     assert np.all(sample_lc.cadenceno == cbvs.cadenceno)
     assert len(cbvs.cadenceno) == 6
     assert len(sample_lc.flux) == 6
-    assert np.all(cbvs.gap_indicators.value[[1,3,5]])
+    assert np.all(cbvs.gap_indicators.value[[1, 3, 5]])
     # Ignore the warning in to_designmatric due to a low rank matrix
     with warnings.catch_warnings():
         # Instantiating light curves with NaN times will yield a warning
         warnings.simplefilter("ignore", LightkurveWarning)
         cbv_designmatrix = cbvs.to_designmatrix(cbv_indices=[1])
-    assert np.all(cbv_designmatrix['VECTOR_1'][[0,1,2,4]] == [1.0, 2.0, 3.0, 6.0])
-    assert np.all(np.isnan(cbv_designmatrix['VECTOR_1'][[3,5]]))
+    assert np.all(cbv_designmatrix["VECTOR_1"][[0, 1, 2, 4]] == [1.0, 2.0, 3.0, 6.0])
+    assert np.all(np.isnan(cbv_designmatrix["VECTOR_1"][[3, 5]]))
 
-    #***
+    # ***
     # interpolate
     nLcCadences = 20
-    xLc = np.linspace(0.0, 2*np.pi, num=nLcCadences)
-    sample_lc = TessLightCurve(time=xLc, flux=np.sin(xLc), flux_err=np.full(nLcCadences, 0.1),
-            cadenceno=np.arange(nLcCadences))
+    xLc = np.linspace(0.0, 2 * np.pi, num=nLcCadences)
+    sample_lc = TessLightCurve(
+        time=xLc,
+        flux=np.sin(xLc),
+        flux_err=np.full(nLcCadences, 0.1),
+        cadenceno=np.arange(nLcCadences),
+    )
     nCbvCadences = 10
-    xCbv = np.linspace(0.0, 2*np.pi, num=nCbvCadences)
-    dataTbl = Table([np.arange(nCbvCadences), np.full(nCbvCadences, False), 
-            np.cos(xCbv), np.sin(xCbv+np.pi*0.125)], 
-            names=('CADENCENO', 'GAP', 'VECTOR_1', 'VECTOR_2'))
-    cbvTime = Time(xCbv, format='btjd')
+    xCbv = np.linspace(0.0, 2 * np.pi, num=nCbvCadences)
+    dataTbl = Table(
+        [
+            np.arange(nCbvCadences),
+            np.full(nCbvCadences, False),
+            np.cos(xCbv),
+            np.sin(xCbv + np.pi * 0.125),
+        ],
+        names=("CADENCENO", "GAP", "VECTOR_1", "VECTOR_2"),
+    )
+    cbvTime = Time(xCbv, format="btjd")
     cbvs = CotrendingBasisVectors(dataTbl, cbvTime)
     cbv_interpolated = cbvs.interpolate(sample_lc, extrapolate=False)
     assert np.all(cbv_interpolated.time.value == sample_lc.time.value)
     # Extrapolation test
-    xCbv = np.linspace(0.0, 1.5*np.pi, num=nCbvCadences)
-    dataTbl = Table([np.arange(nCbvCadences), np.full(nCbvCadences, False), 
-            np.cos(xCbv), np.sin(xCbv+np.pi*0.125)], 
-            names=('CADENCENO', 'GAP', 'VECTOR_1', 'VECTOR_2'))
-    cbvTime = Time(xCbv, format='btjd')
+    xCbv = np.linspace(0.0, 1.5 * np.pi, num=nCbvCadences)
+    dataTbl = Table(
+        [
+            np.arange(nCbvCadences),
+            np.full(nCbvCadences, False),
+            np.cos(xCbv),
+            np.sin(xCbv + np.pi * 0.125),
+        ],
+        names=("CADENCENO", "GAP", "VECTOR_1", "VECTOR_2"),
+    )
+    cbvTime = Time(xCbv, format="btjd")
     cbvs = CotrendingBasisVectors(dataTbl, cbvTime)
     cbv_interpolated = cbvs.interpolate(sample_lc, extrapolate=False)
-    assert np.all(np.isnan(
-        cbv_interpolated['VECTOR_1'].value[
-            np.nonzero(cbv_interpolated.time.value > 1.5*np.pi)[0]]))
+    assert np.all(
+        np.isnan(
+            cbv_interpolated["VECTOR_1"].value[
+                np.nonzero(cbv_interpolated.time.value > 1.5 * np.pi)[0]
+            ]
+        )
+    )
     cbv_interpolated = cbvs.interpolate(sample_lc, extrapolate=True)
-    assert np.all(np.logical_not(np.isnan(
-        cbv_interpolated['VECTOR_1'].value[
-            np.nonzero(cbv_interpolated.time.value > 1.5*np.pi)[0]])))
-    
+    assert np.all(
+        np.logical_not(
+            np.isnan(
+                cbv_interpolated["VECTOR_1"].value[
+                    np.nonzero(cbv_interpolated.time.value > 1.5 * np.pi)[0]
+                ]
+            )
+        )
+    )
+
+
 @pytest.mark.remote_data
 def test_cbv_retrieval():
-    """ Tests reading in some CBVs from MAST
+    """Tests reading in some CBVs from MAST
 
-        This indirectly tests the classes KeplerCotrendingBasisVectors and
-        TessCotrendingBasisVectors
+    This indirectly tests the classes KeplerCotrendingBasisVectors and
+    TessCotrendingBasisVectors
 
     """
 
-    cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type = 'SingleScale')
+    cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type="SingleScale")
     assert isinstance(cbvs, TessCotrendingBasisVectors)
-    ax = cbvs.plot([1,2,4,6,8])
+    ax = cbvs.plot([1, 2, 4, 6, 8])
     assert isinstance(ax, matplotlib.axes.Axes)
-    assert cbvs.mission == 'TESS'
-    assert cbvs.cbv_type == 'SingleScale'
+    assert cbvs.mission == "TESS"
+    assert cbvs.cbv_type == "SingleScale"
     assert cbvs.band is None
     assert cbvs.sector == 10
     assert cbvs.camera == 2
     assert cbvs.ccd == 4
-    
-    cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type = 'MultiScale', band=2)
+
+    cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type="MultiScale", band=2)
     assert isinstance(cbvs, TessCotrendingBasisVectors)
-    ax = cbvs.plot('all')
+    ax = cbvs.plot("all")
     assert isinstance(ax, matplotlib.axes.Axes)
     assert cbvs.band == 2
-    
-    cbvs = download_tess_cbvs(sector=8, camera=3, ccd=1, cbv_type = 'Spike')
+
+    cbvs = download_tess_cbvs(sector=8, camera=3, ccd=1, cbv_type="Spike")
     assert isinstance(cbvs, TessCotrendingBasisVectors)
-    ax = cbvs.plot('all')
+    ax = cbvs.plot("all")
     assert isinstance(ax, matplotlib.axes.Axes)
-    
+
     # No band specified for MultiScale, this should error
     with pytest.raises(AssertionError):
-        cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type = 'MultiScale')
+        cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type="MultiScale")
     # Band specified for SingleScale, this should also error
     with pytest.raises(AssertionError):
-        cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type = 'SingleScale', band=2)
+        cbvs = download_tess_cbvs(
+            sector=10, camera=2, ccd=4, cbv_type="SingleScale", band=2
+        )
     # Improper CBV type request
     with pytest.raises(Exception):
-        cbvs = download_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type = 'SuperSingleScale')
+        cbvs = download_tess_cbvs(
+            sector=10, camera=2, ccd=4, cbv_type="SuperSingleScale"
+        )
 
-    cbvs = download_kepler_cbvs(mission='Kepler', quarter=8, module=16, output=4)
+    cbvs = download_kepler_cbvs(mission="Kepler", quarter=8, module=16, output=4)
     assert isinstance(cbvs, KeplerCotrendingBasisVectors)
-    ax = cbvs.plot('all')
+    ax = cbvs.plot("all")
     assert isinstance(ax, matplotlib.axes.Axes)
-    assert cbvs.mission == 'Kepler'
-    assert cbvs.cbv_type == 'SingleScale'
+    assert cbvs.mission == "Kepler"
+    assert cbvs.cbv_type == "SingleScale"
     assert cbvs.quarter == 8
     assert cbvs.campaign is None
     assert cbvs.module == 16
     assert cbvs.output == 4
 
-    cbvs = download_kepler_cbvs(mission='K2', campaign=15, channel=24)
+    cbvs = download_kepler_cbvs(mission="K2", campaign=15, channel=24)
     assert isinstance(cbvs, KeplerCotrendingBasisVectors)
-    ax = cbvs.plot('all')
+    ax = cbvs.plot("all")
     assert isinstance(ax, matplotlib.axes.Axes)
-    assert cbvs.mission == 'K2'
-    assert cbvs.cbv_type == 'SingleScale'
+    assert cbvs.mission == "K2"
+    assert cbvs.cbv_type == "SingleScale"
     assert cbvs.quarter is None
     assert cbvs.campaign == 15
     assert cbvs.module == 8
     assert cbvs.output == 4
 
 
-#*******************************************************************************
-#*******************************************************************************
-#*******************************************************************************
+# *******************************************************************************
+# *******************************************************************************
+# *******************************************************************************
 # CBVCorrector Unit Tests
+
 
 def test_CBVCorrector():
 
     # Create a CBVCorrector without reading CBVs from MAST
-    sample_lc = TessLightCurve(time=[1,2,3,4,5], flux=[1,2,np.nan,4,5], flux_err=[0.1, 0.1, 0.1, 0.1, 0.1],
-            cadenceno=[1,2,3,4,5], flux_unit=u.Unit('electron / second'))
+    sample_lc = TessLightCurve(
+        time=[1, 2, 3, 4, 5],
+        flux=[1, 2, np.nan, 4, 5],
+        flux_err=[0.1, 0.1, 0.1, 0.1, 0.1],
+        cadenceno=[1, 2, 3, 4, 5],
+        flux_unit=u.Unit("electron / second"),
+    )
 
-    cbvCorrector =  CBVCorrector(sample_lc, do_not_load_cbvs=True)
+    cbvCorrector = CBVCorrector(sample_lc, do_not_load_cbvs=True)
     # Check that Nan was removed
     assert len(cbvCorrector.lc.flux) == 4
     # Check that the median flux value is preserved
-    assert_allclose(np.nanmedian(cbvCorrector.lc.flux).value, np.nanmedian(sample_lc.flux).value)
+    assert_allclose(
+        np.nanmedian(cbvCorrector.lc.flux).value, np.nanmedian(sample_lc.flux).value
+    )
 
-    dm = DesignMatrix(pd.DataFrame({'a':np.ones(4), 'b':[1,2,4,5]}))
+    dm = DesignMatrix(pd.DataFrame({"a": np.ones(4), "b": [1, 2, 4, 5]}))
 
-    #***
+    # ***
     # RegressioNCorrector.correct passthrough method
     lc = cbvCorrector.correct_regressioncorrector(dm)
     # Check that returned lc is in absolute flux units
@@ -240,10 +303,11 @@ def test_CBVCorrector():
     lc_median = np.nanmedian(lc.flux)
     assert_allclose(lc.flux, lc_median)
 
-    #***
+    # ***
     # Gaussian Prior fit
-    lc = cbvCorrector.correct_gaussian_prior(cbv_type=None, cbv_indices=None,
-        alpha=1e-9, ext_dm=dm)
+    lc = cbvCorrector.correct_gaussian_prior(
+        cbv_type=None, cbv_indices=None, alpha=1e-9, ext_dm=dm
+    )
     assert isinstance(lc, TessLightCurve)
     # Check that returned lc is in absolute flux units
     assert lc.flux.unit == u.Unit("electron / second")
@@ -254,22 +318,25 @@ def test_CBVCorrector():
     assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
 
     # Now add a strong regularization term and under-fit the data
-    lc = cbvCorrector.correct_gaussian_prior(cbv_type=None, cbv_indices=None,
-        alpha=1e9, ext_dm=dm)
+    lc = cbvCorrector.correct_gaussian_prior(
+        cbv_type=None, cbv_indices=None, alpha=1e9, ext_dm=dm
+    )
     # There should be virtually no change in the flux
     assert_allclose(lc.flux, sample_lc.remove_nans().flux)
 
     # This should error because the dm has incorrect number of cadences
-    dm_err = DesignMatrix(pd.DataFrame({'a':np.ones(5), 'b':[1,2,4,5,6]}))
+    dm_err = DesignMatrix(pd.DataFrame({"a": np.ones(5), "b": [1, 2, 4, 5, 6]}))
     with pytest.raises(ValueError):
-        lc = cbvCorrector.correct_gaussian_prior(cbv_type=None, cbv_indices=None,
-            alpha=1e-2, ext_dm=dm_err)
+        lc = cbvCorrector.correct_gaussian_prior(
+            cbv_type=None, cbv_indices=None, alpha=1e-2, ext_dm=dm_err
+        )
 
-    #***
+    # ***
     # ElasticNet fit
-    lc = cbvCorrector.correct_elasticnet(cbv_type=None, cbv_indices=None,
-        alpha=1e-20, l1_ratio=0.5, ext_dm=dm)
-    assert isinstance(lc, TessLightCurve) 
+    lc = cbvCorrector.correct_elasticnet(
+        cbv_type=None, cbv_indices=None, alpha=1e-20, l1_ratio=0.5, ext_dm=dm
+    )
+    assert isinstance(lc, TessLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
     # The design matrix should have completely zeroed the flux around the median
     lc_median = np.nanmedian(lc.flux)
@@ -277,105 +344,128 @@ def test_CBVCorrector():
     ax = cbvCorrector.diagnose()
     assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
     # Now add a strong regularization term and under-fit the data
-    lc = cbvCorrector.correct_elasticnet(cbv_type=None, cbv_indices=None,
-        alpha=1e9, l1_ratio=0.5, ext_dm=dm)
+    lc = cbvCorrector.correct_elasticnet(
+        cbv_type=None, cbv_indices=None, alpha=1e9, l1_ratio=0.5, ext_dm=dm
+    )
     # There should be virtually no change in the flux
     assert_allclose(lc.flux, sample_lc.remove_nans().flux)
 
-    #***
+    # ***
     # Correction optimizer
     # The optimizer cannot be run without downloading targest from MAST for use
     # within the under-fitting metric.
     # So let's just verify it fails as expected (not much else we can do)
-    dm_err = DesignMatrix(pd.DataFrame({'a':np.ones(5), 'b':[1,2,4,5,6]}))
+    dm_err = DesignMatrix(pd.DataFrame({"a": np.ones(5), "b": [1, 2, 4, 5, 6]}))
     with pytest.raises(ValueError):
-        lc = cbvCorrector.correct(cbv_type=None, cbv_indices=None, 
-            alpha_bounds=[1e-4, 1e4], ext_dm=dm_err,
-            target_over_score=0.5, target_under_score=0.8)
+        lc = cbvCorrector.correct(
+            cbv_type=None,
+            cbv_indices=None,
+            alpha_bounds=[1e-4, 1e4],
+            ext_dm=dm_err,
+            target_over_score=0.5,
+            target_under_score=0.8,
+        )
 
 
 @pytest.mark.remote_data
 def test_CBVCorrector_retrieval():
-    """ Tests CBVCorrector by retrieving some sample Kepler/TESS light curves
+    """Tests CBVCorrector by retrieving some sample Kepler/TESS light curves
     and correcting them
     """
 
-    #***
+    # ***
     # A good TESS example of both over- and under-fitting
     # The "over-fitted" curve looks better to the eye, but eyes can be deceiving!
-    lc = search_lightcurve('TIC 357126143', mission='tess', author='spoc', sector=10).download(flux_column='sap_flux')
-    cbvCorrector =  CBVCorrector(lc)
+    lc = search_lightcurve(
+        "TIC 357126143", mission="tess", author="spoc", sector=10
+    ).download(flux_column="sap_flux")
+    cbvCorrector = CBVCorrector(lc)
     assert isinstance(cbvCorrector, CBVCorrector)
 
-    cbv_type = ['SingleScale', 'Spike']
-    cbv_indices = [np.arange(1,9), 'ALL']
+    cbv_type = ["SingleScale", "Spike"]
+    cbv_indices = [np.arange(1, 9), "ALL"]
 
     # Gaussian Prior correction
-    lc = cbvCorrector.correct_gaussian_prior(cbv_type=cbv_type, cbv_indices=cbv_indices,
-        alpha=1e-2)
-    assert isinstance(lc, TessLightCurve) 
+    lc = cbvCorrector.correct_gaussian_prior(
+        cbv_type=cbv_type, cbv_indices=cbv_indices, alpha=1e-2
+    )
+    assert isinstance(lc, TessLightCurve)
     # Check that returned lightcurve is in flux units
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
     assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
 
     # ElasticNet corrections
-    lc = cbvCorrector.correct_elasticnet(cbv_type=cbv_type, cbv_indices=cbv_indices,
-        alpha=1e1, l1_ratio=0.5)
-    assert isinstance(lc, TessLightCurve) 
+    lc = cbvCorrector.correct_elasticnet(
+        cbv_type=cbv_type, cbv_indices=cbv_indices, alpha=1e1, l1_ratio=0.5
+    )
+    assert isinstance(lc, TessLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
     assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
 
     # Correction optimizer
-    lc = cbvCorrector.correct(cbv_type=cbv_type, cbv_indices=cbv_indices, 
+    lc = cbvCorrector.correct(
+        cbv_type=cbv_type,
+        cbv_indices=cbv_indices,
         alpha_bounds=[1e-4, 1e4],
-        target_over_score=0.5, target_under_score=0.8)
-    assert isinstance(lc, TessLightCurve) 
+        target_over_score=0.5,
+        target_under_score=0.8,
+    )
+    assert isinstance(lc, TessLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
     assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
 
     # Goodness metric scan plot
-    ax = cbvCorrector.goodness_metric_scan_plot(cbv_type=cbv_type, cbv_indices=cbv_indices)
+    ax = cbvCorrector.goodness_metric_scan_plot(
+        cbv_type=cbv_type, cbv_indices=cbv_indices
+    )
     assert isinstance(ax, matplotlib.axes.Axes)
 
     # Try multi-scale basis vectors
-    cbv_type = ['MultiScale.1', 'MultiScale.2', 'MultiScale.3']
-    cbv_indices = ['ALL', 'ALL', 'ALL']
-    lc = cbvCorrector.correct_gaussian_prior(cbv_type=cbv_type, cbv_indices=cbv_indices,
-        alpha=1e-2)
-    assert isinstance(lc, TessLightCurve) 
-    
-    #***
+    cbv_type = ["MultiScale.1", "MultiScale.2", "MultiScale.3"]
+    cbv_indices = ["ALL", "ALL", "ALL"]
+    lc = cbvCorrector.correct_gaussian_prior(
+        cbv_type=cbv_type, cbv_indices=cbv_indices, alpha=1e-2
+    )
+    assert isinstance(lc, TessLightCurve)
+
+    # ***
     # A Kepler and K2 example
-    lc = search_lightcurve('KIC 6508221', mission='kepler', author='kepler', quarter=5).download(flux_column='sap_flux')
-    cbvCorrector =  CBVCorrector(lc)
+    lc = search_lightcurve(
+        "KIC 6508221", mission="kepler", author="kepler", quarter=5
+    ).download(flux_column="sap_flux")
+    cbvCorrector = CBVCorrector(lc)
     lc = cbvCorrector.correct_gaussian_prior(alpha=1.0)
-    assert isinstance(lc, KeplerLightCurve) 
+    assert isinstance(lc, KeplerLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
 
-    lc = search_lightcurve('EPIC 247887989', mission='k2', author='k2').download(flux_column='sap_flux')
-    cbvCorrector =  CBVCorrector(lc)
+    lc = search_lightcurve("EPIC 247887989", mission="k2", author="k2").download(
+        flux_column="sap_flux"
+    )
+    cbvCorrector = CBVCorrector(lc)
     lc = cbvCorrector.correct_gaussian_prior(alpha=1.0)
-    assert isinstance(lc, KeplerLightCurve) 
+    assert isinstance(lc, KeplerLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
 
-    #***
+    # ***
     # Try some expected failures
 
     # cbv_type and cbv_indices not the same list lengths
     with pytest.raises(AssertionError):
-        lc = cbvCorrector.correct_gaussian_prior(cbv_type=['SingleScale', 'Spike'], 
-                cbv_indices=['all'], alpha=1e-2)
+        lc = cbvCorrector.correct_gaussian_prior(
+            cbv_type=["SingleScale", "Spike"], cbv_indices=["all"], alpha=1e-2
+        )
 
     # cbv_type is not a list
     with pytest.raises(AssertionError):
-        lc = cbvCorrector.correct_gaussian_prior(cbv_type='SingleScale', 
-                cbv_indices=['all'], alpha=1e-2)
+        lc = cbvCorrector.correct_gaussian_prior(
+            cbv_type="SingleScale", cbv_indices=["all"], alpha=1e-2
+        )
 
     # cbv_indices is not a list
     with pytest.raises(AssertionError):
-        lc = cbvCorrector.correct_gaussian_prior(cbv_type=['SingleScale'], 
-                cbv_indices='all', alpha=1e-2)
-
+        lc = cbvCorrector.correct_gaussian_prior(
+            cbv_type=["SingleScale"], cbv_indices="all", alpha=1e-2
+        )

--- a/tests/correctors/test_designmatrix.py
+++ b/tests/correctors/test_designmatrix.py
@@ -11,20 +11,20 @@ from lightkurve import LightkurveWarning
 
 def test_designmatrix_basics():
     """Can we create a design matrix from a dataframe?"""
-    size, name = 10, 'testmatrix'
-    df = pd.DataFrame({'vector1': np.ones(size),
-                       'vector2': np.zeros(size),
-                       'vector3': np.ones(size)})
+    size, name = 10, "testmatrix"
+    df = pd.DataFrame(
+        {"vector1": np.ones(size), "vector2": np.zeros(size), "vector3": np.ones(size)}
+    )
     dm = DesignMatrix(df, name=name)
-    assert dm.columns == ['vector1', 'vector2', 'vector3']
+    assert dm.columns == ["vector1", "vector2", "vector3"]
     assert dm.name == name
     assert dm.shape == (size, 3)
-    assert (dm['vector1'] == df['vector1']).all()
+    assert (dm["vector1"] == df["vector1"]).all()
     dm.plot()
     dm.plot_priors()
     assert dm.append_constant().shape == (size, 4)  # expect one column more
-    assert dm.pca(nterms=2).shape == (size, 2)      # expect one column less
-    assert dm.split([10]).shape == (size, 6)        # expect double columns
+    assert dm.pca(nterms=2).shape == (size, 2)  # expect one column less
+    assert dm.split([10]).shape == (size, 6)  # expect double columns
     dm.__repr__()
 
     dm = DesignMatrix(df, name=name)
@@ -33,7 +33,7 @@ def test_designmatrix_basics():
 
     dm = DesignMatrix(df, name=name)
     dm.split([10], inplace=True)
-    assert dm.shape == (size, 6)        # expect double columns
+    assert dm.shape == (size, 6)  # expect double columns
 
 
 def test_designmatrix_from_numpy():
@@ -41,31 +41,31 @@ def test_designmatrix_from_numpy():
     size = 10
     dm = DesignMatrix(np.ones((size, 2)))
     assert dm.columns == [0, 1]
-    assert dm.name == 'unnamed_matrix'
+    assert dm.name == "unnamed_matrix"
     assert (dm[0] == np.ones(size)).all()
 
 
 def test_designmatrix_from_dict():
     """Can we create a design matrix from a dictionary?"""
     size = 10
-    dm = DesignMatrix({'centroid_col': np.ones(size),
-                       'centroid_row': np.ones(size)},
-                      name='motion_systematics')
+    dm = DesignMatrix(
+        {"centroid_col": np.ones(size), "centroid_row": np.ones(size)},
+        name="motion_systematics",
+    )
     assert dm.shape == (size, 2)
-    assert (dm['centroid_col'] == np.ones(size)).all()
+    assert (dm["centroid_col"] == np.ones(size)).all()
 
 
 def test_split():
     """Can we split a design matrix correctly?"""
-    dm = DesignMatrix({'a': np.linspace(0, 9, 10),
-                       'b': np.linspace(100, 109, 10)})
+    dm = DesignMatrix({"a": np.linspace(0, 9, 10), "b": np.linspace(100, 109, 10)})
     # Do we retrieve the correct shape?
     assert dm.shape == (10, 2)
     assert dm.split(2).shape == (10, 4)
-    assert dm.split([2,8]).shape == (10, 6)
+    assert dm.split([2, 8]).shape == (10, 6)
     # Are the new areas padded with zeros?
-    assert (dm.split([2,8]).values[2:, 0:2] == 0).all()
-    assert (dm.split([2,8]).values[:8, 4:] == 0).all()
+    assert (dm.split([2, 8]).values[2:, 0:2] == 0).all()
+    assert (dm.split([2, 8]).values[:8, 4:] == 0).all()
     # Are all the column names unique?
     assert len(set(dm.split(2).columns)) == 4
 
@@ -73,20 +73,25 @@ def test_split():
 def test_standardize():
     """Verifies DesignMatrix.standardize()"""
     # A column with zero standard deviation remains unchanged
-    dm = DesignMatrix({'const': np.ones(10)})
-    assert (dm.standardize()['const'] == dm['const']).all()
+    dm = DesignMatrix({"const": np.ones(10)})
+    assert (dm.standardize()["const"] == dm["const"]).all()
     # Normally-distributed columns will become Normal(0, 1)
-    dm = DesignMatrix({'normal': np.random.normal(loc=5, scale=3, size=100)})
-    assert np.round(np.median(dm.standardize()['normal']), 3) == 0
-    assert np.round(np.std(dm.standardize()['normal']), 1) == 1
+    dm = DesignMatrix({"normal": np.random.normal(loc=5, scale=3, size=100)})
+    assert np.round(np.median(dm.standardize()["normal"]), 3) == 0
+    assert np.round(np.std(dm.standardize()["normal"]), 1) == 1
     dm.standardize(inplace=True)
+
 
 def test_pca():
     """Verifies DesignMatrix.pca()"""
     size = 10
-    dm = DesignMatrix({'a':np.random.normal(10, 20, size),
-                       'b':np.random.normal(40, 10, size),
-                       'c':np.random.normal(60, 5, size)})
+    dm = DesignMatrix(
+        {
+            "a": np.random.normal(10, 20, size),
+            "b": np.random.normal(40, 10, size),
+            "c": np.random.normal(60, 5, size),
+        }
+    )
     for nterms in [1, 2, 3]:
         assert dm.pca(nterms=nterms).shape == (size, nterms)
 
@@ -94,19 +99,19 @@ def test_pca():
 def test_collection_basics():
     """Can we create a design matrix collection?"""
     size = 5
-    dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1')
-    dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2')
+    dm1 = DesignMatrix(np.ones((size, 1)), columns=["col1"], name="matrix1")
+    dm2 = DesignMatrix(np.zeros((size, 2)), columns=["col2", "col3"], name="matrix2")
 
     dmc = DesignMatrixCollection([dm1, dm2])
-    assert_array_equal(dmc['matrix1'].values, dm1.values)
-    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc["matrix1"].values, dm1.values)
+    assert_array_equal(dmc["matrix2"].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
     dmc.plot()
     dmc.__repr__()
 
     dmc = dm1.collect(dm2)
-    assert_array_equal(dmc['matrix1'].values, dm1.values)
-    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc["matrix1"].values, dm1.values)
+    assert_array_equal(dmc["matrix2"].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
 
     assert isinstance(dmc.to_designmatrix(), DesignMatrix)
@@ -117,13 +122,20 @@ def test_designmatrix_rank():
     warnings.simplefilter("always")
 
     # Good rank
-    dm = DesignMatrix({'a': [1, 2, 3]})
+    dm = DesignMatrix({"a": [1, 2, 3]})
     assert dm.rank == 1
     dm.validate(rank=True)  # Should not raise a warning
 
     # Bad rank
-    with pytest.warns(LightkurveWarning, match='rank'):
-        dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
-                           'd': [1, 1, 1], 'e': [3, 4, 5]})
+    with pytest.warns(LightkurveWarning, match="rank"):
+        dm = DesignMatrix(
+            {
+                "a": [1, 2, 3],
+                "b": [1, 1, 1],
+                "c": [1, 1, 1],
+                "d": [1, 1, 1],
+                "e": [3, 4, 5],
+            }
+        )
         assert dm.rank == 2
-        dm.validate(rank=True) # Should raise a warning
+        dm.validate(rank=True)  # Should raise a warning

--- a/tests/correctors/test_metrics.py
+++ b/tests/correctors/test_metrics.py
@@ -1,9 +1,13 @@
 import numpy as np
 import pytest
-from numpy.testing import (assert_allclose)
+from numpy.testing import assert_allclose
 
 from lightkurve import LightCurve, search_lightcurve
-from lightkurve.correctors.metrics import overfit_metric_lombscargle, underfit_metric_neighbors, _compute_correlation
+from lightkurve.correctors.metrics import (
+    overfit_metric_lombscargle,
+    underfit_metric_neighbors,
+    _compute_correlation,
+)
 
 
 def test_overfit_metric_lombscargle():
@@ -50,23 +54,30 @@ def test_underfit_metric_neighbors():
     assert underfit_metric_neighbors(lc_sap, min_targets=3, max_targets=3) == 1.0
 
 
-
 def test_compute_correlation():
     """ Simple test to verify the correction function works"""
-    
+
     # Fully correlated matrix
-    fluxMatrix = np.array([[1,1,1,1], [1,1,1,1], [1,1,1,1], [1,1,1,1]])
+    fluxMatrix = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]])
     correlation_matrix = _compute_correlation(fluxMatrix)
     assert np.all(correlation_matrix == 1.0)
 
     # Partially correlated
-    fluxMatrix = np.array([[ 1.0, -1.0,  1.0, -1.0], 
-                           [-1.0,  1.0,  1.0, -1.0], 
-                           [ 1.0, -1.0,  1.0, -1.0], 
-                           [-1.0,  1.0, -1.0,  1.0]])
+    fluxMatrix = np.array(
+        [
+            [1.0, -1.0, 1.0, -1.0],
+            [-1.0, 1.0, 1.0, -1.0],
+            [1.0, -1.0, 1.0, -1.0],
+            [-1.0, 1.0, -1.0, 1.0],
+        ]
+    )
     correlation_matrix = _compute_correlation(fluxMatrix)
-    correlation_truth = np.array([[ 1.0, -1.0,  0.5, -0.5], 
-                           [-1.0,  1.0, -0.5,  0.5], 
-                           [ 0.5, -0.5,  1.0, -1.0], 
-                           [-0.5,  0.5, -1.0,  1.0]])
+    correlation_truth = np.array(
+        [
+            [1.0, -1.0, 0.5, -0.5],
+            [-1.0, 1.0, -0.5, 0.5],
+            [0.5, -0.5, 1.0, -1.0],
+            [-0.5, 0.5, -1.0, 1.0],
+        ]
+    )
     assert_allclose(correlation_matrix, correlation_truth)

--- a/tests/correctors/test_pldcorrector.py
+++ b/tests/correctors/test_pldcorrector.py
@@ -2,17 +2,22 @@ import pytest
 
 import matplotlib.pyplot as plt
 
-from lightkurve import search_targetpixelfile, search_tesscut, KeplerLightCurve, TessLightCurve
+from lightkurve import (
+    search_targetpixelfile,
+    search_tesscut,
+    KeplerLightCurve,
+    TessLightCurve,
+)
 from lightkurve.correctors import PLDCorrector
 
 
 @pytest.mark.remote_data
 def test_kepler_pld_corrector():
-    tpf = search_targetpixelfile('K2-199')[0].download()
+    tpf = search_targetpixelfile("K2-199")[0].download()
     pld = PLDCorrector(tpf)
     # Is the correct filetype returned?
     clc = pld.correct()
-    assert(isinstance(clc, KeplerLightCurve))
+    assert isinstance(clc, KeplerLightCurve)
     # Do the diagnostic plots run?
     pld.diagnose()
     plt.close()
@@ -21,17 +26,17 @@ def test_kepler_pld_corrector():
     # Does sparse correction work?
     pld.correct(sparse=True)
     # Did the correction with default values help?
-    raw_lc = tpf.to_lightcurve(aperture_mask='threshold')
-    assert(clc.estimate_cdpp() < raw_lc.estimate_cdpp())
+    raw_lc = tpf.to_lightcurve(aperture_mask="threshold")
+    assert clc.estimate_cdpp() < raw_lc.estimate_cdpp()
 
 
 @pytest.mark.remote_data
 def test_tess_pld_corrector():
-    tpf = search_targetpixelfile('TOI 700')[0].download()
+    tpf = search_targetpixelfile("TOI 700")[0].download()
     pld = PLDCorrector(tpf)
     # Is the correct filetype returned?
     clc = pld.correct()
-    assert(isinstance(clc, TessLightCurve))
+    assert isinstance(clc, TessLightCurve)
     # Do the diagnostic plots run?
     pld.diagnose()
     plt.close()
@@ -40,23 +45,25 @@ def test_tess_pld_corrector():
     # Does sparse correction work?
     pld.correct(sparse=True)
     # Did the correction with default values help?
-    raw_lc = tpf.to_lightcurve(aperture_mask='threshold')
-    assert(clc.estimate_cdpp() < raw_lc.estimate_cdpp())
+    raw_lc = tpf.to_lightcurve(aperture_mask="threshold")
+    assert clc.estimate_cdpp() < raw_lc.estimate_cdpp()
 
 
 @pytest.mark.remote_data
 def test_pld_aperture_mask():
     """Test for #523: does PLDCorrector.correct() accept separate apertures for
     PLD pixels?"""
-    tpf = search_targetpixelfile('K2-205')[0].download()
+    tpf = search_targetpixelfile("K2-205")[0].download()
     # use only the pixels in the pipeline mask
-    lc_pipeline = tpf.to_corrector("pld").correct(pld_aperture_mask='pipeline',
-                                                  restore_trend=False)
+    lc_pipeline = tpf.to_corrector("pld").correct(
+        pld_aperture_mask="pipeline", restore_trend=False
+    )
     # use all pixels in the tpf
-    lc_all = tpf.to_corrector("pld").correct(pld_aperture_mask='all',
-                                             restore_trend=False)
+    lc_all = tpf.to_corrector("pld").correct(
+        pld_aperture_mask="all", restore_trend=False
+    )
     # does this improve the correction?
-    assert(lc_all.estimate_cdpp() < lc_pipeline.estimate_cdpp())
+    assert lc_all.estimate_cdpp() < lc_pipeline.estimate_cdpp()
 
 
 @pytest.mark.remote_data
@@ -65,15 +72,15 @@ def test_pld_corrector():
     k2_target = "EPIC247887989"
     k2_tpf = search_targetpixelfile(k2_target).download()
     # instantiate PLD corrector object
-    pld = PLDCorrector(k2_tpf[:500], aperture_mask='threshold')
+    pld = PLDCorrector(k2_tpf[:500], aperture_mask="threshold")
     # produce a PLD-corrected light curve with a default aperture mask
     corrected_lc = pld.correct()
     # ensure the CDPP was reduced by the corrector
     pld_cdpp = corrected_lc.estimate_cdpp()
     raw_cdpp = k2_tpf.to_lightcurve().estimate_cdpp()
-    assert(pld_cdpp < raw_cdpp)
+    assert pld_cdpp < raw_cdpp
     # make sure the returned object is the correct type (`KeplerLightCurve`)
-    assert(isinstance(corrected_lc, KeplerLightCurve))
+    assert isinstance(corrected_lc, KeplerLightCurve)
     # try detrending using a threshold mask
     corrected_lc = pld.correct()
     # reduce using fewer principle components
@@ -81,20 +88,21 @@ def test_pld_corrector():
     # try PLD on a TESS observation
     from lightkurve import TessTargetPixelFile
     from ..test_targetpixelfile import TESS_SIM
+
     tess_tpf = TessTargetPixelFile(TESS_SIM)
     # instantiate PLD corrector object
-    pld = PLDCorrector(tess_tpf[:500], aperture_mask='pipeline')
+    pld = PLDCorrector(tess_tpf[:500], aperture_mask="pipeline")
     # produce a PLD-corrected light curve with a pipeline aperture mask
-    raw_lc = tess_tpf.to_lightcurve(aperture_mask='pipeline')
+    raw_lc = tess_tpf.to_lightcurve(aperture_mask="pipeline")
     corrected_lc = pld.correct(pca_components=20)
     # the corrected light curve should have higher precision
-    assert(corrected_lc.estimate_cdpp() < raw_lc.estimate_cdpp())
+    assert corrected_lc.estimate_cdpp() < raw_lc.estimate_cdpp()
     # make sure the returned object is the correct type (`TessLightCurve`)
-    assert(isinstance(corrected_lc, TessLightCurve))
+    assert isinstance(corrected_lc, TessLightCurve)
 
 
 @pytest.mark.remote_data
 def test_tpf_with_zero_flux_cadence():
     """Regression test for #873."""
     tpf = search_tesscut("TIC 123835353", sector=6).download(cutout_size=5)
-    tpf.to_corrector('pld').correct()
+    tpf.to_corrector("pld").correct()

--- a/tests/correctors/test_regressioncorrector.py
+++ b/tests/correctors/test_regressioncorrector.py
@@ -20,7 +20,7 @@ def test_regressioncorrector_priors():
     """
     lc1 = LightCurve(flux=[5, 10])
     lc2 = LightCurve(flux=[5, 10], flux_err=[1, 1])
-    design_matrix = DesignMatrix(pd.DataFrame({'a':[1, 1], 'b':[1, 2]}))
+    design_matrix = DesignMatrix(pd.DataFrame({"a": [1, 1], "b": [1, 2]}))
     for dm in [design_matrix, design_matrix.to_sparse()]:
         for lc in [lc1, lc2]:
             rc = RegressionCorrector(lc)
@@ -47,19 +47,20 @@ def test_regressioncorrector_priors():
             rc.correct(dm)
             assert_almost_equal(rc.coefficients, [0, 5])
 
+
 def test_sinusoid_noise():
     """Can we remove simple sinusoid noise added to a flat light curve?"""
     size = 100
     time = np.linspace(1, 100, size)
     true_flux = np.ones(size)
-    noise = np.sin(time/5)
+    noise = np.sin(time / 5)
     # True light curve is flat, i.e. flux=1 at all time steps
-    true_lc = LightCurve(time=time, flux=true_flux, flux_err=0.1*np.ones(size))
+    true_lc = LightCurve(time=time, flux=true_flux, flux_err=0.1 * np.ones(size))
     # Noisy light curve has a sinusoid single added
-    noisy_lc = LightCurve(time=time, flux=true_flux+noise, flux_err=true_lc.flux_err)
-    design_matrix = DesignMatrix({'noise': noise,
-                                  'offset': np.ones(len(time))},
-                                  name='noise_model')
+    noisy_lc = LightCurve(time=time, flux=true_flux + noise, flux_err=true_lc.flux_err)
+    design_matrix = DesignMatrix(
+        {"noise": noise, "offset": np.ones(len(time))}, name="noise_model"
+    )
 
     for dm in [design_matrix, design_matrix.to_sparse()]:
         # Can we recover the true light curve?
@@ -77,7 +78,7 @@ def test_sinusoid_noise():
         assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
         # Does it work when `flux_err` isn't available?
-        noisy_lc = LightCurve(time=time, flux=true_flux+noise)
+        noisy_lc = LightCurve(time=time, flux=true_flux + noise)
         corrected_lc = RegressionCorrector(noisy_lc).correct(dm)
         assert_almost_equal(corrected_lc.normalize().flux, true_lc.flux)
 
@@ -87,8 +88,10 @@ def test_nan_input():
     with warnings.catch_warnings():
         # Instantiating light curves with NaN times will yield a warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        lcs = [LightCurve(flux=[5, 10], flux_err=[np.nan, 1]),
-               LightCurve(flux=[np.nan, 10], flux_err=[1, 1])]
+        lcs = [
+            LightCurve(flux=[5, 10], flux_err=[np.nan, 1]),
+            LightCurve(flux=[np.nan, 10], flux_err=[1, 1]),
+        ]
 
     # Passing these to RegressionCorrector should raise a ValueError
     for lc in lcs:

--- a/tests/correctors/test_sffcorrector.py
+++ b/tests/correctors/test_sffcorrector.py
@@ -6,14 +6,20 @@ import numpy as np
 from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_array_equal
 
-from lightkurve import LightCurve, KeplerLightCurve, \
-                TessLightCurve, LightkurveWarning, \
-                search_lightcurve
+from lightkurve import (
+    LightCurve,
+    KeplerLightCurve,
+    TessLightCurve,
+    LightkurveWarning,
+    search_lightcurve,
+)
 from lightkurve.correctors import SFFCorrector
 
 
-K2_C08 = ("https://archive.stsci.edu/missions/k2/lightcurves/c8/"
-          "220100000/39000/ktwo220139473-c08_llc.fits")
+K2_C08 = (
+    "https://archive.stsci.edu/missions/k2/lightcurves/c8/"
+    "220100000/39000/ktwo220139473-c08_llc.fits"
+)
 
 
 @pytest.mark.remote_data
@@ -33,21 +39,26 @@ def test_sff_knots():
     in the interval between day 30 and 78.  SFF should fail without error.
     """
     n_points = 300
-    fn = get_pkg_data_filename('../../tests/data/ep60021426alldiagnostics.csv')
-    data = np.genfromtxt(fn, delimiter=',', skip_header=1)
+    fn = get_pkg_data_filename("../../tests/data/ep60021426alldiagnostics.csv")
+    data = np.genfromtxt(fn, delimiter=",", skip_header=1)
     raw_flux = data[:, 1][:n_points]
     centroid_col = data[:, 3][:n_points]
     centroid_row = data[:, 4][:n_points]
 
-    time = np.concatenate((np.linspace(0, 20, int(n_points/3)),
-                           np.linspace(30, 78, int(n_points/3)),
-                           np.linspace(80, 100, int(n_points/3))
-                           ))
-    lc = KeplerLightCurve(time=time,
-                          flux=raw_flux,
-                          flux_err=np.ones(n_points) * 0.0001,
-                          centroid_col=centroid_col,
-                          centroid_row=centroid_row)
+    time = np.concatenate(
+        (
+            np.linspace(0, 20, int(n_points / 3)),
+            np.linspace(30, 78, int(n_points / 3)),
+            np.linspace(80, 100, int(n_points / 3)),
+        )
+    )
+    lc = KeplerLightCurve(
+        time=time,
+        flux=raw_flux,
+        flux_err=np.ones(n_points) * 0.0001,
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+    )
 
     # These calls should not raise an exception:
     SFFCorrector(lc).correct()
@@ -60,8 +71,8 @@ def test_sff_corrector():
     # The following csv file, provided by Vanderburg and Johnson
     # at https://www.cfa.harvard.edu/~avanderb/k2/ep60021426.html,
     # contains the results of applying SFF to EPIC 60021426.
-    fn = get_pkg_data_filename('../../tests/data/ep60021426alldiagnostics.csv')
-    data = np.genfromtxt(fn, delimiter=',', skip_header=1)
+    fn = get_pkg_data_filename("../../tests/data/ep60021426alldiagnostics.csv")
+    data = np.genfromtxt(fn, delimiter=",", skip_header=1)
     mask = data[:, -2] == 0  # indicates whether the thrusters were on or off
     time = data[:, 0]
     raw_flux = data[:, 1]
@@ -73,60 +84,83 @@ def test_sff_corrector():
     # is unusually short, i.e. has an unusually small number of cadences.
     lc = LightCurve(time=time, flux=raw_flux, flux_err=np.ones(len(raw_flux)) * 0.0001)
     sff = SFFCorrector(lc)
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row,
-                               restore_trend=True,
-                               windows=1)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        restore_trend=True,
+        windows=1,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
     assert len(sff.window_points) == 0  # expect 0 break points for 1 window
 
     # masking
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row,
-                               windows=3,
-                               restore_trend=True,
-                               cadence_mask=mask)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        windows=3,
+        restore_trend=True,
+        cadence_mask=mask,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
     assert len(sff.window_points) == 2  # expect 2 break points for 3 windows
 
     # masking and breakindex
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row,
-                               windows=3,
-                               restore_trend=True,
-                               cadence_mask=mask)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        windows=3,
+        restore_trend=True,
+        cadence_mask=mask,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
 
     # masking and breakindex and iters
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row, windows=3, restore_trend=True,
-                               cadence_mask=mask, niters=3)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        windows=3,
+        restore_trend=True,
+        cadence_mask=mask,
+        niters=3,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
 
     # masking and breakindex and bins
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row, windows=3, restore_trend=True,
-                               cadence_mask=mask, bins=5)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
-    assert np.all((sff.lc.flux_err/sff.corrected_lc.flux_err) == 1)
-
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        windows=3,
+        restore_trend=True,
+        cadence_mask=mask,
+        bins=5,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
+    assert np.all((sff.lc.flux_err / sff.corrected_lc.flux_err) == 1)
 
     # masking and breakindex and bins and propagate_errors
-    corrected_lc = sff.correct(centroid_col=centroid_col,
-                               centroid_row=centroid_row, windows=3, restore_trend=True,
-                               cadence_mask=mask, bins=5, propagate_errors=True)
-    assert (np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all())
-    assert np.all((sff.lc.flux_err/sff.corrected_lc.flux_err) < 1)
+    corrected_lc = sff.correct(
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        windows=3,
+        restore_trend=True,
+        cadence_mask=mask,
+        bins=5,
+        propagate_errors=True,
+    )
+    assert np.isclose(corrected_flux, corrected_lc.flux, atol=0.001).all()
+    assert np.all((sff.lc.flux_err / sff.corrected_lc.flux_err) < 1)
 
     # test using KeplerLightCurve interface
-    klc = KeplerLightCurve(time=time,
-                           flux=raw_flux,
-                           flux_err=np.ones(len(raw_flux)) * 0.0001,
-                           centroid_col=centroid_col,
-                           centroid_row=centroid_row)
+    klc = KeplerLightCurve(
+        time=time,
+        flux=raw_flux,
+        flux_err=np.ones(len(raw_flux)) * 0.0001,
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+    )
     sff = klc.to_corrector("sff")
     klc = sff.correct(windows=3, restore_trend=True)
-    assert (np.isclose(corrected_flux, klc.flux, atol=0.001).all())
+    assert np.isclose(corrected_flux, klc.flux, atol=0.001).all()
 
     # Can plot
     sff.diagnose()
@@ -137,26 +171,31 @@ def test_sff_priors():
     SFF arclength component should have mean 0
     """
     n_points = 300
-    fn = get_pkg_data_filename('../../tests/data/ep60021426alldiagnostics.csv')
-    data = np.genfromtxt(fn, delimiter=',', skip_header=1)
+    fn = get_pkg_data_filename("../../tests/data/ep60021426alldiagnostics.csv")
+    data = np.genfromtxt(fn, delimiter=",", skip_header=1)
     raw_flux = data[:, 1][:n_points]
     centroid_col = data[:, 3][:n_points]
     centroid_row = data[:, 4][:n_points]
 
-    time = np.concatenate((np.linspace(0, 20, int(n_points/3)),
-                           np.linspace(30, 78, int(n_points/3)),
-                           np.linspace(80, 100, int(n_points/3))
-                           ))
-    lc = KeplerLightCurve(time=time,
-                          flux=raw_flux,
-                          flux_err=np.ones(n_points) * 0.0001,
-                          centroid_col=centroid_col,
-                          centroid_row=centroid_row)
+    time = np.concatenate(
+        (
+            np.linspace(0, 20, int(n_points / 3)),
+            np.linspace(30, 78, int(n_points / 3)),
+            np.linspace(80, 100, int(n_points / 3)),
+        )
+    )
+    lc = KeplerLightCurve(
+        time=time,
+        flux=raw_flux,
+        flux_err=np.ones(n_points) * 0.0001,
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+    )
 
     sff = SFFCorrector(lc)
     sff.correct()  # should not raise an exception
-    assert np.isclose(sff.diagnostic_lightcurves['spline'].flux.mean(), 1, atol=1e-3)
-    assert np.isclose(sff.diagnostic_lightcurves['sff'].flux.mean(), 0, atol=1e-3)
+    assert np.isclose(sff.diagnostic_lightcurves["spline"].flux.mean(), 1, atol=1e-3)
+    assert np.isclose(sff.diagnostic_lightcurves["sff"].flux.mean(), 0, atol=1e-3)
 
 
 def test_sff_breakindex():
@@ -166,21 +205,26 @@ def test_sff_breakindex():
         # Ignore "LightkurveWarning: The design matrix has low rank".
         warnings.simplefilter("ignore", LightkurveWarning)
         corr = SFFCorrector(lc)
-        corr.correct(breakindex=[5, 10],
-                    centroid_col=np.random.randn(20),
-                    centroid_row=np.random.randn(20))
+        corr.correct(
+            breakindex=[5, 10],
+            centroid_col=np.random.randn(20),
+            centroid_row=np.random.randn(20),
+        )
         assert 5 in corr.window_points
         assert 10 in corr.window_points
-        corr.correct(breakindex=[5, 10],
-                    centroid_col=np.random.randn(20),
-                    centroid_row=np.random.randn(20), windows=1)
+        corr.correct(
+            breakindex=[5, 10],
+            centroid_col=np.random.randn(20),
+            centroid_row=np.random.randn(20),
+            windows=1,
+        )
         assert_array_equal(corr.window_points, np.asarray([5, 10]))
 
 
 def test_sff_tess_warning():
     """SFF is not designed for TESS, so we raise a warning."""
-    lc = TessLightCurve(flux=[1, 2, 3], meta={'MISSION': 'TESS'})
-    with pytest.warns(LightkurveWarning, match='not suitable'):
+    lc = TessLightCurve(flux=[1, 2, 3], meta={"MISSION": "TESS"})
+    with pytest.warns(LightkurveWarning, match="not suitable"):
         corr = SFFCorrector(lc)
 
 

--- a/tests/correctors/test_sparsedesignmatrix.py
+++ b/tests/correctors/test_sparsedesignmatrix.py
@@ -6,49 +6,63 @@ from numpy.testing import assert_array_equal
 import pandas as pd
 from scipy import sparse
 
-from lightkurve.correctors import SparseDesignMatrix, SparseDesignMatrixCollection, DesignMatrix, DesignMatrixCollection
+from lightkurve.correctors import (
+    SparseDesignMatrix,
+    SparseDesignMatrixCollection,
+    DesignMatrix,
+    DesignMatrixCollection,
+)
 from lightkurve import LightkurveWarning
-from lightkurve.correctors.designmatrix import create_sparse_spline_matrix, create_spline_matrix
+from lightkurve.correctors.designmatrix import (
+    create_sparse_spline_matrix,
+    create_spline_matrix,
+)
 
 
 def test_designmatrix_basics():
     """Can we create a design matrix from a dataframe?"""
-    size, name = 10, 'testmatrix'
-    df = pd.DataFrame({'vector1': np.ones(size),
-                       'vector2': np.arange(size),
-                       'vector3': np.arange(size)**2})
+    size, name = 10, "testmatrix"
+    df = pd.DataFrame(
+        {
+            "vector1": np.ones(size),
+            "vector2": np.arange(size),
+            "vector3": np.arange(size) ** 2,
+        }
+    )
     X = sparse.csr_matrix(np.asarray(df))
-    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
-    assert dm.columns == ['vector1', 'vector2', 'vector3']
+    dm = SparseDesignMatrix(X, name=name, columns=["vector1", "vector2", "vector3"])
+    assert dm.columns == ["vector1", "vector2", "vector3"]
     assert dm.name == name
     assert dm.shape == (size, 3)
     dm.plot()
     dm.plot_priors()
     assert dm.append_constant().shape == (size, 4)  # expect one column more
-    assert dm.pca(nterms=2).shape == (size, 2)      # expect one column less
-    assert dm.split([5]).shape == (size, 6)        # expect double columns
+    assert dm.pca(nterms=2).shape == (size, 2)  # expect one column less
+    assert dm.split([5]).shape == (size, 6)  # expect double columns
     dm.__repr__()
 
-    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
+    dm = SparseDesignMatrix(X, name=name, columns=["vector1", "vector2", "vector3"])
     dm.append_constant(inplace=True)
     assert dm.shape == (size, 4)  # expect one column more
 
-    dm = SparseDesignMatrix(X, name=name, columns=['vector1', 'vector2', 'vector3'])
+    dm = SparseDesignMatrix(X, name=name, columns=["vector1", "vector2", "vector3"])
     dm.split([5], inplace=True)
-    assert dm.shape == (size, 6)        # expect double columns
+    assert dm.shape == (size, 6)  # expect double columns
 
 
 def test_split():
     """Can we split a design matrix correctly?"""
-    X = sparse.csr_matrix(np.vstack([np.linspace(0, 9, 10), np.linspace(100, 109, 10)]).T)
-    dm = SparseDesignMatrix(X, columns=['a', 'b'])
+    X = sparse.csr_matrix(
+        np.vstack([np.linspace(0, 9, 10), np.linspace(100, 109, 10)]).T
+    )
+    dm = SparseDesignMatrix(X, columns=["a", "b"])
     # Do we retrieve the correct shape?
     assert dm.shape == (10, 2)
     assert dm.split(2).shape == (10, 4)
-    assert dm.split([2,8]).shape == (10, 6)
+    assert dm.split([2, 8]).shape == (10, 6)
     # Are the new areas padded with zeros?
-    assert (dm.split([2,8]).values[2:, 0:2] == 0).all()
-    assert (dm.split([2,8]).values[:8, 4:] == 0).all()
+    assert (dm.split([2, 8]).values[2:, 0:2] == 0).all()
+    assert (dm.split([2, 8]).values[:8, 4:] == 0).all()
     # Are all the column names unique?
     assert len(set(dm.split(4).columns)) == 4
 
@@ -57,22 +71,27 @@ def test_standardize():
     """Verifies DesignMatrix.standardize()"""
     # A column with zero standard deviation remains unchanged
     X = sparse.csr_matrix(np.vstack([np.ones(10)]).T)
-    dm = SparseDesignMatrix(X, columns=['const'])
-    assert (dm.standardize()['const'] == dm['const']).all()
+    dm = SparseDesignMatrix(X, columns=["const"])
+    assert (dm.standardize()["const"] == dm["const"]).all()
     # Normally-distributed columns will become Normal(0, 1)
-    X = sparse.csr_matrix(np.vstack([ np.random.normal(loc=5, scale=3, size=100)]).T)
-    dm = SparseDesignMatrix(X, columns=['normal'])
+    X = sparse.csr_matrix(np.vstack([np.random.normal(loc=5, scale=3, size=100)]).T)
+    dm = SparseDesignMatrix(X, columns=["normal"])
 
-    assert np.round(np.mean(dm.standardize()['normal']), 3) == 0
-    assert np.round(np.std(dm.standardize()['normal']), 1) == 1
+    assert np.round(np.mean(dm.standardize()["normal"]), 3) == 0
+    assert np.round(np.std(dm.standardize()["normal"]), 1) == 1
     dm.standardize(inplace=True)
+
 
 def test_pca():
     """Verifies DesignMatrix.pca()"""
     size = 10
-    dm = DesignMatrix({'a':np.random.normal(10, 20, size),
-                       'b':np.random.normal(40, 10, size),
-                       'c':np.random.normal(60, 5, size)}).to_sparse()
+    dm = DesignMatrix(
+        {
+            "a": np.random.normal(10, 20, size),
+            "b": np.random.normal(40, 10, size),
+            "c": np.random.normal(60, 5, size),
+        }
+    ).to_sparse()
     for nterms in [1, 2, 3]:
         assert dm.pca(nterms=nterms).shape == (size, nterms)
 
@@ -80,35 +99,45 @@ def test_pca():
 def test_collection_basics():
     """Can we create a design matrix collection?"""
     size = 5
-    dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1').to_sparse()
-    dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2').to_sparse()
+    dm1 = DesignMatrix(np.ones((size, 1)), columns=["col1"], name="matrix1").to_sparse()
+    dm2 = DesignMatrix(
+        np.zeros((size, 2)), columns=["col2", "col3"], name="matrix2"
+    ).to_sparse()
 
     dmc = SparseDesignMatrixCollection([dm1, dm2])
-    assert_array_equal(dmc['matrix1'].values, dm1.values)
-    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc["matrix1"].values, dm1.values)
+    assert_array_equal(dmc["matrix2"].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
     dmc.plot()
     dmc.__repr__()
 
     dmc = dm1.collect(dm2)
-    assert_array_equal(dmc['matrix1'].values, dm1.values)
-    assert_array_equal(dmc['matrix2'].values, dm2.values)
+    assert_array_equal(dmc["matrix1"].values, dm1.values)
+    assert_array_equal(dmc["matrix2"].values, dm2.values)
     assert_array_equal(dmc.values, np.hstack((dm1.values, dm2.values)))
 
     """Can we create a design matrix collection when one is sparse?"""
     size = 5
-    dm1 = DesignMatrix(np.ones((size, 1)), columns=['col1'], name='matrix1')
-    dm2 = DesignMatrix(np.zeros((size, 2)), columns=['col2', 'col3'], name='matrix2').to_sparse()
+    dm1 = DesignMatrix(np.ones((size, 1)), columns=["col1"], name="matrix1")
+    dm2 = DesignMatrix(
+        np.zeros((size, 2)), columns=["col2", "col3"], name="matrix2"
+    ).to_sparse()
 
     with warnings.catch_warnings():
         warnings.simplefilter("always")
-        with pytest.warns(LightkurveWarning, match='Sparse matrices will be converted to dense matrices.'):
+        with pytest.warns(
+            LightkurveWarning,
+            match="Sparse matrices will be converted to dense matrices.",
+        ):
             dmc = DesignMatrixCollection([dm1, dm2])
             assert not np.any([sparse.issparse(d.X) for d in dmc])
 
     with warnings.catch_warnings():
         warnings.simplefilter("always")
-        with pytest.warns(LightkurveWarning, match='Dense matrices will be converted to sparse matrices.'):
+        with pytest.warns(
+            LightkurveWarning,
+            match="Dense matrices will be converted to sparse matrices.",
+        ):
             dmc = SparseDesignMatrixCollection([dm1, dm2])
             assert np.all([sparse.issparse(d.X) for d in dmc])
 
@@ -123,18 +152,25 @@ def test_designmatrix_rank():
     warnings.simplefilter("always")
 
     # Good rank
-    dm = DesignMatrix({'a': [1, 2, 3]}).to_sparse()
+    dm = DesignMatrix({"a": [1, 2, 3]}).to_sparse()
     assert dm.rank == 1
     dm.validate(rank=True)  # Should not raise a warning
 
     # Bad rank
-    with pytest.warns(LightkurveWarning, match='rank'):
-        dm = DesignMatrix({'a': [1, 2, 3], 'b': [1, 1, 1], 'c': [1, 1, 1],
-                           'd': [1, 1, 1], 'e': [3, 4, 5]})
-        dm.validate(rank=True) # Should raise a warning
+    with pytest.warns(LightkurveWarning, match="rank"):
+        dm = DesignMatrix(
+            {
+                "a": [1, 2, 3],
+                "b": [1, 1, 1],
+                "c": [1, 1, 1],
+                "d": [1, 1, 1],
+                "e": [3, 4, 5],
+            }
+        )
+        dm.validate(rank=True)  # Should raise a warning
     dm = dm.to_sparse()
     assert dm.rank == 2
-    with pytest.warns(LightkurveWarning, match='rank'):
+    with pytest.warns(LightkurveWarning, match="rank"):
         dm.validate(rank=True)
 
 

--- a/tests/io/test_detect.py
+++ b/tests/io/test_detect.py
@@ -12,5 +12,5 @@ def test_detect_filetype():
     """Can we detect the correct filetype?"""
     k2_path = os.path.join(TESTDATA, "test-tpf-star.fits")
     tess_path = os.path.join(TESTDATA, "tess25155310-s01-first-cadences.fits.gz")
-    assert detect_filetype(fits.open(k2_path)) == 'KeplerTargetPixelFile'
-    assert detect_filetype(fits.open(tess_path)) == 'TessTargetPixelFile'
+    assert detect_filetype(fits.open(k2_path)) == "KeplerTargetPixelFile"
+    assert detect_filetype(fits.open(tess_path)) == "TessTargetPixelFile"

--- a/tests/io/test_k2sff.py
+++ b/tests/io/test_k2sff.py
@@ -19,11 +19,11 @@ def test_read_k2sff():
         lc = read_k2sff_lightcurve(url, ext=ext)
         assert type(lc).__name__ == "KeplerLightCurve"
         # Are `time` and `flux` consistent with the FITS file?
-        assert_array_equal(f[ext].data['T'], lc.time.value)
-        assert_array_equal(f[ext].data['FCOR'], lc.flux.value)
+        assert_array_equal(f[ext].data["T"], lc.time.value)
+        assert_array_equal(f[ext].data["FCOR"], lc.flux.value)
         fluxes.append(lc.flux)
     # Different extensions should show different fluxes
-    assert not np.array_equal(fluxes[0] , fluxes[1])
+    assert not np.array_equal(fluxes[0], fluxes[1])
 
 
 @pytest.mark.remote_data

--- a/tests/io/test_pathos.py
+++ b/tests/io/test_pathos.py
@@ -8,13 +8,14 @@ from lightkurve import search_lightcurve
 from lightkurve.io.pathos import read_pathos_lightcurve
 from lightkurve.io.detect import detect_filetype
 
+
 @pytest.mark.remote_data
 def test_detect_pathos():
     """Can we detect the correct format for PATHOS files?"""
     url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/pathos/s0008/hlsp_pathos_tess_lightcurve_tic-0093270923-s0008_tess_v1_llc.fits"
     f = fits.open(url)
 
-    assert detect_filetype(f)=="PATHOS"
+    assert detect_filetype(f) == "PATHOS"
 
 
 @pytest.mark.remote_data
@@ -25,22 +26,21 @@ def test_read_pathos():
     # Verify different extensions
     fluxes = []
 
-    exts = ['PSF_FLUX_RAW', 'PSF_FLUX_COR']
-    exts.extend([f'AP{ap}_FLUX_RAW' for ap in [1,2,3,4]])
-    exts.extend([f'AP{ap}_FLUX_COR' for ap in [1,2,3,4]])
+    exts = ["PSF_FLUX_RAW", "PSF_FLUX_COR"]
+    exts.extend([f"AP{ap}_FLUX_RAW" for ap in [1, 2, 3, 4]])
+    exts.extend([f"AP{ap}_FLUX_COR" for ap in [1, 2, 3, 4]])
 
     for ext in exts:
         lc = read_pathos_lightcurve(url, flux_column=ext)
         assert type(lc).__name__ == "TessLightCurve"
         # Are `time` and `flux` consistent with the FITS file?
-        assert_array_equal(f[1].data['TIME'][lc.meta['QUALITY_MASK']],
-                           lc.time.value)
-        assert_array_equal(f[1].data[ext][lc.meta['QUALITY_MASK']],
-                           lc.flux.value)
+        assert_array_equal(f[1].data["TIME"][lc.meta["QUALITY_MASK"]], lc.time.value)
+        assert_array_equal(f[1].data[ext][lc.meta["QUALITY_MASK"]], lc.flux.value)
         fluxes.append(lc.flux)
     # Different extensions should show different fluxes
     for i in range(9):
-        assert not np.array_equal(fluxes[i] , fluxes[i+1])
+        assert not np.array_equal(fluxes[i], fluxes[i + 1])
+
 
 @pytest.mark.remote_data
 def test_search_pathos():

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -5,10 +5,16 @@ import tempfile
 import pytest
 
 from lightkurve.utils import LightkurveDeprecationWarning, LightkurveError
-from lightkurve import PACKAGEDIR, KeplerTargetPixelFile, TessTargetPixelFile, LightCurve
+from lightkurve import (
+    PACKAGEDIR,
+    KeplerTargetPixelFile,
+    TessTargetPixelFile,
+    LightCurve,
+)
 from lightkurve.io import read
 
 from .. import TESTDATA
+
 
 def test_read():
     # define paths to k2 and tess data
@@ -16,24 +22,25 @@ def test_read():
     tess_path = os.path.join(TESTDATA, "tess25155310-s01-first-cadences.fits.gz")
     # Ensure files are read in as the correct object
     k2tpf = read(k2_path)
-    assert(isinstance(k2tpf, KeplerTargetPixelFile))
+    assert isinstance(k2tpf, KeplerTargetPixelFile)
     tesstpf = read(tess_path)
-    assert(isinstance(tesstpf, TessTargetPixelFile))
+    assert isinstance(tesstpf, TessTargetPixelFile)
     # Open should fail if the filetype is not recognized
     try:
         read(os.path.join(PACKAGEDIR, "data", "lightkurve.mplstyle"))
     except LightkurveError:
         pass
     # Can you instantiate with a path?
-    assert(isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile))
-    assert(isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile))
+    assert isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile)
+    assert isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile)
     # Can open take a quality_bitmask argument?
-    assert(read(k2_path, quality_bitmask='hard').quality_bitmask == 'hard')
+    assert read(k2_path, quality_bitmask="hard").quality_bitmask == "hard"
 
 
 def test_open():
     """Does the deprecated `open` function still work?"""
     from lightkurve.io import open
+
     with warnings.catch_warnings():  # lk.open is deprecated
         warnings.simplefilter("ignore", LightkurveDeprecationWarning)
         # define paths to k2 and tess data
@@ -41,19 +48,19 @@ def test_open():
         tess_path = os.path.join(TESTDATA, "tess25155310-s01-first-cadences.fits.gz")
         # Ensure files are read in as the correct object
         k2tpf = open(k2_path)
-        assert(isinstance(k2tpf, KeplerTargetPixelFile))
+        assert isinstance(k2tpf, KeplerTargetPixelFile)
         tesstpf = open(tess_path)
-        assert(isinstance(tesstpf, TessTargetPixelFile))
+        assert isinstance(tesstpf, TessTargetPixelFile)
         # Open should fail if the filetype is not recognized
         try:
             open(os.path.join(PACKAGEDIR, "data", "lightkurve.mplstyle"))
         except LightkurveError:
             pass
         # Can you instantiate with a path?
-        assert(isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile))
-        assert(isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile))
+        assert isinstance(KeplerTargetPixelFile(k2_path), KeplerTargetPixelFile)
+        assert isinstance(TessTargetPixelFile(tess_path), TessTargetPixelFile)
         # Can open take a quality_bitmask argument?
-        assert(open(k2_path, quality_bitmask='hard').quality_bitmask == 'hard')
+        assert open(k2_path, quality_bitmask="hard").quality_bitmask == "hard"
 
 
 def test_filenotfound():
@@ -65,7 +72,9 @@ def test_filenotfound():
 def test_basic_ascii_io():
     """Verify we do not break the basic ascii i/o functionality provided by AstroPy Table."""
     # Part I: Can we read a LightCurve from a CSV file?
-    csvfile = tempfile.NamedTemporaryFile(delete=False)  # using delete=False to make tests pass on Windows
+    csvfile = tempfile.NamedTemporaryFile(
+        delete=False
+    )  # using delete=False to make tests pass on Windows
     try:
         csvfile.write(b"time,flux,flux_err,color\n1,2,3,red\n4,5,6,green\n7,8,9,blue")
         csvfile.flush()
@@ -80,8 +89,8 @@ def test_basic_ascii_io():
     # Part II: can we write the light curve to a tab-separated ascii file, and read it back in?
     tabfile = tempfile.NamedTemporaryFile(delete=False)
     try:
-        lc_csv.write(tabfile.name, format='ascii.tab', overwrite=True)
-        lc_rst = LightCurve.read(tabfile.name, format='ascii.tab')
+        lc_csv.write(tabfile.name, format="ascii.tab", overwrite=True)
+        lc_rst = LightCurve.read(tabfile.name, format="ascii.tab")
         assert lc_rst.color[2] == "blue"
         assert (lc_csv == lc_rst).all()
     finally:

--- a/tests/io/test_tasoc.py
+++ b/tests/io/test_tasoc.py
@@ -8,13 +8,14 @@ from lightkurve import search_lightcurve
 from lightkurve.io.tasoc import read_tasoc_lightcurve
 from lightkurve.io.detect import detect_filetype
 
+
 @pytest.mark.remote_data
 def test_detect_tasoc():
     """Can we detect the correct format for TASOC files?"""
     url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/tasoc/s0001/ffi/0000/0004/1206/4070/hlsp_tasoc_tess_ffi_tic00412064070-s01-c1800_tess_v04_lc.fits"
     f = fits.open(url)
 
-    assert detect_filetype(f)=="TASOC"
+    assert detect_filetype(f) == "TASOC"
 
 
 @pytest.mark.remote_data
@@ -22,14 +23,15 @@ def test_read_tasoc():
     """Can we read TASOC files?"""
     url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/tasoc/s0001/ffi/0000/0004/1206/4070/hlsp_tasoc_tess_ffi_tic00412064070-s01-c1800_tess_v04_lc.fits"
     with fits.open(url, mode="readonly") as hdulist:
-        fluxes = hdulist[1].data['FLUX_RAW']
-        
-    lc = read_tasoc_lightcurve(url, flux_column='FLUX_RAW')
+        fluxes = hdulist[1].data["FLUX_RAW"]
+
+    lc = read_tasoc_lightcurve(url, flux_column="FLUX_RAW")
 
     flux_lc = lc.flux.value
 
-    #print(flux_lc, fluxes)
+    # print(flux_lc, fluxes)
     assert np.sum(fluxes) == np.sum(flux_lc)
+
 
 @pytest.mark.remote_data
 def test_search_tasoc():

--- a/tests/prf/test_tpfmodel.py
+++ b/tests/prf/test_tpfmodel.py
@@ -24,9 +24,11 @@ def test_fixedvalueprior():
 def test_starprior():
     """Tests the StarPrior class."""
     col, row, flux = 1, 2, 3
-    sp = StarPrior(col=GaussianPrior(mean=col, var=0.1),
-                   row=GaussianPrior(mean=row, var=0.1),
-                   flux=GaussianPrior(mean=flux, var=0.1))
+    sp = StarPrior(
+        col=GaussianPrior(mean=col, var=0.1),
+        row=GaussianPrior(mean=row, var=0.1),
+        flux=GaussianPrior(mean=flux, var=0.1),
+    )
     assert sp.col.mean == col
     assert sp.row.mean == row
     assert sp.flux.mean == flux
@@ -36,15 +38,15 @@ def test_starprior():
     # A point further away from the mean should have a larger negative log likelihood
     assert sp.evaluate(col, row, flux) < sp.evaluate(col, row, flux + 0.1)
     # Object should have a nice __repr__
-    assert 'StarPrior' in str(sp)
+    assert "StarPrior" in str(sp)
 
 
 def test_backgroundprior():
     """Tests the BackgroundPrior class."""
-    flux = 2.
+    flux = 2.0
     bp = BackgroundPrior(flux=flux)
     assert bp.flux.mean == flux
-    assert bp(flux) == 0.
+    assert bp(flux) == 0.0
     assert not np.isfinite(bp(flux + 0.1))
 
 
@@ -57,23 +59,33 @@ def test_tpf_model_simple():
 def test_tpf_model():
     col, row, flux, bgflux = 1, 2, 3, 4
     shape = (7, 8)
-    model = TPFModel(star_priors=[StarPrior(col=GaussianPrior(mean=col, var=2**2),
-                                            row=GaussianPrior(mean=row, var=2**2),
-                                            flux=UniformPrior(lb=flux - 0.5, ub=flux + 0.5),
-                                            targetid="TESTSTAR")],
-                     background_prior=BackgroundPrior(flux=GaussianPrior(mean=bgflux, var=bgflux)),
-                     focus_prior=FocusPrior(scale_col=GaussianPrior(mean=1, var=0.0001),
-                                            scale_row=GaussianPrior(mean=1, var=0.0001),
-                                            rotation_angle=UniformPrior(lb=-3.1415, ub=3.1415)),
-                     motion_prior=MotionPrior(shift_col=GaussianPrior(mean=0., var=0.01),
-                                              shift_row=GaussianPrior(mean=0., var=0.01)),
-                     prfmodel=KeplerPRF(channel=40, shape=shape, column=30, row=20),
-                     fit_background=True,
-                     fit_focus=False,
-                     fit_motion=False)
+    model = TPFModel(
+        star_priors=[
+            StarPrior(
+                col=GaussianPrior(mean=col, var=2 ** 2),
+                row=GaussianPrior(mean=row, var=2 ** 2),
+                flux=UniformPrior(lb=flux - 0.5, ub=flux + 0.5),
+                targetid="TESTSTAR",
+            )
+        ],
+        background_prior=BackgroundPrior(flux=GaussianPrior(mean=bgflux, var=bgflux)),
+        focus_prior=FocusPrior(
+            scale_col=GaussianPrior(mean=1, var=0.0001),
+            scale_row=GaussianPrior(mean=1, var=0.0001),
+            rotation_angle=UniformPrior(lb=-3.1415, ub=3.1415),
+        ),
+        motion_prior=MotionPrior(
+            shift_col=GaussianPrior(mean=0.0, var=0.01),
+            shift_row=GaussianPrior(mean=0.0, var=0.01),
+        ),
+        prfmodel=KeplerPRF(channel=40, shape=shape, column=30, row=20),
+        fit_background=True,
+        fit_focus=False,
+        fit_motion=False,
+    )
     # Sanity checks
     assert model.star_priors[0].col.mean == col
-    assert model.star_priors[0].targetid == 'TESTSTAR'
+    assert model.star_priors[0].targetid == "TESTSTAR"
     # Test initial guesses
     params = model.get_initial_guesses()
     assert params.stars[0].col == col
@@ -85,7 +97,7 @@ def test_tpf_model():
     # Predict should return an image
     assert model.predict().shape == shape
     # Test __repr__
-    assert 'TESTSTAR' in str(model)
+    assert "TESTSTAR" in str(model)
 
 
 # Tagging the test below as `remote_data` because AppVeyor hangs on this test;
@@ -98,16 +110,20 @@ def test_tpf_model_fitting():
     col, row = 173, 526
     fluxsum = np.sum(tpf[1].data)
     bkg = mode(tpf[1].data, None)[0]
-    prfmodel = KeplerPRF(channel=tpf[0].header['CHANNEL'],
-                         column=col, row=row,
-                         shape=tpf[1].data.shape)
-    star_priors = [StarPrior(col=UniformPrior(lb=prfmodel.col_coord[0], ub=prfmodel.col_coord[-1]),
-                             row=UniformPrior(lb=prfmodel.row_coord[0], ub=prfmodel.row_coord[-1]),
-                             flux=UniformPrior(lb=0.5*fluxsum, ub=1.5*fluxsum))]
-    background_prior = BackgroundPrior(flux=UniformPrior(lb=.5*bkg, ub=1.5*bkg))
-    model = TPFModel(star_priors=star_priors,
-                     background_prior=background_prior,
-                     prfmodel=prfmodel)
+    prfmodel = KeplerPRF(
+        channel=tpf[0].header["CHANNEL"], column=col, row=row, shape=tpf[1].data.shape
+    )
+    star_priors = [
+        StarPrior(
+            col=UniformPrior(lb=prfmodel.col_coord[0], ub=prfmodel.col_coord[-1]),
+            row=UniformPrior(lb=prfmodel.row_coord[0], ub=prfmodel.row_coord[-1]),
+            flux=UniformPrior(lb=0.5 * fluxsum, ub=1.5 * fluxsum),
+        )
+    ]
+    background_prior = BackgroundPrior(flux=UniformPrior(lb=0.5 * bkg, ub=1.5 * bkg))
+    model = TPFModel(
+        star_priors=star_priors, background_prior=background_prior, prfmodel=prfmodel
+    )
     # Does fitting run without errors?
     result = model.fit(tpf[1].data)
     # Can we change model parameters?
@@ -135,28 +151,39 @@ def test_model_with_one_star():
     """Can we fit the background flux in a model with one star?"""
     channel = 42
     shape = (10, 12)
-    starflux, col, row = 1000., 60., 70.
-    bgflux = 10.
+    starflux, col, row = 1000.0, 60.0, 70.0
+    bgflux = 10.0
     scale_col, scale_row, rotation_angle = 1.2, 1.3, 0.2
     prf = KeplerPRF(channel=channel, shape=shape, column=col, row=row)
-    star_prior = StarPrior(col=GaussianPrior(col + 6, 0.01),
-                           row=GaussianPrior(row + 6, 0.01),
-                           flux=UniformPrior(lb=0.5*starflux, ub=1.5*starflux))
+    star_prior = StarPrior(
+        col=GaussianPrior(col + 6, 0.01),
+        row=GaussianPrior(row + 6, 0.01),
+        flux=UniformPrior(lb=0.5 * starflux, ub=1.5 * starflux),
+    )
     background_prior = BackgroundPrior(flux=UniformPrior(lb=0, ub=100))
-    focus_prior = FocusPrior(scale_col=UniformPrior(lb=0.5, ub=1.5),
-                             scale_row=UniformPrior(lb=0.5, ub=1.5),
-                             rotation_angle=UniformPrior(lb=0., ub=0.5))
-    model = TPFModel(star_priors=[star_prior],
-                     background_prior=background_prior,
-                     focus_prior=focus_prior,
-                     prfmodel=prf,
-                     fit_background=True,
-                     fit_focus=True)
+    focus_prior = FocusPrior(
+        scale_col=UniformPrior(lb=0.5, ub=1.5),
+        scale_row=UniformPrior(lb=0.5, ub=1.5),
+        rotation_angle=UniformPrior(lb=0.0, ub=0.5),
+    )
+    model = TPFModel(
+        star_priors=[star_prior],
+        background_prior=background_prior,
+        focus_prior=focus_prior,
+        prfmodel=prf,
+        fit_background=True,
+        fit_focus=True,
+    )
     # Generate and fit fake data
-    fake_data = bgflux + prf(col + 6, row + 6, starflux,
-                             scale_col=scale_col, scale_row=scale_row,
-                             rotation_angle=rotation_angle)
-    results = model.fit(fake_data, tol=1e-12, options={'maxiter': 100})
+    fake_data = bgflux + prf(
+        col + 6,
+        row + 6,
+        starflux,
+        scale_col=scale_col,
+        scale_row=scale_row,
+        rotation_angle=rotation_angle,
+    )
+    results = model.fit(fake_data, tol=1e-12, options={"maxiter": 100})
     # Do the results match the input?
     assert np.isclose(results.stars[0].col, col + 6)
     assert np.isclose(results.stars[0].row, row + 6)

--- a/tests/seismology/test_butler.py
+++ b/tests/seismology/test_butler.py
@@ -11,34 +11,33 @@ from lightkurve.periodogram import SNRPeriodogram
 
 @pytest.mark.remote_data
 def test_asteroseismology():
-    datalist = search_lightcurve('KIC11615890')
+    datalist = search_lightcurve("KIC11615890")
     data = datalist.download_all()
     lc = data[0].normalize().flatten()
     for nlc in data[0:5]:
         lc = lc.append(nlc.normalize().flatten())
     lc = lc.remove_nans()
-    pg = lc.to_periodogram(normalization='psd')
+    pg = lc.to_periodogram(normalization="psd")
     snr = pg.flatten()
     snr.to_seismology().estimate_numax()
 
 
 def generate_test_spectrum():
-    """Generates a simple solar-like oscillator spectrum of oscillation modes
-    """
-    f = np.arange(0, 4000., 0.4)
+    """Generates a simple solar-like oscillator spectrum of oscillation modes"""
+    f = np.arange(0, 4000.0, 0.4)
     p = np.ones(len(f))
-    nmx = 2500.
-    fs = f.max()/len(f)
+    nmx = 2500.0
+    fs = f.max() / len(f)
 
-    s = 0.25*nmx/2.335    #std of the hump
-    p *= 10 * np.exp(-0.5*(f-nmx)**2/s**2)  #gaussian profile of the hump
+    s = 0.25 * nmx / 2.335  # std of the hump
+    p *= 10 * np.exp(-0.5 * (f - nmx) ** 2 / s ** 2)  # gaussian profile of the hump
 
     m = np.zeros(len(f))
-    lo = int(np.floor(.5*nmx/fs))
-    hi = int(np.floor(1.5*nmx/fs))
+    lo = int(np.floor(0.5 * nmx / fs))
+    hi = int(np.floor(1.5 * nmx / fs))
 
     deltanu_true = 0.294 * nmx ** 0.772
-    modelocs = np.arange(lo, hi, deltanu_true/2, dtype=int)
+    modelocs = np.arange(lo, hi, deltanu_true / 2, dtype=int)
 
     for modeloc in modelocs:
         m += deltafn(len(f), modeloc)
@@ -50,58 +49,61 @@ def generate_test_spectrum():
 def test_estimate_numax_basics():
     """Test if we can estimate a numax."""
     f, p, true_numax, _ = generate_test_spectrum()
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     numax = snr.to_seismology().estimate_numax()
 
-    #Assert recovers numax within 10%
-    assert(np.isclose(true_numax, numax.value, atol=.1*true_numax))
-    #Assert numax has unit equal to input frequency unit
-    assert(numax.unit == u.microhertz)
+    # Assert recovers numax within 10%
+    assert np.isclose(true_numax, numax.value, atol=0.1 * true_numax)
+    # Assert numax has unit equal to input frequency unit
+    assert numax.unit == u.microhertz
 
     # Assert you can recover numax with a chopped periodogram
-    rsnr = snr[(snr.frequency.value>1600) & (snr.frequency.value<3200)]
+    rsnr = snr[(snr.frequency.value > 1600) & (snr.frequency.value < 3200)]
     numax = rsnr.to_seismology().estimate_numax()
-    assert(np.isclose(true_numax, numax.value, atol=.1*true_numax))
+    assert np.isclose(true_numax, numax.value, atol=0.1 * true_numax)
 
     # Assert numax estimator works when input frequency is not in microhertz
-    fday = u.Quantity(f*u.microhertz, 1/u.day)
+    fday = u.Quantity(f * u.microhertz, 1 / u.day)
     snr = SNRPeriodogram(fday, u.Quantity(p, None))
     numax = snr.to_seismology().estimate_numax()
-    nmxday = u.Quantity(true_numax*u.microhertz, 1/u.day)
-    assert(np.isclose(nmxday, numax, atol=.1*nmxday))
+    nmxday = u.Quantity(true_numax * u.microhertz, 1 / u.day)
+    assert np.isclose(nmxday, numax, atol=0.1 * nmxday)
 
     # Assert numax estimator fails when frequqencies are not uniform
     f, p, true_numax, _ = generate_test_spectrum()
     f += np.random.uniform(size=len(f))
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
 
     with pytest.raises(ValueError) as exc:
         numax = snr.to_seismology().estimate_numax()
     assert "uniformly spaced" in str(exc.value)
 
+
 def test_estimate_numax_kwargs():
     """Test if we can estimate a numax using its various keyword arguments."""
     f, p, true_numax, _ = generate_test_spectrum()
-    std = 0.25*true_numax/2.335  # The standard deviation of the mode envelope
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    std = 0.25 * true_numax / 2.335  # The standard deviation of the mode envelope
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     butler = snr.to_seismology()
-    numaxs = np.linspace(true_numax-2*std, true_numax+2*std, 500)
+    numaxs = np.linspace(true_numax - 2 * std, true_numax + 2 * std, 500)
     numax = butler.estimate_numax(numaxs=numaxs)
 
     # Assert we can recover numax using a custom numax
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
 
     # Assert we can't pass custom numaxs outside a functional range
     with pytest.raises(ValueError):
-        numax = butler.estimate_numax(numaxs=np.linspace(-5, 5.))
+        numax = butler.estimate_numax(numaxs=np.linspace(-5, 5.0))
     with pytest.raises(ValueError):
-        numax = butler.estimate_numax(numaxs=np.linspace(1., 5000.))
+        numax = butler.estimate_numax(numaxs=np.linspace(1.0, 5000.0))
 
     # Assert we can pass a custom window in microhertz or days
-    numax = butler.estimate_numax(window_width=200.)
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
-    numax = butler.estimate_numax(window_width=u.Quantity(200., u.microhertz).to(1/u.day))
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
+    numax = butler.estimate_numax(window_width=200.0)
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
+    numax = butler.estimate_numax(
+        window_width=u.Quantity(200.0, u.microhertz).to(1 / u.day)
+    )
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
 
     # Assert we can't pass in window_widths outside functional range
     # Assert we can't pass custom numaxs outside a functional range
@@ -113,10 +115,10 @@ def test_estimate_numax_kwargs():
         numax = butler.estimate_numax(window_width=0.001)
 
     # Assert we can pass a custom spacing in microhertz or days
-    numax = butler.estimate_numax(spacing=15.)
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
-    numax = butler.estimate_numax(spacing=u.Quantity(15., u.microhertz).to(1/u.day))
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
+    numax = butler.estimate_numax(spacing=15.0)
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
+    numax = butler.estimate_numax(spacing=u.Quantity(15.0, u.microhertz).to(1 / u.day))
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
 
     # Assert we can't pass in spacing outside functional range
     with pytest.raises(ValueError):
@@ -128,10 +130,10 @@ def test_estimate_numax_kwargs():
 
     # Assert it doesn't matter what units of frqeuency numaxs are passed in as
     # Assert the output is still in the same units as the object frequencies
-    daynumaxs = u.Quantity(numaxs*u.microhertz, 1/u.day)
+    daynumaxs = u.Quantity(numaxs * u.microhertz, 1 / u.day)
     numax = butler.estimate_numax(numaxs=daynumaxs)
-    assert(np.isclose(numax.value, true_numax, atol=.1*true_numax))
-    assert(numax.unit == u.microhertz)
+    assert np.isclose(numax.value, true_numax, atol=0.1 * true_numax)
+    assert numax.unit == u.microhertz
 
 
 def test_plot_numax_diagnostics():
@@ -139,104 +141,103 @@ def test_plot_numax_diagnostics():
     it returns a correct metric when requested
     """
     f, p, true_numax, _ = generate_test_spectrum()
-    std = 0.25*true_numax/2.335  # The standard deviation of the mode envelope
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    std = 0.25 * true_numax / 2.335  # The standard deviation of the mode envelope
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     butler = snr.to_seismology()
-    numaxs = np.linspace(true_numax-2*std, true_numax+2*std, 500)
-    butler.estimate_numax(numaxs=numaxs, window_width=250., spacing=10.)
+    numaxs = np.linspace(true_numax - 2 * std, true_numax + 2 * std, 500)
+    butler.estimate_numax(numaxs=numaxs, window_width=250.0, spacing=10.0)
     butler.diagnose_numax()
     # Note: checks on the `numaxs` kwarg in `estimate_numax_kwargs` also apply
     # to this function, no need to check them twice.
 
     # Assert recovers numax within 10%
-    assert(np.isclose(true_numax, butler.numax.value, atol=.1*true_numax))
+    assert np.isclose(true_numax, butler.numax.value, atol=0.1 * true_numax)
     # Assert numax has unit equal to input frequency unit
-    assert(butler.numax.unit == u.microhertz)
+    assert butler.numax.unit == u.microhertz
 
     # Sanity check that plotting works under all conditions
     numax = butler.estimate_numax()
     butler.diagnose_numax(numax)
     numax = butler.estimate_numax(numaxs=numaxs)
     butler.diagnose_numax(numax)
-    daynumaxs = u.Quantity(numaxs*u.microhertz, 1/u.day)
+    daynumaxs = u.Quantity(numaxs * u.microhertz, 1 / u.day)
     numax = butler.estimate_numax(numaxs=daynumaxs)
     butler.diagnose_numax(numax)
-    numax = butler.estimate_numax(window_width=100.)
+    numax = butler.estimate_numax(window_width=100.0)
     butler.diagnose_numax(numax)
 
     # Check plotting works when periodogram is sliced
-    rsnr = snr[(snr.frequency.value>1600)&(snr.frequency.value<3200)]
+    rsnr = snr[(snr.frequency.value > 1600) & (snr.frequency.value < 3200)]
     butler = rsnr.to_seismology()
     butler.estimate_numax()
     butler.diagnose_numax()
 
     # Check metric of appropriate length is returned
     numax = butler.estimate_numax(numaxs=numaxs)
-    assert(len(numax.diagnostics['metric']) == len(numaxs))
+    assert len(numax.diagnostics["metric"]) == len(numaxs)
 
 
 def test_estimate_deltanu_basics():
-    """Test if we can estimate a deltanu
-    """
+    """Test if we can estimate a deltanu"""
     f, p, _, true_deltanu = generate_test_spectrum()
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     butler = snr.to_seismology()
     butler.estimate_numax()
     deltanu = butler.estimate_deltanu()
 
     # Assert recovers deltanu within 25%
-    assert(np.isclose(true_deltanu, deltanu.value, atol=.25*true_deltanu))
+    assert np.isclose(true_deltanu, deltanu.value, atol=0.25 * true_deltanu)
     # Assert deltanu has unit equal to input frequency unit
-    assert(deltanu.unit == u.microhertz)
+    assert deltanu.unit == u.microhertz
 
     # Assert you can recover numax with a sliced periodogram
-    rsnr = snr[(snr.frequency.value>1600) & (snr.frequency.value<3200)]
+    rsnr = snr[(snr.frequency.value > 1600) & (snr.frequency.value < 3200)]
     butler = rsnr.to_seismology()
     butler.estimate_numax()
     numax = butler.estimate_deltanu()
-    assert(np.isclose(true_deltanu, deltanu.value, atol=.25*true_deltanu))
+    assert np.isclose(true_deltanu, deltanu.value, atol=0.25 * true_deltanu)
 
     # Assert deltanu estimator works when input frequency is not in microhertz
-    fday = u.Quantity(f*u.microhertz, 1/u.day)
+    fday = u.Quantity(f * u.microhertz, 1 / u.day)
     daysnr = SNRPeriodogram(fday, u.Quantity(p, None))
     butler = daysnr.to_seismology()
     butler.estimate_numax()
     deltanu = butler.estimate_deltanu()
-    deltanuday = u.Quantity(true_deltanu*u.microhertz, 1/u.day)
-    assert(np.isclose(deltanuday.value, deltanu.value, atol=.25*deltanuday.value))
+    deltanuday = u.Quantity(true_deltanu * u.microhertz, 1 / u.day)
+    assert np.isclose(deltanuday.value, deltanu.value, atol=0.25 * deltanuday.value)
 
     # Assert deltanu estimator fails when frequqencies are not uniform
     f, p, true_numax, _ = generate_test_spectrum()
     f += np.random.uniform(size=len(f))
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
 
     with pytest.raises(ValueError) as exc:
         deltanu = snr.to_seismology().estimate_deltanu(numax=100)
     assert "uniformly spaced" in str(exc.value)
 
+
 def test_estimate_deltanu_kwargs():
-    """Test if we can estimate a deltanu using its various keyword arguments
-    """
+    """Test if we can estimate a deltanu using its various keyword arguments"""
     f, p, _, true_deltanu = generate_test_spectrum()
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     butler = snr.to_seismology()
 
     # Assert custom numax works
     numax = butler.estimate_numax()
     deltanu = butler.estimate_deltanu(numax=numax)
-    assert(np.isclose(deltanu.value, true_deltanu, atol=.25*true_deltanu))
+    assert np.isclose(deltanu.value, true_deltanu, atol=0.25 * true_deltanu)
 
     # Assert you can't pass custom numax outside of appropriate range
     with pytest.raises(ValueError):
-        deltanu = butler.estimate_deltanu(numax= -5.)
+        deltanu = butler.estimate_deltanu(numax=-5.0)
     with pytest.raises(ValueError):
         deltanu = butler.estimate_deltanu(numax=5000)
 
     # Assert it doesn't matter what units of frequency numax is passed in as
-    daynumax = u.Quantity(numax.value*u.microhertz, 1/u.day)
+    daynumax = u.Quantity(numax.value * u.microhertz, 1 / u.day)
     deltanu = butler.estimate_deltanu(numax=daynumax)
-    assert(np.isclose(deltanu.value, true_deltanu, atol=.25*true_deltanu))
-    assert(deltanu.unit == u.microhertz)
+    assert np.isclose(deltanu.value, true_deltanu, atol=0.25 * true_deltanu)
+    assert deltanu.unit == u.microhertz
 
 
 def test_plot_deltanu_diagnostics():
@@ -244,50 +245,50 @@ def test_plot_deltanu_diagnostics():
     it returns a correct metric when requested
     """
     f, p, _, true_deltanu = generate_test_spectrum()
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
     butler = snr.to_seismology()
 
     butler.estimate_numax()
     deltanu = butler.estimate_deltanu()
     ax = butler.diagnose_deltanu()
-    assert(np.isclose(deltanu.value, true_deltanu, atol=.25*true_deltanu))
-    assert(deltanu.unit == u.microhertz)
-    plt.close('all')
+    assert np.isclose(deltanu.value, true_deltanu, atol=0.25 * true_deltanu)
+    assert deltanu.unit == u.microhertz
+    plt.close("all")
 
-    #Note: checks on the `numax` kwarg in `estimate_deltanu_kwargs` also apply
-    #to this function, no need to check them twice.
+    # Note: checks on the `numax` kwarg in `estimate_deltanu_kwargs` also apply
+    # to this function, no need to check them twice.
 
     # Sanity check that plotting works under all conditions
     numax = butler.estimate_numax()
     butler.diagnose_deltanu()
     deltanu = butler.estimate_deltanu(numax=numax)
     butler.diagnose_deltanu(deltanu)
-    daynumax = u.Quantity(numax.value*u.microhertz, 1/u.day)
+    daynumax = u.Quantity(numax.value * u.microhertz, 1 / u.day)
     deltanu = butler.estimate_deltanu(numax=daynumax)
     butler.diagnose_deltanu(deltanu)
-    plt.close('all')
+    plt.close("all")
 
     # Check plotting works when periodogram is sliced
-    rsnr = snr[(snr.frequency.value>1600)&(snr.frequency.value<3200)]
+    rsnr = snr[(snr.frequency.value > 1600) & (snr.frequency.value < 3200)]
     butler = rsnr.to_seismology()
     butler.estimate_numax()
     butler.estimate_deltanu()
     ax = butler.diagnose_deltanu()
-    plt.close('all')
+    plt.close("all")
 
     # Check it plots when frequency is in days
-    fday = u.Quantity(f*u.microhertz, 1/u.day)
+    fday = u.Quantity(f * u.microhertz, 1 / u.day)
     daysnr = SNRPeriodogram(fday, u.Quantity(p, None))
     butler = daysnr.to_seismology()
     butler.estimate_deltanu(numax=daynumax)
     butler.diagnose_deltanu()
-    plt.close('all')
+    plt.close("all")
 
 
 def test_stellar_estimator_calls():
     f, p, _, true_deltanu = generate_test_spectrum()
-    snr = SNRPeriodogram(f*u.microhertz, u.Quantity(p, None))
-    snr.meta = {'TEFF': 3000}
+    snr = SNRPeriodogram(f * u.microhertz, u.Quantity(p, None))
+    snr.meta = {"TEFF": 3000}
 
     butler = snr.to_seismology()
     butler.estimate_numax()
@@ -304,7 +305,7 @@ def test_stellar_estimator_calls():
     log = butler.estimate_logg(3100)
 
     # Raise error if no teff available
-    butler.periodogram.meta['TEFF'] = None
+    butler.periodogram.meta["TEFF"] = None
     with pytest.raises(ValueError):
         mass = butler.estimate_mass()
     with pytest.raises(ValueError):
@@ -312,56 +313,61 @@ def test_stellar_estimator_calls():
     with pytest.raises(ValueError):
         log = butler.estimate_logg()
 
+
 def test_plot_echelle():
     f, p, numax, deltanu = generate_test_spectrum()
     numax *= u.microhertz
     deltanu *= u.microhertz
 
-    pg = Periodogram(f*u.microhertz, u.Quantity(p, None))
+    pg = Periodogram(f * u.microhertz, u.Quantity(p, None))
     butler = pg.to_seismology()
 
     # Assert basic echelle works
     butler.plot_echelle(deltanu=deltanu, numax=numax)
-    plt.close('all')
-    butler.plot_echelle(u.Quantity(deltanu, 1/u.day), numax)
-    plt.close('all')
+    plt.close("all")
+    butler.plot_echelle(u.Quantity(deltanu, 1 / u.day), numax)
+    plt.close("all")
 
     # Assert accepts dimensionless input
-    butler.plot_echelle(deltanu=deltanu.value*1.001, numax=numax)
-    plt.close('all')
-    butler.plot_echelle(deltanu=deltanu, numax=numax.value/1.001)
-    plt.close('all')
+    butler.plot_echelle(deltanu=deltanu.value * 1.001, numax=numax)
+    plt.close("all")
+    butler.plot_echelle(deltanu=deltanu, numax=numax.value / 1.001)
+    plt.close("all")
 
     # Assert echelle works with numax
     butler.plot_echelle(deltanu, numax)
-    plt.close('all')
-    butler.plot_echelle(deltanu, u.Quantity(numax, 1/u.day))
-    plt.close('all')
+    plt.close("all")
+    butler.plot_echelle(deltanu, u.Quantity(numax, 1 / u.day))
+    plt.close("all")
 
     # Assert echelle works with minimum limit
     butler.plot_echelle(deltanu, numax, minimum_frequency=numax)
-    plt.close('all')
+    plt.close("all")
     butler.plot_echelle(deltanu, numax, maximum_frequency=numax)
-    plt.close('all')
-    butler.plot_echelle(deltanu, numax, minimum_frequency=u.Quantity(numax, 1/u.day))
-    plt.close('all')
-    butler.plot_echelle(deltanu, numax, maximum_frequency=u.Quantity(numax, 1/u.day))
-    plt.close('all')
-    butler.plot_echelle(deltanu, numax, minimum_frequency=u.Quantity(numax-deltanu, 1/u.day),
-                        maximum_frequency=numax+deltanu)
-    plt.close('all')
+    plt.close("all")
+    butler.plot_echelle(deltanu, numax, minimum_frequency=u.Quantity(numax, 1 / u.day))
+    plt.close("all")
+    butler.plot_echelle(deltanu, numax, maximum_frequency=u.Quantity(numax, 1 / u.day))
+    plt.close("all")
+    butler.plot_echelle(
+        deltanu,
+        numax,
+        minimum_frequency=u.Quantity(numax - deltanu, 1 / u.day),
+        maximum_frequency=numax + deltanu,
+    )
+    plt.close("all")
 
     # Assert raises error if numax or either of the limits are too high
     with pytest.raises(ValueError):
-        butler.plot_echelle(deltanu, numax, minimum_frequency=f[-1]+10)
-    plt.close('all')
+        butler.plot_echelle(deltanu, numax, minimum_frequency=f[-1] + 10)
+    plt.close("all")
     with pytest.raises(ValueError):
-        butler.plot_echelle(deltanu, numax, maximum_frequency=f[-1]+10)
-    plt.close('all')
+        butler.plot_echelle(deltanu, numax, maximum_frequency=f[-1] + 10)
+    plt.close("all")
     with pytest.raises(ValueError):
-        butler.plot_echelle(deltanu, numax=f[-1]+10)
-    plt.close('all')
+        butler.plot_echelle(deltanu, numax=f[-1] + 10)
+    plt.close("all")
 
     # Assert can pass colormap
-    butler.plot_echelle(deltanu, numax, cmap='viridis')
-    plt.close('all')
+    butler.plot_echelle(deltanu, numax, cmap="viridis")
+    plt.close("all")

--- a/tests/seismology/test_stellar_estimators.py
+++ b/tests/seismology/test_stellar_estimators.py
@@ -2,8 +2,15 @@ from astropy import units as u
 import numpy as np
 from uncertainties import ufloat
 
-from lightkurve.seismology.stellar_estimators import (NUMAX_SOL, DELTANU_SOL, TEFF_SOL, G_SOL,
-                                  estimate_radius, estimate_mass, estimate_logg)
+from lightkurve.seismology.stellar_estimators import (
+    NUMAX_SOL,
+    DELTANU_SOL,
+    TEFF_SOL,
+    G_SOL,
+    estimate_radius,
+    estimate_mass,
+    estimate_logg,
+)
 
 
 cM = ufloat(1.30, 0.09)
@@ -20,8 +27,8 @@ cdeltanu = 4.934
 def assert_correct_answer(quantity, reference):
     """Standard way we'll compare results against reference values below;
     wrapped in a function to reduce code duplication."""
-    assert(np.isclose(quantity.value, reference.n, atol=reference.s))
-    assert(np.isclose(quantity.error.value, reference.s, atol=.1))
+    assert np.isclose(quantity.value, reference.n, atol=reference.s)
+    assert np.isclose(quantity.error.value, reference.s, atol=0.1)
 
 
 def test_constants():
@@ -31,53 +38,53 @@ def test_constants():
     assert NUMAX_SOL.s == 30.0
     assert DELTANU_SOL.n == 135.1
     assert DELTANU_SOL.s == 0.1
-    assert TEFF_SOL.n == 5772.
+    assert TEFF_SOL.n == 5772.0
     assert TEFF_SOL.s == 0.8
     assert np.isclose(G_SOL.value, 27420)
-    assert G_SOL.unit == u.cm/u.second**2
+    assert G_SOL.unit == u.cm / u.second ** 2
 
 
 def test_estimate_radius_basic():
-    """Assert the basic functions of estimate_radius
-    """
+    """Assert the basic functions of estimate_radius"""
     R = estimate_radius(cnumax, cdeltanu, cteff)
 
-    #Check units
-    assert(R.unit == u.solRad)
+    # Check units
+    assert R.unit == u.solRad
 
     # Check returns right answer
-    assert(np.isclose(R.value, cR.n, rtol=cR.s))
+    assert np.isclose(R.value, cR.n, rtol=cR.s)
 
     # Check units on parameters
     R = estimate_radius(u.Quantity(cnumax, u.microhertz), cdeltanu, cteff)
-    assert(np.isclose(R.value, cR.n, rtol=cR.s))
+    assert np.isclose(R.value, cR.n, rtol=cR.s)
 
     R = estimate_radius(cnumax, u.Quantity(cdeltanu, u.microhertz), cteff)
-    assert(np.isclose(R.value, cR.n, rtol=cR.s))
+    assert np.isclose(R.value, cR.n, rtol=cR.s)
 
     R = estimate_radius(cnumax, cdeltanu, u.Quantity(cteff, u.Kelvin))
-    assert(np.isclose(R.value, cR.n, rtol=cR.s))
+    assert np.isclose(R.value, cR.n, rtol=cR.s)
 
-    #Check works with a random selection of appropriate units
-    R = estimate_radius(u.Quantity(cnumax, u.microhertz).to(1/u.day),
-                             u.Quantity(cdeltanu, u.microhertz).to(u.hertz),
-                             cteff)
-    assert(np.isclose(R.value, cR.n, rtol=cR.s))
+    # Check works with a random selection of appropriate units
+    R = estimate_radius(
+        u.Quantity(cnumax, u.microhertz).to(1 / u.day),
+        u.Quantity(cdeltanu, u.microhertz).to(u.hertz),
+        cteff,
+    )
+    assert np.isclose(R.value, cR.n, rtol=cR.s)
 
 
 def test_estimate_radius_kwargs():
-    """Test the kwargs of estimate_radius
-    """
+    """Test the kwargs of estimate_radius"""
     R = estimate_radius(cnumax, cdeltanu, cteff, cenumax, cedeltanu, ceteff)
     assert R.error is not None
 
-    #Check conditions for return
+    # Check conditions for return
     t = estimate_radius(cnumax, cdeltanu, cteff, cenumax, cedeltanu)
     assert t.error is not None
     t = estimate_radius(cnumax, cdeltanu, cteff, cenumax, cedeltanu, ceteff)
     assert t.error is not None
 
-    #Check units
+    # Check units
     assert R.unit == u.solRad
     assert R.error.unit == u.solRad
 
@@ -85,48 +92,56 @@ def test_estimate_radius_kwargs():
     assert_correct_answer(R, cR)
 
     # Check units on parameters
-    R = estimate_radius(cnumax, cdeltanu, cteff,
-                        u.Quantity(cenumax, u.microhertz), cedeltanu, ceteff)
+    R = estimate_radius(
+        cnumax, cdeltanu, cteff, u.Quantity(cenumax, u.microhertz), cedeltanu, ceteff
+    )
     assert_correct_answer(R, cR)
 
-    R = estimate_radius(cnumax, cdeltanu, cteff,
-                        cenumax, u.Quantity(cedeltanu, u.microhertz), ceteff)
+    R = estimate_radius(
+        cnumax, cdeltanu, cteff, cenumax, u.Quantity(cedeltanu, u.microhertz), ceteff
+    )
     assert_correct_answer(R, cR)
 
-    R = estimate_radius(cnumax, cdeltanu, cteff,
-                        cenumax, cedeltanu, u.Quantity(ceteff, u.Kelvin))
+    R = estimate_radius(
+        cnumax, cdeltanu, cteff, cenumax, cedeltanu, u.Quantity(ceteff, u.Kelvin)
+    )
     assert_correct_answer(R, cR)
 
-    #Check works with a random selection of appropriate units
-    R = estimate_radius(cnumax, cdeltanu, cteff,
-                        u.Quantity(cenumax, u.microhertz).to(1/u.day),
-                        u.Quantity(cedeltanu, u.microhertz).to(u.hertz),
-                        ceteff)
+    # Check works with a random selection of appropriate units
+    R = estimate_radius(
+        cnumax,
+        cdeltanu,
+        cteff,
+        u.Quantity(cenumax, u.microhertz).to(1 / u.day),
+        u.Quantity(cedeltanu, u.microhertz).to(u.hertz),
+        ceteff,
+    )
     assert_correct_answer(R, cR)
 
 
 def test_estimate_mass_basic():
-    """Assert the basic functions of estimate_mass
-    """
+    """Assert the basic functions of estimate_mass"""
     M = estimate_mass(cnumax, cdeltanu, cteff)
-    assert(M.unit == u.solMass)  # Check units
-    assert(np.isclose(M.value, cM.n, rtol=cM.s))  # Check right answer
+    assert M.unit == u.solMass  # Check units
+    assert np.isclose(M.value, cM.n, rtol=cM.s)  # Check right answer
 
     # Check units on parameters
     M = estimate_mass(u.Quantity(cnumax, u.microhertz), cdeltanu, cteff)
-    assert(np.isclose(M.value, cM.n, rtol=cM.s))
+    assert np.isclose(M.value, cM.n, rtol=cM.s)
 
     M = estimate_mass(cnumax, u.Quantity(cdeltanu, u.microhertz), cteff)
-    assert(np.isclose(M.value, cM.n, rtol=cM.s))
+    assert np.isclose(M.value, cM.n, rtol=cM.s)
 
     M = estimate_mass(cnumax, cdeltanu, u.Quantity(cteff, u.Kelvin))
-    assert(np.isclose(M.value, cM.n, rtol=cM.s))
+    assert np.isclose(M.value, cM.n, rtol=cM.s)
 
     # Check works with a random selection of appropriate units
-    M = estimate_mass(u.Quantity(cnumax, u.microhertz).to(1/u.day),
-                      u.Quantity(cdeltanu, u.microhertz).to(u.hertz),
-                      cteff)
-    assert(np.isclose(M.value, cM.n, rtol=cM.s))
+    M = estimate_mass(
+        u.Quantity(cnumax, u.microhertz).to(1 / u.day),
+        u.Quantity(cdeltanu, u.microhertz).to(u.hertz),
+        cteff,
+    )
+    assert np.isclose(M.value, cM.n, rtol=cM.s)
 
 
 def test_estimate_mass_kwargs():
@@ -141,23 +156,30 @@ def test_estimate_mass_kwargs():
     assert_correct_answer(M, cM)
 
     # Check units on parameters
-    M = estimate_mass(cnumax, cdeltanu, cteff,
-                      u.Quantity(cenumax, u.microhertz), cedeltanu, ceteff)
+    M = estimate_mass(
+        cnumax, cdeltanu, cteff, u.Quantity(cenumax, u.microhertz), cedeltanu, ceteff
+    )
     assert_correct_answer(M, cM)
 
-    M = estimate_mass(cnumax, cdeltanu, cteff,
-                      cenumax, u.Quantity(cedeltanu, u.microhertz), ceteff)
+    M = estimate_mass(
+        cnumax, cdeltanu, cteff, cenumax, u.Quantity(cedeltanu, u.microhertz), ceteff
+    )
     assert_correct_answer(M, cM)
 
-    M = estimate_mass(cnumax, cdeltanu, cteff,
-                      cenumax, cedeltanu, u.Quantity(ceteff, u.Kelvin))
+    M = estimate_mass(
+        cnumax, cdeltanu, cteff, cenumax, cedeltanu, u.Quantity(ceteff, u.Kelvin)
+    )
     assert_correct_answer(M, cM)
 
-    #Check works with a random selection of appropriate units
-    M = estimate_mass(cnumax, cdeltanu, cteff,
-                      u.Quantity(cenumax, u.microhertz).to(1/u.day),
-                      u.Quantity(cedeltanu, u.microhertz).to(u.hertz),
-                      ceteff)
+    # Check works with a random selection of appropriate units
+    M = estimate_mass(
+        cnumax,
+        cdeltanu,
+        cteff,
+        u.Quantity(cenumax, u.microhertz).to(1 / u.day),
+        u.Quantity(cedeltanu, u.microhertz).to(u.hertz),
+        ceteff,
+    )
     assert_correct_answer(M, cM)
 
 
@@ -165,17 +187,17 @@ def test_estimate_logg_basic():
     """Assert basic functionality of estimate_logg."""
     logg = estimate_logg(cnumax, cteff)
     # Check units
-    assert(logg.unit == u.dex)
+    assert logg.unit == u.dex
     # Check returns right answer
-    assert(np.isclose(logg.value, clogg.n, rtol=clogg.s))
+    assert np.isclose(logg.value, clogg.n, rtol=clogg.s)
     # Check units on parameters
     logg = estimate_logg(u.Quantity(cnumax, u.microhertz), cteff)
-    assert(np.isclose(logg.value, clogg.n, rtol=clogg.s))
+    assert np.isclose(logg.value, clogg.n, rtol=clogg.s)
     logg = estimate_logg(cnumax, u.Quantity(cteff, u.Kelvin))
-    assert(np.isclose(logg.value, clogg.n, rtol=clogg.s))
+    assert np.isclose(logg.value, clogg.n, rtol=clogg.s)
     # Check works with a random selection of appropriate units
-    logg = estimate_logg(u.Quantity(cnumax, u.microhertz).to(1/u.day), cteff)
-    assert(np.isclose(logg.value, clogg.n, rtol=clogg.s))
+    logg = estimate_logg(u.Quantity(cnumax, u.microhertz).to(1 / u.day), cteff)
+    assert np.isclose(logg.value, clogg.n, rtol=clogg.s)
 
 
 def test_estimate_logg_kwargs():
@@ -196,8 +218,8 @@ def test_estimate_logg_kwargs():
     logg = estimate_logg(cnumax, cteff, cenumax, u.Quantity(ceteff, u.Kelvin))
     assert_correct_answer(logg, clogg)
 
-    #Check works with a random selection of appropriate units
-    logg = estimate_logg(cnumax, cteff,
-                         u.Quantity(cenumax, u.microhertz).to(1/u.day),
-                         ceteff)
+    # Check works with a random selection of appropriate units
+    logg = estimate_logg(
+        cnumax, cteff, u.Quantity(cenumax, u.microhertz).to(1 / u.day), ceteff
+    )
     assert_correct_answer(logg, clogg)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -17,25 +17,38 @@ filename_tpf_one_center = get_pkg_data_filename("data/test-tpf-non-zero-center.f
 
 
 def test_collection_init():
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
-    lc2 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15), flux_err=np.arange(10, 15))
+    lc = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5)
+    )
+    lc2 = LightCurve(
+        time=np.arange(10, 15), flux=np.arange(10, 15), flux_err=np.arange(10, 15)
+    )
     lcc = LightCurveCollection([lc, lc2])
-    assert(len(lcc) == 2)
-    assert(lcc.data == [lc, lc2])
+    assert len(lcc) == 2
+    assert lcc.data == [lc, lc2]
     str(lcc)  # Does repr work?
     lcc.plot()
-    plt.close('all')
+    plt.close("all")
 
 
 def test_collection_append():
     """Does Collection.append() work?"""
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=500)
-    lc2 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=100)
+    lc = LightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=500,
+    )
+    lc2 = LightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=100,
+    )
     lcc = LightCurveCollection([lc])
     lcc.append(lc2)
-    assert(len(lcc) == 2)
+    assert len(lcc) == 2
+
 
 def test_collection_stitch():
     """Does Collection.stitch() work?"""
@@ -43,49 +56,71 @@ def test_collection_stitch():
     lc2 = LightCurve(time=np.arange(5, 16), flux=np.ones(11))
     lcc = LightCurveCollection([lc, lc2])
     lc_stitched = lcc.stitch()
-    assert(len(lc_stitched.flux) == 15)
-    lc_stitched2 = lcc.stitch(corrector_func=lambda x: x*2)
-    assert_array_equal(lc_stitched.flux*2, lc_stitched2.flux)
+    assert len(lc_stitched.flux) == 15
+    lc_stitched2 = lcc.stitch(corrector_func=lambda x: x * 2)
+    assert_array_equal(lc_stitched.flux * 2, lc_stitched2.flux)
+
 
 def test_collection_getitem():
     """Tests Collection.__getitem__"""
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
-    lc2 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
+    lc = LightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc2 = LightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
     lcc = LightCurveCollection([lc])
     lcc.append(lc2)
-    assert((lcc[0] == lc).all())
-    assert((lcc[1] == lc2).all())
+    assert (lcc[0] == lc).all()
+    assert (lcc[1] == lc2).all()
     with pytest.raises(IndexError):
         lcc[50]
 
+
 def test_collection_getitem_by_boolean_array():
     """Tests Collection.__getitem__ , case the argument is a mask, i.e, indexed by boolean array"""
-    lc0 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
-    lc1 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
-    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
-                     flux_err=np.arange(15, 20), targetid=23456)
+    lc0 = LightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc1 = LightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
+    lc2 = LightCurve(
+        time=np.arange(15, 20),
+        flux=np.arange(15, 20),
+        flux_err=np.arange(15, 20),
+        targetid=23456,
+    )
     lcc = LightCurveCollection([lc0, lc1, lc2])
 
     lcc_f = lcc[[True, False, True]]
-    assert(lcc_f.data == [lc0, lc2])
-    assert(type(lcc_f), LightCurveCollection)
+    assert lcc_f.data == [lc0, lc2]
+    assert (type(lcc_f), LightCurveCollection)
 
     # boundary case: 1 element
     lcc_f = lcc[[False, True, False]]
-    assert(lcc_f.data == [lc1])
+    assert lcc_f.data == [lc1]
     # boundary case: no element
     lcc_f = lcc[[False, False, False]]
-    assert(lcc_f.data == [])
+    assert lcc_f.data == []
     # other array-like input: tuple
     lcc_f = lcc[(True, False, True)]
-    assert(lcc_f.data == [lc0, lc2])
+    assert lcc_f.data == [lc0, lc2]
     # other array-like input: ndarray
     lcc_f = lcc[np.array([True, False, True])]
-    assert(lcc_f.data == [lc0, lc2])
+    assert lcc_f.data == [lc0, lc2]
 
     # boundary case: mask length not matching - shorter
     with pytest.raises(IndexError):
@@ -95,49 +130,71 @@ def test_collection_getitem_by_boolean_array():
     with pytest.raises(IndexError):
         lcc[[True, False, True, True]]
 
+
 def test_collection_getitem_by_other_array():
     """Tests Collection.__getitem__ , case the argument an non-boolean array"""
-    lc0 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
-    lc1 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
-    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
-                     flux_err=np.arange(15, 20), targetid=23456)
+    lc0 = LightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc1 = LightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
+    lc2 = LightCurve(
+        time=np.arange(15, 20),
+        flux=np.arange(15, 20),
+        flux_err=np.arange(15, 20),
+        targetid=23456,
+    )
     lcc = LightCurveCollection([lc0, lc1, lc2])
 
     # case: an int array-like, follow ndarray behavior
     lcc_f = lcc[[2, 0]]
-    assert(lcc_f.data == [lc2, lc0])
+    assert lcc_f.data == [lc2, lc0]
     lcc_f = lcc[np.array([2, 0])]
-    assert(lcc_f.data == [lc2, lc0])
+    assert lcc_f.data == [lc2, lc0]
     # support other int types in np too
     lcc_f = lcc[np.array([np.int64(2), np.uint8(0)])]
-    assert(lcc_f.data == [lc2, lc0])
+    assert lcc_f.data == [lc2, lc0]
     # boundary condition: True / False is interpreted as 1/0 in an bool/int mixed array-like
     lcc_f = lcc[[True, False, 2]]
-    assert(lcc_f.data == [lc1, lc0, lc2])
+    assert lcc_f.data == [lc1, lc0, lc2]
     # boundary condition: some index is out of bound
     with pytest.raises(IndexError):
         lcc[[2, 99]]
     # boundary conditions: array-like of neither bool or int, follow ndarray behavior
     with pytest.raises(IndexError):
-        lcc[['abc', 'def']]
+        lcc[["abc", "def"]]
     with pytest.raises(IndexError):
-        lcc[[True, 'def']]
+        lcc[[True, "def"]]
+
 
 def test_collection_setitem():
     """Tests Collection. __setitem__"""
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                    flux_err=np.arange(1, 5), targetid=50000)
-    lc2 = LightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                     flux_err=np.arange(10, 15), targetid=120334)
+    lc = LightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc2 = LightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
     lcc = LightCurveCollection([lc])
     lcc.append(lc2)
     lc3 = LightCurve(time=[1], targetid=55)
     lcc[1] = lc3
-    assert(lcc[1].time == lc3.time)
+    assert lcc[1].time == lc3.time
     lcc.append(lc2)
-    assert((lcc[2].time == lc2.time).all())
+    assert (lcc[2].time == lc2.time).all()
     with pytest.raises(IndexError):
         lcc[51] = 10
 
@@ -146,25 +203,25 @@ def test_tpfcollection():
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
     tpf2 = KeplerTargetPixelFile(filename_tpf_one_center)
     tpfc = TargetPixelFileCollection([tpf, tpf2])
-    assert(len(tpfc) == 2)
-    assert(tpfc.data == [tpf, tpf2])
+    assert len(tpfc) == 2
+    assert tpfc.data == [tpf, tpf2]
     tpfc.append(tpf2)
-    assert(len(tpfc) == 3)
-    assert(tpfc[0] == tpf)
-    assert(tpfc[1] == tpf2)
-    assert(tpfc[2] == tpf2)
+    assert len(tpfc) == 3
+    assert tpfc[0] == tpf
+    assert tpfc[1] == tpf2
+    assert tpfc[2] == tpf2
     with pytest.raises(IndexError):
         tpfc[51]
     # ensure index by boolean array also works for TPFs
     tpfc_f = tpfc[[False, True, True]]
-    assert(tpfc_f.data == [tpf2, tpf2])
-    assert(type(tpfc_f), TargetPixelFileCollection)
+    assert tpfc_f.data == [tpf2, tpf2]
+    assert (type(tpfc_f), TargetPixelFileCollection)
     # Test __setitem__
     tpf3 = KeplerTargetPixelFile(filename_tpf_one_center, targetid=55)
     tpfc[1] = tpf3
-    assert(tpfc[1] == tpf3)
+    assert tpfc[1] == tpf3
     tpfc.append(tpf2)
-    assert(tpfc[2] == tpf2)
+    assert tpfc[2] == tpf2
     str(tpfc)  # Regression test for #564
 
 
@@ -177,43 +234,55 @@ def test_tpfcollection_plot():
     # Does plotting work with one TPF?
     coll = TargetPixelFileCollection([tpf])
     coll.plot()
-    plt.close('all')
+    plt.close("all")
 
 
 @pytest.mark.remote_data
 def test_stitch_repr():
     """Regression test for #884."""
-    lc = search_lightcurve("Pi Men", mission='TESS', author='SPOC', sector=1).download()
+    lc = search_lightcurve("Pi Men", mission="TESS", author="SPOC", sector=1).download()
     # The line below used to raise `ValueError: Unable to parse format string
     # "{:10d}" for entry "70445.0" in column "cadenceno"`
-    LightCurveCollection((lc,lc)).stitch().__repr__()
+    LightCurveCollection((lc, lc)).stitch().__repr__()
 
 
 def test_accessor_tess_sector():
-    lc0 = TessLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                         flux_err=np.arange(1, 5), targetid=50000)
-    lc0.meta['SECTOR'] = 14
-    lc1 = TessLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                         flux_err=np.arange(10, 15), targetid=120334)
-    lc1.meta['SECTOR'] = 26
+    lc0 = TessLightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc0.meta["SECTOR"] = 14
+    lc1 = TessLightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
+    lc1.meta["SECTOR"] = 26
     lcc = LightCurveCollection([lc0, lc1])
-    assert((lcc.sector == [14, 26]).all())
+    assert (lcc.sector == [14, 26]).all()
     # The sector accessor can be used to generate boolean array
     # to support filter collection by sector
-    assert(((lcc.sector == 26) == [False, True]).all())
-    assert(((lcc.sector < 20) == [True, False]).all())
+    assert ((lcc.sector == 26) == [False, True]).all()
+    assert ((lcc.sector < 20) == [True, False]).all()
 
     # boundary condition: some lightcurve objects do not have sector
-    lc2 = LightCurve(time=np.arange(15, 20), flux=np.arange(15, 20),
-                     flux_err=np.arange(15, 20), targetid=23456)
+    lc2 = LightCurve(
+        time=np.arange(15, 20),
+        flux=np.arange(15, 20),
+        flux_err=np.arange(15, 20),
+        targetid=23456,
+    )
     lcc.append(lc2)
     # expecting [14, 26, np.nan], need 2 asserts to do it.
-    assert((lcc.sector[:-1] == [14, 26]).all())
-    assert(np.isnan(lcc.sector[-1]))
+    assert (lcc.sector[:-1] == [14, 26]).all()
+    assert np.isnan(lcc.sector[-1])
     # The sector accessor can be used to generate boolean array
     # to support filter collection by sector
-    assert(((lcc.sector == 26) == [False, True, False]).all())
-    assert(((lcc.sector < 20) == [True, False, False]).all())
+    assert ((lcc.sector == 26) == [False, True, False]).all()
+    assert ((lcc.sector < 20) == [True, False, False]).all()
 
     # ensure it works for TPFs too.
     with warnings.catch_warnings():
@@ -221,50 +290,66 @@ def test_accessor_tess_sector():
         # Ignore "A Kepler data product is being opened using the `TessTargetPixelFile` class"
         # the test only cares about the SECTOR header that it sets.
         tpf = TessTargetPixelFile(filename_tpf_all_zeros)
-        tpf.hdu[0].header['SECTOR'] = 23
+        tpf.hdu[0].header["SECTOR"] = 23
         tpf2 = TessTargetPixelFile(filename_tpf_one_center)
         # tpf2 has no sector defined
         tpf3 = TessTargetPixelFile(filename_tpf_one_center)
-        tpf3.hdu[0].header['SECTOR'] = 1
+        tpf3.hdu[0].header["SECTOR"] = 1
     tpfc = TargetPixelFileCollection([tpf, tpf2, tpf3])
-    assert((tpfc.sector == [23, None, 1]).all())
+    assert (tpfc.sector == [23, None, 1]).all()
 
 
 def test_accessor_kepler_quarter():
     # scaled down version of tess sector test, as they share the same codepath
-    lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                           flux_err=np.arange(1, 5), targetid=50000)
-    lc0.meta['QUARTER'] = 2
-    lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                           flux_err=np.arange(10, 15), targetid=120334)
-    lc1.meta['QUARTER'] = 1
+    lc0 = KeplerLightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc0.meta["QUARTER"] = 2
+    lc1 = KeplerLightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
+    lc1.meta["QUARTER"] = 1
     lcc = LightCurveCollection([lc0, lc1])
-    assert((lcc.quarter == [2, 1]).all())
+    assert (lcc.quarter == [2, 1]).all()
 
     # ensure it works for TPFs too.
     tpf0 = KeplerTargetPixelFile(filename_tpf_all_zeros)
-    tpf0.hdu[0].header['QUARTER'] = 2
+    tpf0.hdu[0].header["QUARTER"] = 2
     tpf1 = KeplerTargetPixelFile(filename_tpf_one_center)
-    tpf1.hdu[0].header['QUARTER'] = 1
+    tpf1.hdu[0].header["QUARTER"] = 1
     tpfc = TargetPixelFileCollection([tpf0, tpf1])
-    assert((tpfc.quarter == [2, 1]).all())
+    assert (tpfc.quarter == [2, 1]).all()
 
 
 def test_accessor_k2_campaign():
     # scaled down version of tess sector test, as they share the same codepath
-    lc0 = KeplerLightCurve(time=np.arange(1, 5), flux=np.arange(1, 5),
-                           flux_err=np.arange(1, 5), targetid=50000)
-    lc0.meta['CAMPAIGN'] = 2
-    lc1 = KeplerLightCurve(time=np.arange(10, 15), flux=np.arange(10, 15),
-                           flux_err=np.arange(10, 15), targetid=120334)
-    lc1.meta['CAMPAIGN'] = 1
+    lc0 = KeplerLightCurve(
+        time=np.arange(1, 5),
+        flux=np.arange(1, 5),
+        flux_err=np.arange(1, 5),
+        targetid=50000,
+    )
+    lc0.meta["CAMPAIGN"] = 2
+    lc1 = KeplerLightCurve(
+        time=np.arange(10, 15),
+        flux=np.arange(10, 15),
+        flux_err=np.arange(10, 15),
+        targetid=120334,
+    )
+    lc1.meta["CAMPAIGN"] = 1
     lcc = LightCurveCollection([lc0, lc1])
-    assert((lcc.campaign == [2, 1]).all())
+    assert (lcc.campaign == [2, 1]).all()
 
     # ensure it works for TPFs too.
     tpf0 = KeplerTargetPixelFile(filename_tpf_all_zeros)
-    tpf0.hdu[0].header['CAMPAIGN'] = 2
+    tpf0.hdu[0].header["CAMPAIGN"] = 2
     tpf1 = KeplerTargetPixelFile(filename_tpf_one_center)
-    tpf1.hdu[0].header['CAMPAIGN'] = 1
+    tpf1.hdu[0].header["CAMPAIGN"] = 1
     tpfc = TargetPixelFileCollection([tpf0, tpf1])
-    assert((tpfc.campaign == [2, 1]).all())
+    assert (tpfc.campaign == [2, 1]).all()

--- a/tests/test_correctors.py
+++ b/tests/test_correctors.py
@@ -1,10 +1,12 @@
 import pytest
 
+
 @pytest.mark.remote_data
 def test_to_corrector():
     """Does the tpf.to_corrector('pld') convenience method work?"""
     from lightkurve import KeplerTargetPixelFile
     from .test_targetpixelfile import TABBY_TPF
+
     tpf = KeplerTargetPixelFile(TABBY_TPF)
     lc = tpf.to_corrector("pld").correct()
     assert len(lc.flux) == len(tpf.time)

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -36,22 +36,24 @@ def test_bokeh_import_error(caplog):
 def test_malformed_notebook_url():
     """Test if malformed notebook_urls raise proper exceptions."""
     import bokeh
+
     tpf = TessTargetPixelFile(example_tpf)
     with pytest.raises(ValueError) as exc:
-        tpf.interact(notebook_url='')
-    assert('Empty host value' in exc.value.args[0])
+        tpf.interact(notebook_url="")
+    assert "Empty host value" in exc.value.args[0]
     with pytest.raises(AttributeError) as exc:
         tpf.interact(notebook_url=None)
-    assert('object has no attribute' in exc.value.args[0])
+    assert "object has no attribute" in exc.value.args[0]
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_graceful_exit_outside_notebook():
     """Test if running interact outside of a notebook does fails gracefully."""
     import bokeh
+
     tpf = TessTargetPixelFile(example_tpf)
     result = tpf.interact()
-    assert(result is None)
+    assert result is None
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
@@ -60,15 +62,15 @@ def test_custom_aperture_mask():
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(TABBY_TPF),
-                TessTargetPixelFile(example_tpf)]
+        tpfs = [KeplerTargetPixelFile(TABBY_TPF), TessTargetPixelFile(example_tpf)]
     import bokeh
+
     for tpf in tpfs:
         mask = tpf.flux[0, :, :] == tpf.flux[0, :, :]
         tpf.interact(aperture_mask=mask)
         mask = None
         tpf.interact(aperture_mask=mask)
-        mask = 'threshold'
+        mask = "threshold"
         tpf.interact(aperture_mask=mask)
 
 
@@ -76,18 +78,18 @@ def test_custom_aperture_mask():
 def test_custom_exported_filename():
     """Can we provide a custom lightcurve to show?"""
     import bokeh
+
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(TABBY_TPF),
-                TessTargetPixelFile(example_tpf)]
+        tpfs = [KeplerTargetPixelFile(TABBY_TPF), TessTargetPixelFile(example_tpf)]
     for tpf in tpfs:
-        tpf.interact(exported_filename='demo.fits')
+        tpf.interact(exported_filename="demo.fits")
         tpf[0:2].interact()
-        tpf[0:2].interact(exported_filename='string_only')
-        tpf[0:2].interact(exported_filename='demo2.FITS')
-        tpf[0:2].interact(exported_filename='demo3.png')
-        tpf[0:2].interact(exported_filename='')
+        tpf[0:2].interact(exported_filename="string_only")
+        tpf[0:2].interact(exported_filename="demo2.FITS")
+        tpf[0:2].interact(exported_filename="demo3.png")
+        tpf[0:2].interact(exported_filename="")
         tpf.interact(exported_filename=210690913)
         mask = tpf.time == tpf.time
         tpf[mask].interact()
@@ -99,12 +101,11 @@ def test_transform_and_ylim_funcs():
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(TABBY_TPF),
-                TessTargetPixelFile(example_tpf)]
+        tpfs = [KeplerTargetPixelFile(TABBY_TPF), TessTargetPixelFile(example_tpf)]
     for tpf in tpfs:
-        tpf.interact(transform_func=lambda lc:lc.normalize())
-        tpf.interact(transform_func=lambda lc:lc.flatten().normalize())
-        tpf.interact(transform_func=lambda lc:lc, ylim_func=lambda lc: (0, 2))
+        tpf.interact(transform_func=lambda lc: lc.normalize())
+        tpf.interact(transform_func=lambda lc: lc.flatten().normalize())
+        tpf.interact(transform_func=lambda lc: lc, ylim_func=lambda lc: (0, 2))
         tpf.interact(ylim_func=lambda lc: (0, lc.flux.max()))
 
 
@@ -112,9 +113,15 @@ def test_transform_and_ylim_funcs():
 def test_interact_functions():
     """Do the helper functions in the interact module run without syntax error?"""
     import bokeh
-    from lightkurve.interact import (prepare_tpf_datasource, prepare_lightcurve_datasource,
-                            get_lightcurve_y_limits, make_lightcurve_figure_elements,
-                            make_tpf_figure_elements, show_interact_widget)
+    from lightkurve.interact import (
+        prepare_tpf_datasource,
+        prepare_lightcurve_datasource,
+        get_lightcurve_y_limits,
+        make_lightcurve_figure_elements,
+        make_tpf_figure_elements,
+        show_interact_widget,
+    )
+
     tpf = TessTargetPixelFile(example_tpf)
     mask = tpf.flux[0, :, :] == tpf.flux[0, :, :]
     tpf_source = prepare_tpf_datasource(tpf, aperture_mask=mask)
@@ -125,10 +132,15 @@ def test_interact_functions():
 
     def ylim_func_sample(lc):
         return (np.nanpercentile(lc.flux, 0.1), np.nanpercentile(lc.flux, 99.9))
+
     make_lightcurve_figure_elements(lc, lc_source, ylim_func=ylim_func_sample)
 
     def ylim_func_unitless(lc):
-        return (np.nanpercentile(lc.flux, 0.1).value, np.nanpercentile(lc.flux, 99.9).value)
+        return (
+            np.nanpercentile(lc.flux, 0.1).value,
+            np.nanpercentile(lc.flux, 99.9).value,
+        )
+
     make_lightcurve_figure_elements(lc, lc_source, ylim_func=ylim_func_unitless)
 
     make_tpf_figure_elements(tpf, tpf_source)
@@ -139,8 +151,12 @@ def test_interact_functions():
 def test_interact_sky_functions():
     """Do the helper functions in the interact module run without syntax error?"""
     import bokeh
-    from lightkurve.interact import (prepare_tpf_datasource, make_tpf_figure_elements,
-                            add_gaia_figure_elements)
+    from lightkurve.interact import (
+        prepare_tpf_datasource,
+        make_tpf_figure_elements,
+        add_gaia_figure_elements,
+    )
+
     tpf = TessTargetPixelFile(example_tpf)
     mask = tpf.flux[0, :, :] == tpf.flux[0, :, :]
     tpf_source = prepare_tpf_datasource(tpf, aperture_mask=mask)
@@ -152,7 +168,7 @@ def test_interact_sky_functions():
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_ylim_with_nans():
     """Regression test for #679: y limits should not be NaN."""
-    lc_source = ColumnDataSource({'flux': [-1, np.nan, 1]})
+    lc_source = ColumnDataSource({"flux": [-1, np.nan, 1]})
     ymin, ymax = get_lightcurve_y_limits(lc_source)
     # ymin/ymax used to return nan, make sure this is no longer the case
     assert ymin == -1.176

--- a/tests/test_interact_bls.py
+++ b/tests/test_interact_bls.py
@@ -16,48 +16,55 @@ except:
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(bad_optional_imports,
-                    reason="requires bokeh and astropy.stats.bls")
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")
 def test_malformed_notebook_url():
     """Test if malformed notebook_urls raise proper exceptions."""
     lc = KeplerLightCurve.read(KEPLER10)
     lc = lc.normalize().remove_nans().flatten()
     with pytest.raises(ValueError) as exc:
-        lc.interact_bls(notebook_url='')
-    assert('Empty host value' in exc.value.args[0])
+        lc.interact_bls(notebook_url="")
+    assert "Empty host value" in exc.value.args[0]
     with pytest.raises(AttributeError) as exc:
         lc.interact_bls(notebook_url=None)
-    assert('object has no attribute' in exc.value.args[0])
+    assert "object has no attribute" in exc.value.args[0]
+
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(bad_optional_imports,
-                    reason="requires bokeh and astropy.stats.bls")
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")
 def test_graceful_exit_outside_notebook():
     """Test if running interact outside of a notebook does fails gracefully."""
     lc = KeplerLightCurve.read(KEPLER10)
     lc = lc.normalize().remove_nans().flatten()
     result = lc.interact_bls()
-    assert(result is None)
+    assert result is None
+
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(bad_optional_imports,
-                    reason="requires bokeh and astropy.stats.bls")
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")
 def test_helper_functions():
     """Can we use all the functions in interact_bls?"""
-    from lightkurve.interact_bls import (prepare_bls_datasource,
-                        prepare_folded_datasource, prepare_lightcurve_datasource)
-    from lightkurve.interact_bls import (make_bls_figure_elements,
-                                        make_folded_figure_elements,
-                                        make_lightcurve_figure_elements)
-    from lightkurve.interact_bls import (prepare_bls_help_source,
-                                        prepare_f_help_source,
-                                        prepare_lc_help_source)
+    from lightkurve.interact_bls import (
+        prepare_bls_datasource,
+        prepare_folded_datasource,
+        prepare_lightcurve_datasource,
+    )
+    from lightkurve.interact_bls import (
+        make_bls_figure_elements,
+        make_folded_figure_elements,
+        make_lightcurve_figure_elements,
+    )
+    from lightkurve.interact_bls import (
+        prepare_bls_help_source,
+        prepare_f_help_source,
+        prepare_lc_help_source,
+    )
+
     lc = KeplerLightCurve.read(KEPLER10)
     lc = lc.normalize().remove_nans().flatten()
     lc_source = prepare_lightcurve_datasource(lc)
     f_source = prepare_folded_datasource(lc.fold(1))
     model = BoxLeastSquares(lc.time, lc.flux)
-    result = model.power([1,2,3], 0.3)
+    result = model.power([1, 2, 3], 0.3)
     bls_source = prepare_bls_datasource(result, 0)
 
     lc_help = prepare_lc_help_source(lc)
@@ -71,29 +78,29 @@ def test_helper_functions():
 
 @pytest.mark.remote_data
 def test_preprocess_lc():
-    '''Test to ensure the lightcurve is pre-processed before applying BLS for correctness and consistent output'''
+    """Test to ensure the lightcurve is pre-processed before applying BLS for correctness and consistent output"""
     from lightkurve.interact_bls import _preprocess_lc_for_bls
+
     lc = KeplerLightCurve.read(KEPLER10)
     assert np.isnan(lc.flux).any()  # ensure the test data has nan in flux
 
     clean = _preprocess_lc_for_bls(lc)
-    assert not np.isnan(clean.flux).any()   # ensure processed lc has no nan
-    assert clean.meta.get('NORMALIZED', False)
+    assert not np.isnan(clean.flux).any()  # ensure processed lc has no nan
+    assert clean.meta.get("NORMALIZED", False)
     assert clean.flux.unit == u.dimensionless_unscaled
 
     # case the lc is normalized, but in other units
-    lc = lc.normalize(unit='percent')
+    lc = lc.normalize(unit="percent")
     clean = _preprocess_lc_for_bls(lc)
-    assert not np.isnan(clean.flux).any()   # ensure processed lc has no nan
-    assert clean.meta.get('NORMALIZED', False)
+    assert not np.isnan(clean.flux).any()  # ensure processed lc has no nan
+    assert clean.meta.get("NORMALIZED", False)
     assert clean.flux.unit == u.dimensionless_unscaled
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(bad_optional_imports,
-                    reason="requires bokeh and astropy.stats.bls")
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")
 def test_full_widget():
-    '''Test if we can run the widget with the keywords'''
+    """Test if we can run the widget with the keywords"""
     lc = KeplerLightCurve.read(KEPLER10)
     lc = lc.normalize().remove_nans().flatten()
     lc.interact_bls()
@@ -103,10 +110,9 @@ def test_full_widget():
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif(bad_optional_imports,
-                    reason="requires bokeh and astropy.stats.bls")
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")
 def test_tess_widget():
-    '''Test if we can run the widget with the keywords'''
+    """Test if we can run the widget with the keywords"""
     lc = TessLightCurve.read(TESS_SIM)
     lc = lc.normalize().remove_nans().flatten()
     lc.interact_bls()

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -9,8 +9,7 @@ from astropy.table import Table, Column, MaskedColumn
 import matplotlib.pyplot as plt
 import numpy as np
 
-from numpy.testing import (assert_almost_equal, assert_array_equal,
-                           assert_allclose)
+from numpy.testing import assert_almost_equal, assert_array_equal, assert_allclose
 import pytest
 import tempfile
 import warnings
@@ -27,17 +26,29 @@ from .test_targetpixelfile import TABBY_TPF
 
 
 # 8th Quarter of Tabby's star
-TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
-            "/0084/008462852/kplr008462852-2011073133259_llc.fits")
-K2_C08 = ("https://archive.stsci.edu/missions/k2/lightcurves/c8/"
-          "220100000/39000/ktwo220139473-c08_llc.fits")
-KEPLER10 = ("https://archive.stsci.edu/missions/kepler/lightcurves/"
-            "0119/011904151/kplr011904151-2010009091648_llc.fits")
-TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/"
-            "004/104/tess2019128220341-0000000410458113-0016-s_lc.fits")
+TABBY_Q8 = (
+    "https://archive.stsci.edu/missions/kepler/lightcurves"
+    "/0084/008462852/kplr008462852-2011073133259_llc.fits"
+)
+K2_C08 = (
+    "https://archive.stsci.edu/missions/k2/lightcurves/c8/"
+    "220100000/39000/ktwo220139473-c08_llc.fits"
+)
+KEPLER10 = (
+    "https://archive.stsci.edu/missions/kepler/lightcurves/"
+    "0119/011904151/kplr011904151-2010009091648_llc.fits"
+)
+TESS_SIM = (
+    "https://archive.stsci.edu/missions/tess/ete-6/tid/00/000/"
+    "004/104/tess2019128220341-0000000410458113-0016-s_lc.fits"
+)
 filename_tess = get_pkg_data_filename("data/tess25155310-s01-first-cadences.fits.gz")
-filename_tess_custom = get_pkg_data_filename("data/test_TESS_interact_generated_custom-lc.fits")
-filename_K2_custom = get_pkg_data_filename("data/test_K2_interact_generated_custom-lc.fits")
+filename_tess_custom = get_pkg_data_filename(
+    "data/test_TESS_interact_generated_custom-lc.fits"
+)
+filename_K2_custom = get_pkg_data_filename(
+    "data/test_K2_interact_generated_custom-lc.fits"
+)
 
 
 # `asteroid_test.fits` is a single cadence of TESS FFI data which contains a known solar system object
@@ -61,7 +72,9 @@ def test_lc_nan_time():
 
 
 def test_math_operators():
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
+    lc = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5)
+    )
     lc_add = lc + 1
     lc_sub = lc - 1
     lc_mul = lc * 2
@@ -73,8 +86,12 @@ def test_math_operators():
 
 
 def test_math_operators_on_objects():
-    lc1 = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
-    lc2 = LightCurve(time=np.arange(1, 5), flux=np.arange(11, 15), flux_err=np.arange(1, 5))
+    lc1 = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5)
+    )
+    lc2 = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(11, 15), flux_err=np.arange(1, 5)
+    )
     assert_array_equal((lc1 + lc2).flux, lc1.flux + lc2.flux)
     assert_array_equal((lc1 - lc2).flux, lc1.flux - lc2.flux)
     assert_array_equal((lc1 * lc2).flux, lc1.flux * lc2.flux)
@@ -92,7 +109,9 @@ def test_math_operators_on_objects():
 
 
 def test_rmath_operators():
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
+    lc = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5)
+    )
     lc_add = 1 + lc
     lc_sub = 1 - lc
     lc_mul = 2 * lc
@@ -104,71 +123,84 @@ def test_rmath_operators():
 
 
 def test_math_operators_on_units():
-    lc = LightCurve(time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5))
+    lc = LightCurve(
+        time=np.arange(1, 5), flux=np.arange(1, 5), flux_err=np.arange(1, 5)
+    )
     lc_mul = lc * u.pixel
     lc_div = lc / u.pixel
-    assert lc_mul.flux.unit == 'pixel'
-    assert lc_mul.flux_err.unit == 'pixel'
-    assert lc_div.flux.unit == 1/u.pixel
-    assert lc_div.flux_err.unit == 1/u.pixel
+    assert lc_mul.flux.unit == "pixel"
+    assert lc_mul.flux_err.unit == "pixel"
+    assert lc_div.flux.unit == 1 / u.pixel
+    assert lc_div.flux_err.unit == 1 / u.pixel
 
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("path, mission", [(TABBY_Q8, "Kepler"), (K2_C08, "K2")])
 def test_KeplerLightCurveFile(path, mission):
     lc = KeplerLightCurveFile(path, flux_column="sap_flux", quality_bitmask=None)
-    assert lc.obsmode == 'long cadence'
+    assert lc.obsmode == "long cadence"
     assert len(lc.pos_corr1) == len(lc.pos_corr2)
 
     assert lc.mission.lower() == mission.lower()
-    if lc.mission.lower() == 'kepler':
-        assert lc.meta.get('CAMPAIGN') is None
+    if lc.mission.lower() == "kepler":
+        assert lc.meta.get("CAMPAIGN") is None
         assert lc.quarter == 8
-    elif lc.mission.lower() == 'k2':
+    elif lc.mission.lower() == "k2":
         assert lc.campaign == 8
-        assert lc.meta.get('QUARTER') is None
-    assert lc.time.format == 'bkjd'
-    assert lc.time.scale == 'tdb'
+        assert lc.meta.get("QUARTER") is None
+    assert lc.time.format == "bkjd"
+    assert lc.time.scale == "tdb"
     assert lc.flux.unit == u.electron / u.second
 
     # Does the data match what one would obtain using pyfits.open?
     hdu = pyfits.open(path)
-    assert lc.label == hdu[0].header['OBJECT']
-    nanmask = ~np.isnan(hdu[1].data['TIME'])
-    assert_array_equal(lc.time.value, hdu[1].data['TIME'][nanmask])
-    assert_array_equal(lc.flux.value, hdu[1].data['SAP_FLUX'][nanmask])
+    assert lc.label == hdu[0].header["OBJECT"]
+    nanmask = ~np.isnan(hdu[1].data["TIME"])
+    assert_array_equal(lc.time.value, hdu[1].data["TIME"][nanmask])
+    assert_array_equal(lc.flux.value, hdu[1].data["SAP_FLUX"][nanmask])
 
 
 @pytest.mark.remote_data
-@pytest.mark.parametrize("quality_bitmask",
-                         ['hardest', 'hard', 'default', None,
-                          1, 100, 2096639])
+@pytest.mark.parametrize(
+    "quality_bitmask", ["hardest", "hard", "default", None, 1, 100, 2096639]
+)
 def test_TessLightCurveFile(quality_bitmask):
-    lc = TessLightCurveFile(TESS_SIM, quality_bitmask=quality_bitmask, flux_column="sap_flux")
+    lc = TessLightCurveFile(
+        TESS_SIM, quality_bitmask=quality_bitmask, flux_column="sap_flux"
+    )
     hdu = pyfits.open(TESS_SIM)
 
-    assert lc.mission == 'TESS'
-    assert lc.label == hdu[0].header['OBJECT']
-    assert lc.time.format == 'btjd'
-    assert lc.time.scale == 'tdb'
+    assert lc.mission == "TESS"
+    assert lc.label == hdu[0].header["OBJECT"]
+    assert lc.time.format == "btjd"
+    assert lc.time.scale == "tdb"
     assert lc.flux.unit == u.electron / u.second
-    assert lc.sector == hdu[0].header['SECTOR']
-    assert lc.camera == hdu[0].header['CAMERA']
-    assert lc.ccd == hdu[0].header['CCD']
-    assert lc.ra == hdu[0].header['RA_OBJ']
-    assert lc.dec == hdu[0].header['DEC_OBJ']
+    assert lc.sector == hdu[0].header["SECTOR"]
+    assert lc.camera == hdu[0].header["CAMERA"]
+    assert lc.ccd == hdu[0].header["CCD"]
+    assert lc.ra == hdu[0].header["RA_OBJ"]
+    assert lc.dec == hdu[0].header["DEC_OBJ"]
 
-    assert_array_equal(lc.time[0:10].value, hdu[1].data['TIME'][0:10])
-    assert_array_equal(lc.flux[0:10].value, hdu[1].data['SAP_FLUX'][0:10])
+    assert_array_equal(lc.time[0:10].value, hdu[1].data["TIME"][0:10])
+    assert_array_equal(lc.flux[0:10].value, hdu[1].data["SAP_FLUX"][0:10])
 
     # Regression test for https://github.com/lightkurve/lightkurve/pull/236
     assert np.isnan(lc.time.value).sum() == 0
 
 
 @pytest.mark.remote_data
-@pytest.mark.parametrize("quality_bitmask, answer", [('hardest', 2661),
-                                                     ('hard', 2706), ('default', 3113), (None, 3143),
-                                                     (1, 3143), (100, 3116), (2096639, 2661)])
+@pytest.mark.parametrize(
+    "quality_bitmask, answer",
+    [
+        ("hardest", 2661),
+        ("hard", 2706),
+        ("default", 3113),
+        (None, 3143),
+        (1, 3143),
+        (100, 3116),
+        (2096639, 2661),
+    ],
+)
 def test_bitmasking(quality_bitmask, answer):
     """Test whether the bitmasking behaves like it should"""
     lc = read(TABBY_Q8, quality_bitmask=quality_bitmask)
@@ -177,8 +209,13 @@ def test_bitmasking(quality_bitmask, answer):
 
 def test_lightcurve_fold():
     """Test the ``LightCurve.fold()`` method."""
-    lc = KeplerLightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1,
-                          targetid=999, label='mystar', meta={'CCD': 2})
+    lc = KeplerLightCurve(
+        time=np.linspace(0, 10, 100),
+        flux=np.zeros(100) + 1,
+        targetid=999,
+        label="mystar",
+        meta={"CCD": 2},
+    )
     fold = lc.fold(period=1)
     assert_almost_equal(fold.phase[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
@@ -186,7 +223,7 @@ def test_lightcurve_fold():
     assert fold.targetid == lc.targetid
     assert fold.label == lc.label
     assert set(lc.meta).issubset(set(fold.meta))
-    assert lc.meta['CCD'] == fold.meta['CCD']
+    assert lc.meta["CCD"] == fold.meta["CCD"]
     assert_array_equal(np.sort(fold.time_original), lc.time)
     assert len(fold.time_original) == len(lc.time)
     fold = lc.fold(period=1, epoch_time=-0.1)
@@ -199,12 +236,12 @@ def test_lightcurve_fold():
         fold = lc.fold(period=1, transit_midpoint=-0.1)
     assert_almost_equal(fold.time[0], -0.5, 2)
     ax = fold.plot()
-    assert ('Phase' in ax.get_xlabel())
+    assert "Phase" in ax.get_xlabel()
     ax = fold.scatter()
-    assert ('Phase' in ax.get_xlabel())
+    assert "Phase" in ax.get_xlabel()
     ax = fold.errorbar()
-    assert ('Phase' in ax.get_xlabel())
-    plt.close('all')
+    assert "Phase" in ax.get_xlabel()
+    plt.close("all")
 
     odd = fold.odd_mask
     even = fold.even_mask
@@ -213,41 +250,47 @@ def test_lightcurve_fold():
     assert np.sum(odd) == np.sum(even)
     # bad transit midpoint should give a warning
     # if user tries a t0 in JD but time is in BKJD
-    with pytest.warns(LightkurveWarning, match='appears to be given in JD'):
+    with pytest.warns(LightkurveWarning, match="appears to be given in JD"):
         lc.fold(10, 2456600)
 
 
 def test_lightcurve_fold_issue520():
     """Regression test for #520; accept quantities in `fold()`."""
-    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1)
-    lc.fold(period=1*u.day, epoch_time=5*u.day)
+    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100) + 1)
+    lc.fold(period=1 * u.day, epoch_time=5 * u.day)
+
 
 def test_lightcurve_append():
     """Test ``LightCurve.append()``."""
-    lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1], flux_err=[0.1, 0.2, 0.3])
+    lc = LightCurve(time=[1, 2, 3], flux=[1, 0.5, 1], flux_err=[0.1, 0.2, 0.3])
     lc = lc.append(lc)
-    assert_array_equal(lc.time.value, 2*[1, 2, 3])
-    assert_array_equal(lc.flux, 2*[1, .5, 1])
-    assert_array_equal(lc.flux_err, 2*[0.1, 0.2, 0.3])
+    assert_array_equal(lc.time.value, 2 * [1, 2, 3])
+    assert_array_equal(lc.flux, 2 * [1, 0.5, 1])
+    assert_array_equal(lc.flux_err, 2 * [0.1, 0.2, 0.3])
     # KeplerLightCurve has extra data
-    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, .5, 1],
-                          centroid_col=[4, 5, 6], centroid_row=[7, 8, 9],
-                          cadenceno=[10, 11, 12], quality=[10, 20, 30])
+    lc = KeplerLightCurve(
+        time=[1, 2, 3],
+        flux=[1, 0.5, 1],
+        centroid_col=[4, 5, 6],
+        centroid_row=[7, 8, 9],
+        cadenceno=[10, 11, 12],
+        quality=[10, 20, 30],
+    )
     lc = lc.append(lc)
-    assert_array_equal(lc.time.value, 2*[1, 2, 3])
-    assert_array_equal(lc.flux, 2*[1, .5, 1])
-    assert_array_equal(lc.centroid_col, 2*[4, 5, 6])
-    assert_array_equal(lc.centroid_row, 2*[7, 8, 9])
-    assert_array_equal(lc.cadenceno, 2*[10, 11, 12])
-    assert_array_equal(lc.quality, 2*[10, 20, 30])
+    assert_array_equal(lc.time.value, 2 * [1, 2, 3])
+    assert_array_equal(lc.flux, 2 * [1, 0.5, 1])
+    assert_array_equal(lc.centroid_col, 2 * [4, 5, 6])
+    assert_array_equal(lc.centroid_row, 2 * [7, 8, 9])
+    assert_array_equal(lc.cadenceno, 2 * [10, 11, 12])
+    assert_array_equal(lc.quality, 2 * [10, 20, 30])
 
 
 def test_lightcurve_append_multiple():
     """Test ``LightCurve.append()`` for multiple lightcurves at once."""
-    lc = LightCurve(time=[1, 2, 3], flux=[1, .5, 1])
+    lc = LightCurve(time=[1, 2, 3], flux=[1, 0.5, 1])
     lc = lc.append([lc, lc, lc])
-    assert_array_equal(lc.flux, 4*[1, .5, 1])
-    assert_array_equal(lc.time.value, 4*[1, 2, 3])
+    assert_array_equal(lc.flux, 4 * [1, 0.5, 1])
+    assert_array_equal(lc.time.value, 4 * [1, 2, 3])
 
 
 def test_lightcurve_copy():
@@ -269,17 +312,22 @@ def test_lightcurve_copy():
     # By changing 1 of the 4 data points in the new lightcurve's array-like
     # attributes, we expect assert_array_equal to raise an AssertionError
     # indicating a mismatch of 1/4 (or 25%).
-    with pytest.raises(AssertionError, match=r'ismatch.*25'):
+    with pytest.raises(AssertionError, match=r"ismatch.*25"):
         assert_array_equal(lc.time, nlc.time)
-    with pytest.raises(AssertionError, match=r'ismatch.*25'):
+    with pytest.raises(AssertionError, match=r"ismatch.*25"):
         assert_array_equal(lc.flux, nlc.flux)
-    with pytest.raises(AssertionError, match=r'ismatch.*25'):
+    with pytest.raises(AssertionError, match=r"ismatch.*25"):
         assert_array_equal(lc.flux_err, nlc.flux_err)
 
     # KeplerLightCurve has extra data
-    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, .5, 1],
-                          centroid_col=[4, 5, 6], centroid_row=[7, 8, 9],
-                          cadenceno=[10, 11, 12], quality=[10, 20, 30])
+    lc = KeplerLightCurve(
+        time=[1, 2, 3],
+        flux=[1, 0.5, 1],
+        centroid_col=[4, 5, 6],
+        centroid_row=[7, 8, 9],
+        cadenceno=[10, 11, 12],
+        quality=[10, 20, 30],
+    )
     nlc = lc.copy()
     assert_array_equal(lc.time, nlc.time)
     assert_array_equal(lc.flux, nlc.flux)
@@ -299,28 +347,29 @@ def test_lightcurve_copy():
     # with a repeating decimal. However, float precision for python 2.7 is 10
     # decimal digits, while python 3.6's is 13 decimal digits. Therefore,
     # a regular expression is needed for both versions.
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.time, nlc.time)
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.flux, nlc.flux)
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.centroid_col, nlc.centroid_col)
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.centroid_row, nlc.centroid_row)
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.cadenceno, nlc.cadenceno)
-    with pytest.raises(AssertionError, match=r'ismatch.*33\.3+'):
+    with pytest.raises(AssertionError, match=r"ismatch.*33\.3+"):
         assert_array_equal(lc.quality, nlc.quality)
 
 
-@pytest.mark.parametrize("path, mission", [(filename_tess_custom, "TESS"),
-                                           (filename_K2_custom, "K2")])
+@pytest.mark.parametrize(
+    "path, mission", [(filename_tess_custom, "TESS"), (filename_K2_custom, "K2")]
+)
 def test_custom_lightcurve_file(path, mission):
     """Test whether we can read in custom interact()-produced lightcurvefiles"""
     if mission == "K2":
         lc = KeplerLightCurve.read(path)
     elif mission == "TESS":
-        #with pytest.warns(LightkurveWarning):
+        # with pytest.warns(LightkurveWarning):
         lc = TessLightCurve.read(path)
     assert lc.cadenceno[0] >= 0
     assert lc.dec == lc.dec
@@ -330,18 +379,17 @@ def test_custom_lightcurve_file(path, mission):
     assert lc.mission.lower() == mission.lower()
     # Does the data match what one would obtain using pyfits.open?
     hdu = pyfits.open(path)
-    assert lc.label == hdu[0].header['OBJECT']
-    assert_array_equal(lc.time.value, hdu[1].data['TIME'])
-    assert_array_equal(lc.flux.value, hdu[1].data['FLUX'])
+    assert lc.label == hdu[0].header["OBJECT"]
+    assert_array_equal(lc.time.value, hdu[1].data["TIME"])
+    assert_array_equal(lc.flux.value, hdu[1].data["FLUX"])
 
     # TESS has QUALITY while Kepler/K2 has SAP_QUALITY:
     if mission == "TESS":
         assert "QUALITY" in hdu[1].columns.names
-        assert_array_equal(lc.quality, hdu[1].data['QUALITY'])
+        assert_array_equal(lc.quality, hdu[1].data["QUALITY"])
     if mission in ["K2", "Kepler"]:
         assert "SAP_QUALITY" in hdu[1].columns.names
-        assert_array_equal(lc.quality, hdu[1].data['SAP_QUALITY'])
-
+        assert_array_equal(lc.quality, hdu[1].data["SAP_QUALITY"])
 
 
 @pytest.mark.remote_data
@@ -354,14 +402,14 @@ def test_lightcurve_plots():
         lc.plot()
         lc.plot(normalize=False, title="Not the default")
         lc.scatter()
-        lc.scatter(c='C3')
-        lc.scatter(c=lc.time.value, show_colorbar=True, colorbar_label='Time')
-        lc.plot(column='sap_flux')
-        lc.plot(column='sap_bkg', normalize=True)
-        lc.plot(column='cadenceno')
-        lc.errorbar(column='psf_centr1')
-        lc.errorbar(column='timecorr')
-        plt.close('all')
+        lc.scatter(c="C3")
+        lc.scatter(c=lc.time.value, show_colorbar=True, colorbar_label="Time")
+        lc.plot(column="sap_flux")
+        lc.plot(column="sap_bkg", normalize=True)
+        lc.plot(column="cadenceno")
+        lc.errorbar(column="psf_centr1")
+        lc.errorbar(column="timecorr")
+        plt.close("all")
 
 
 @pytest.mark.remote_data
@@ -376,12 +424,12 @@ def test_lightcurve_scatter():
     foldedtimeinorder = originaltime.fold(**foldkw).flux
 
     # plot a grid of phase-folded and not, with colors
-    fi, ax = plt.subplots(2, 2, figsize=(10,6), sharey=True, sharex='col')
-    scatterkw = dict( s=5, cmap='winter')
-    lc.scatter(ax=ax[0,0])
-    lc.fold(**foldkw).scatter(ax=ax[0,1])
-    lc.scatter(ax=ax[1,0], c=lc.time.value, **scatterkw)
-    lc.fold(**foldkw).scatter(ax=ax[1,1], c=foldedtimeinorder, **scatterkw)
+    fi, ax = plt.subplots(2, 2, figsize=(10, 6), sharey=True, sharex="col")
+    scatterkw = dict(s=5, cmap="winter")
+    lc.scatter(ax=ax[0, 0])
+    lc.fold(**foldkw).scatter(ax=ax[0, 1])
+    lc.scatter(ax=ax[1, 0], c=lc.time.value, **scatterkw)
+    lc.fold(**foldkw).scatter(ax=ax[1, 1], c=foldedtimeinorder, **scatterkw)
     plt.ylim(0.999, 1.001)
 
 
@@ -396,7 +444,7 @@ def test_lightcurve_plots_unitless():
     lc.scatter()
     lc.errorbar()
     lc.plot(normalize=True, clip_outliers=True)
-    plt.close('all')
+    plt.close("all")
 
 
 def test_cdpp():
@@ -405,8 +453,9 @@ def test_cdpp():
     lc = LightCurve(time=np.arange(200), flux=np.ones(200))
     assert_almost_equal(lc.estimate_cdpp(), 0)
     # An artificial lightcurve with sigma=100ppm should have cdpp=100ppm
-    lc = LightCurve(time=np.arange(10000),
-                    flux=np.random.normal(loc=1, scale=100e-6, size=10000))
+    lc = LightCurve(
+        time=np.arange(10000), flux=np.random.normal(loc=1, scale=100e-6, size=10000)
+    )
     assert_almost_equal(lc.estimate_cdpp(transit_duration=1).value, 100, decimal=-0.5)
     # Transit_duration must be an integer (cadences)
     with pytest.raises(ValueError):
@@ -419,7 +468,7 @@ def test_cdpp_tabby():
     lc = KeplerLightCurve.read(TABBY_Q8)
     # Tabby's star shows dips after cadence 1000 which increase the cdpp
     lc2 = LightCurve(time=lc.time[:1000], flux=lc.flux[:1000])
-    assert(np.abs(lc2.estimate_cdpp().value - lc.cdpp6_0) < 30)
+    assert np.abs(lc2.estimate_cdpp().value - lc.cdpp6_0) < 30
 
 
 # TEMPORARILY SKIP, cf. https://github.com/lightkurve/lightkurve/issues/663
@@ -429,32 +478,33 @@ def test_bin():
     with warnings.catch_warnings():  # binsize is deprecated
         warnings.simplefilter("ignore", LightkurveDeprecationWarning)
 
-        lc = LightCurve(time=np.arange(10),
-                        flux=2*np.ones(10),
-                        flux_err=2**.5*np.ones(10))
+        lc = LightCurve(
+            time=np.arange(10), flux=2 * np.ones(10), flux_err=2 ** 0.5 * np.ones(10)
+        )
         binned_lc = lc.bin(binsize=2)
-        assert_allclose(binned_lc.flux, 2*np.ones(5))
+        assert_allclose(binned_lc.flux, 2 * np.ones(5))
         assert_allclose(binned_lc.flux_err, np.ones(5))
         assert len(binned_lc.time) == 5
         with pytest.raises(ValueError):
-            lc.bin(method='doesnotexist')
+            lc.bin(method="doesnotexist")
         # If `flux_err` is missing, the errors on the bins should be the stddev
-        lc = LightCurve(time=np.arange(10),
-                        flux=2*np.ones(10))
+        lc = LightCurve(time=np.arange(10), flux=2 * np.ones(10))
         binned_lc = lc.bin(binsize=2)
         assert_allclose(binned_lc.flux_err, np.zeros(5))
         # Regression test for #377
-        lc = KeplerLightCurve(time=np.arange(10),
-                            flux=2*np.ones(10))
+        lc = KeplerLightCurve(time=np.arange(10), flux=2 * np.ones(10))
         lc.bin(5).remove_outliers()
         # Second regression test for #377
-        lc = KeplerLightCurve(time=np.arange(1000) * 0.02,
-                            flux=1*np.ones(1000) + np.random.normal(0, 1e-6, 1000),
-                            cadenceno=np.arange(1000))
+        lc = KeplerLightCurve(
+            time=np.arange(1000) * 0.02,
+            flux=1 * np.ones(1000) + np.random.normal(0, 1e-6, 1000),
+            cadenceno=np.arange(1000),
+        )
         assert np.isclose(lc.bin(2).estimate_cdpp(), 1, rtol=1)
         # Regression test for #500
-        lc = LightCurve(time=np.arange(2000),
-                        flux=np.random.normal(loc=42, scale=0.01, size=2000))
+        lc = LightCurve(
+            time=np.arange(2000), flux=np.random.normal(loc=42, scale=0.01, size=2000)
+        )
         assert np.round(lc.bin(2000).flux_err[0], 2) == 0.01
 
 
@@ -462,42 +512,47 @@ def test_bin():
 def test_bins_kwarg():
     """Does binning work with user-defined bin placement?"""
     n_times = 3800
-    end_time = 80.
+    end_time = 80.0
     time_points = np.sort(np.random.uniform(low=0.0, high=end_time, size=n_times))
-    lc = LightCurve(time=time_points, flux=1.0+np.random.normal(0, 0.1, n_times),
-                    flux_err=0.1*np.ones(n_times))
+    lc = LightCurve(
+        time=time_points,
+        flux=1.0 + np.random.normal(0, 0.1, n_times),
+        flux_err=0.1 * np.ones(n_times),
+    )
     # Do the shapes of binned lightcurves make sense?
-    binned_lc = lc.bin(time_bin_size=10*u.day)
+    binned_lc = lc.bin(time_bin_size=10 * u.day)
     assert len(binned_lc) == np.ceil(end_time / 10)
-    binned_lc = lc.bin(time_bin_size=11*u.day)
+    binned_lc = lc.bin(time_bin_size=11 * u.day)
     assert len(binned_lc) == np.ceil(end_time / 11)
     # Resulting length with `n_bins=N` yields exactly N bins every time
-    binned_lc = lc.bin(time_bin_size=10*u.day, n_bins=38)
+    binned_lc = lc.bin(time_bin_size=10 * u.day, n_bins=38)
     assert len(binned_lc) == 38
     # The `bins=`` kwarg can support a list or array
-    time_bin_edges = [0,10,20,30,40,50,60,70,80]
+    time_bin_edges = [0, 10, 20, 30, 40, 50, 60, 70, 80]
     binned_lc = lc.bin(bins=time_bin_edges)
     # You get N-1 bins when you enter N fenceposts
-    assert len(binned_lc) == (len(time_bin_edges) - 1 )
-    time_bin_edges = np.arange(0,81,1)
+    assert len(binned_lc) == (len(time_bin_edges) - 1)
+    time_bin_edges = np.arange(0, 81, 1)
     binned_lc = lc.bin(bins=time_bin_edges)
-    assert len(binned_lc) == (len(time_bin_edges) - 1 )
+    assert len(binned_lc) == (len(time_bin_edges) - 1)
     # Bins outside of the range get stuck in the last bin
-    time_bin_edges = np.arange(0,61,1)
+    time_bin_edges = np.arange(0, 61, 1)
     binned_lc = lc.bin(bins=time_bin_edges)
-    assert len(binned_lc) == (len(time_bin_edges) - 1 )
+    assert len(binned_lc) == (len(time_bin_edges) - 1)
     # The `bins=`` kwarg can support a list or array
-    for special_bins in ['blocks', 'knuth', 'scott', 'freedman']:
+    for special_bins in ["blocks", "knuth", "scott", "freedman"]:
         binned_lc = lc.bin(bins=special_bins)
     with pytest.raises(ValueError):
-        binned_lc = lc.bin(bins='junk_input!')
+        binned_lc = lc.bin(bins="junk_input!")
     # In dense bins, flux error should go down as root-N for N number of bins
-    binned_lc = lc.bin(binsize=100) # Exactly 100 samples per bin
-    assert np.isclose(lc.flux_err.mean()/np.sqrt(100),
-                      binned_lc.flux_err.mean(), rtol=0.3)
-    binned_lc = lc.bin(bins=38) # Roughly 100 samples per bin
-    assert np.isclose(lc.flux_err.mean()/np.sqrt(100),
-                  binned_lc.flux_err.mean(), rtol=0.3)
+    binned_lc = lc.bin(binsize=100)  # Exactly 100 samples per bin
+    assert np.isclose(
+        lc.flux_err.mean() / np.sqrt(100), binned_lc.flux_err.mean(), rtol=0.3
+    )
+    binned_lc = lc.bin(bins=38)  # Roughly 100 samples per bin
+    assert np.isclose(
+        lc.flux_err.mean() / np.sqrt(100), binned_lc.flux_err.mean(), rtol=0.3
+    )
     # The bins parameter must be integer not a float
     with pytest.raises(TypeError):
         binned_lc = lc.bin(bins=381.0)
@@ -515,11 +570,13 @@ def test_bins_kwarg():
 @pytest.mark.xfail
 def test_bin_quality():
     """Binning must also revise the quality and centroid columns."""
-    lc = KeplerLightCurve(time=[1, 2, 3, 4],
-                          flux=[1, 1, 1, 1],
-                          quality=[0, 1, 2, 3],
-                          centroid_col=[0, 1, 0, 1],
-                          centroid_row=[0, 2, 0, 2])
+    lc = KeplerLightCurve(
+        time=[1, 2, 3, 4],
+        flux=[1, 1, 1, 1],
+        quality=[0, 1, 2, 3],
+        centroid_col=[0, 1, 0, 1],
+        centroid_row=[0, 2, 0, 2],
+    )
     binned_lc = lc.bin(binsize=2)
     assert_allclose(binned_lc.quality, [1, 3])  # Expect bitwise or
     assert_allclose(binned_lc.centroid_col, [0.5, 0.5])  # Expect mean
@@ -528,9 +585,11 @@ def test_bin_quality():
 
 def test_normalize():
     """Does the `LightCurve.normalize()` method normalize the flux?"""
-    lc = LightCurve(time=np.arange(10), flux=5*np.ones(10), flux_err=0.05*np.ones(10))
+    lc = LightCurve(
+        time=np.arange(10), flux=5 * np.ones(10), flux_err=0.05 * np.ones(10)
+    )
     assert_allclose(np.median(lc.normalize().flux), 1)
-    assert_allclose(np.median(lc.normalize().flux_err), 0.05/5)
+    assert_allclose(np.median(lc.normalize().flux_err), 0.05 / 5)
 
 
 def test_invalid_normalize():
@@ -538,23 +597,24 @@ def test_invalid_normalize():
     zero-centered, or already in relative units."""
     # zero-centered light curve
     lc = LightCurve(time=np.arange(10), flux=np.zeros(10))
-    with pytest.warns(LightkurveWarning, match='zero-centered'):
+    with pytest.warns(LightkurveWarning, match="zero-centered"):
         lc.normalize()
 
     # zero-centered light curve with flux errors
-    lc = LightCurve(time=np.arange(10), flux=np.zeros(10), flux_err=0.05*np.ones(10))
-    with pytest.warns(LightkurveWarning, match='zero-centered'):
+    lc = LightCurve(time=np.arange(10), flux=np.zeros(10), flux_err=0.05 * np.ones(10))
+    with pytest.warns(LightkurveWarning, match="zero-centered"):
         lc.normalize()
 
     # negative light curve
-    lc = LightCurve(time=np.arange(10), flux=-np.ones(10), flux_err=0.05*np.ones(10))
-    with pytest.warns(LightkurveWarning, match='negative'):
+    lc = LightCurve(time=np.arange(10), flux=-np.ones(10), flux_err=0.05 * np.ones(10))
+    with pytest.warns(LightkurveWarning, match="negative"):
         lc.normalize()
 
     # already in relative units
     lc = LightCurve(time=np.arange(10), flux=np.ones(10))
-    with pytest.warns(LightkurveWarning, match='relative'):
+    with pytest.warns(LightkurveWarning, match="relative"):
         lc.normalize().normalize()
+
 
 def test_to_pandas():
     """Test the `LightCurve.to_pandas()` method."""
@@ -564,7 +624,7 @@ def test_to_pandas():
         df = lc.to_pandas()
         assert_allclose(df.flux, flux)
         assert_allclose(df.flux_err, flux_err)
-        df.describe() # Will fail if for Endianness bugs
+        df.describe()  # Will fail if for Endianness bugs
     except ImportError:
         # pandas is an optional dependency
         pass
@@ -588,9 +648,9 @@ def test_to_table():
     time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
     lc = LightCurve(time=time, flux=flux, flux_err=flux_err)
     tbl = lc.to_table()
-    assert_allclose(tbl['time'].value, time)
-    assert_allclose(tbl['flux'], flux)
-    assert_allclose(tbl['flux_err'], flux_err)
+    assert_allclose(tbl["time"].value, time)
+    assert_allclose(tbl["flux"], flux)
+    assert_allclose(tbl["flux_err"], flux_err)
 
 
 # Looks like `to_pandas` forces the time field to become an ISO datetime;
@@ -602,7 +662,10 @@ def test_to_csv():
     time, flux, flux_err = range(3), np.ones(3), np.zeros(3)
     try:
         lc = LightCurve(time=time, flux=flux, flux_err=flux_err)
-        assert(lc.to_csv(line_terminator='\n') == 'time,flux,flux_err\n0,1.0,0.0\n1,1.0,0.0\n2,1.0,0.0\n')
+        assert (
+            lc.to_csv(line_terminator="\n")
+            == "time,flux,flux_err\n0,1.0,0.0\n1,1.0,0.0\n2,1.0,0.0\n"
+        )
     except ImportError:
         # pandas is an optional dependency
         pass
@@ -614,21 +677,21 @@ def test_to_fits():
     lc = KeplerLightCurve.read(TABBY_Q8)
     hdu = lc.to_fits()
     KeplerLightCurve.read(hdu)  # Regression test for #233
-    assert type(hdu).__name__ is 'HDUList'
+    assert type(hdu).__name__ is "HDUList"
     assert len(hdu) == 2
-    assert hdu[0].header['EXTNAME'] == 'PRIMARY'
-    assert hdu[1].header['EXTNAME'] == 'LIGHTCURVE'
-    assert hdu[1].header['TTYPE1'] == 'TIME'
-    assert hdu[1].header['TTYPE2'] == 'FLUX'
-    assert hdu[1].header['TTYPE3'] == 'FLUX_ERR'
+    assert hdu[0].header["EXTNAME"] == "PRIMARY"
+    assert hdu[1].header["EXTNAME"] == "LIGHTCURVE"
+    assert hdu[1].header["TTYPE1"] == "TIME"
+    assert hdu[1].header["TTYPE2"] == "FLUX"
+    assert hdu[1].header["TTYPE3"] == "FLUX_ERR"
     hdu = LightCurve(time=[0, 1, 2, 3, 4], flux=[1, 1, 1, 1, 1]).to_fits()
 
     # Test "round-tripping": can we read-in what we write
     lc_new = KeplerLightCurve.read(hdu)  # Regression test for #233
-    assert hdu[0].header['EXTNAME'] == 'PRIMARY'
-    assert hdu[1].header['EXTNAME'] == 'LIGHTCURVE'
-    assert hdu[1].header['TTYPE1'] == 'TIME'
-    assert hdu[1].header['TTYPE2'] == 'FLUX'
+    assert hdu[0].header["EXTNAME"] == "PRIMARY"
+    assert hdu[1].header["EXTNAME"] == "LIGHTCURVE"
+    assert hdu[1].header["TTYPE1"] == "TIME"
+    assert hdu[1].header["TTYPE2"] == "FLUX"
 
     # Test aperture mask support in to_fits
     for tpf in [KeplerTargetPixelFile(TABBY_TPF), TessTargetPixelFile(filename_tess)]:
@@ -638,8 +701,11 @@ def test_to_fits():
         lc = tpf.to_lightcurve(aperture_mask=random_mask)
         lc.to_fits(path=tempfile.NamedTemporaryFile().name, aperture_mask=random_mask)
 
-        lc.to_fits(path=tempfile.NamedTemporaryFile().name, overwrite=True,
-                   flux_column_name='SAP_FLUX')
+        lc.to_fits(
+            path=tempfile.NamedTemporaryFile().name,
+            overwrite=True,
+            flux_column_name="SAP_FLUX",
+        )
 
         lc = tpf[0:2].to_lightcurve(aperture_mask=thresh_mask)
         lc.to_fits(aperture_mask=thresh_mask, path=tempfile.NamedTemporaryFile().name)
@@ -647,19 +713,23 @@ def test_to_fits():
         # Test the extra data kwargs
         bkg_mask = ~tpf.create_threshold_mask(threshold=0.1)
         bkg_lc = tpf.to_lightcurve(aperture_mask=bkg_mask)
-        lc = tpf.to_lightcurve(aperture_mask=tpf.hdu['APERTURE'].data)
+        lc = tpf.to_lightcurve(aperture_mask=tpf.hdu["APERTURE"].data)
         lc = tpf.to_lightcurve(aperture_mask=None)
         lc = tpf.to_lightcurve(aperture_mask=thresh_mask)
-        lc_out = lc - bkg_lc.flux * (thresh_mask.sum()/bkg_mask.sum())
-        lc_out.to_fits(aperture_mask=thresh_mask, path=tempfile.NamedTemporaryFile().name,
-                       overwrite=True, extra_data={'BKG': bkg_lc.flux})
+        lc_out = lc - bkg_lc.flux * (thresh_mask.sum() / bkg_mask.sum())
+        lc_out.to_fits(
+            aperture_mask=thresh_mask,
+            path=tempfile.NamedTemporaryFile().name,
+            overwrite=True,
+            extra_data={"BKG": bkg_lc.flux},
+        )
 
 
 def test_astropy_time_bkjd():
     """Does `KeplerLightCurve` support bkjd?"""
     bkjd = np.array([100, 200])
     lc = KeplerLightCurve(time=[100, 200])
-    assert_allclose(lc.time.jd, bkjd + 2454833.)
+    assert_allclose(lc.time.jd, bkjd + 2454833.0)
 
 
 def test_lightcurve_repr():
@@ -699,22 +769,30 @@ def test_slicing():
     centroid_row = np.linspace(50, 60, 10)
     quality = np.linspace(70, 80, 10)
     cadenceno = np.linspace(90, 100, 10)
-    lc = KeplerLightCurve(time=time, flux=flux, flux_err=flux_err,
-                          centroid_col=centroid_col,
-                          centroid_row=centroid_row,
-                          cadenceno=cadenceno,
-                          quality=quality)
+    lc = KeplerLightCurve(
+        time=time,
+        flux=flux,
+        flux_err=flux_err,
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        cadenceno=cadenceno,
+        quality=quality,
+    )
     assert_array_equal(lc[::3].centroid_col, centroid_col[::3])
     assert_array_equal(lc[4:].centroid_row, centroid_row[4:])
     assert_array_equal(lc[10:2].quality, quality[10:2])
     assert_array_equal(lc[3:6].cadenceno, cadenceno[3:6])
 
     # The same is true for TessLightCurve
-    lc = TessLightCurve(time=time, flux=flux, flux_err=flux_err,
-                        centroid_col=centroid_col,
-                        centroid_row=centroid_row,
-                        cadenceno=cadenceno,
-                        quality=quality)
+    lc = TessLightCurve(
+        time=time,
+        flux=flux,
+        flux_err=flux_err,
+        centroid_col=centroid_col,
+        centroid_row=centroid_row,
+        cadenceno=cadenceno,
+        quality=quality,
+    )
     assert_array_equal(lc[::4].centroid_col, centroid_col[::4])
     assert_array_equal(lc[5:].centroid_row, centroid_row[5:])
     assert_array_equal(lc[10:3].quality, quality[10:3])
@@ -722,8 +800,9 @@ def test_slicing():
 
 
 def test_boolean_masking():
-    lc = KeplerLightCurve(time=[1, 2, 3], flux=[1, 1, 10],
-                          quality=[0, 0, 200], cadenceno=[5, 6, 7])
+    lc = KeplerLightCurve(
+        time=[1, 2, 3], flux=[1, 1, 10], quality=[0, 0, 200], cadenceno=[5, 6, 7]
+    )
     assert_array_equal(lc[lc.flux < 5].time.value, [1, 2])
     assert_array_equal(lc[lc.flux < 5].flux, [1, 1])
     assert_array_equal(lc[lc.flux < 5].quality, [0, 0])
@@ -737,7 +816,7 @@ def test_remove_nans():
     lc_clean = lc.remove_nans()
     assert_array_equal(lc_clean.time.value, [1, 3])
     assert_array_equal(lc_clean.flux, [100, 102])
-    lc_clean = lc.remove_nans('flux_err')
+    lc_clean = lc.remove_nans("flux_err")
     assert_array_equal(lc_clean.flux, [])
 
 
@@ -749,19 +828,19 @@ def test_remove_outliers():
     assert_array_equal(lc_clean.flux, [1, 1, 1])
     # It should also be possible to return the outlier mask
     lc_clean, outlier_mask = lc.remove_outliers(sigma=1, return_mask=True)
-    assert(len(outlier_mask) == len(lc.flux))
-    assert(outlier_mask.sum() == 1)
+    assert len(outlier_mask) == len(lc.flux)
+    assert outlier_mask.sum() == 1
     # Can we set sigma_lower and sigma_upper?
     lc = LightCurve(time=[1, 2, 3, 4, 5], flux=[1, 1000, 1, -1000, 1])
-    lc_clean = lc.remove_outliers(sigma_lower=float('inf'), sigma_upper=1)
+    lc_clean = lc.remove_outliers(sigma_lower=float("inf"), sigma_upper=1)
     assert_array_equal(lc_clean.time.value, [1, 3, 4, 5])
     assert_array_equal(lc_clean.flux, [1, 1, -1000, 1])
 
 
 @pytest.mark.remote_data
 def test_properties(capfd):
-    '''Test if the describe function produces an output.
-    The output is 624 characters at the moment, but we might add more properties.'''
+    """Test if the describe function produces an output.
+    The output is 624 characters at the moment, but we might add more properties."""
     kplc = KeplerLightCurve.read(TABBY_Q8, flux_column="sap_flux")
     kplc.show_properties()
     out, _ = capfd.readouterr()
@@ -770,20 +849,22 @@ def test_properties(capfd):
 
 def test_flatten_with_nans():
     """Flatten should not remove NaNs."""
-    lc = LightCurve(time=[1, 2, 3, 4, 5],
-                    flux=[np.nan, 1.1, 1.2, np.nan, 1.4],
-                    flux_err=[1.0, np.nan, 1.2, 1.3, np.nan])
+    lc = LightCurve(
+        time=[1, 2, 3, 4, 5],
+        flux=[np.nan, 1.1, 1.2, np.nan, 1.4],
+        flux_err=[1.0, np.nan, 1.2, 1.3, np.nan],
+    )
     flat_lc = lc.flatten(window_length=3)
-    assert(len(flat_lc.time) == 5)
-    assert(np.isfinite(flat_lc.flux).sum() == 3)
-    assert(np.isfinite(flat_lc.flux_err).sum() == 3)
+    assert len(flat_lc.time) == 5
+    assert np.isfinite(flat_lc.flux).sum() == 3
+    assert np.isfinite(flat_lc.flux_err).sum() == 3
 
 
 def test_flatten_robustness():
     """Test various special cases for flatten()."""
     # flatten should work with integer fluxes
     lc = LightCurve(time=[1, 2, 3, 4, 5, 6], flux=[10, 20, 30, 40, 50, 60])
-    expected_result = np.array([1.,  1.,  1.,  1.,  1., 1.])
+    expected_result = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
     flat_lc = lc.flatten(window_length=3, polyorder=1)
     assert_allclose(flat_lc.flux, expected_result)
     # flatten should work even if `window_length > len(flux)`
@@ -806,28 +887,29 @@ def test_flatten_returns_normalized():
     """Ensure returned lightcurves from flatten() can be normalized"""
     # Test for https://github.com/lightkurve/lightkurve/issues/838
     lc_flux_unit = u.Unit("electron/second")
-    lc = LightCurve(time=[1, 2, 3, 4, 5, 6],
-                    flux=[10.1, 20.2, 30.3, 40.4, 50.5, 60.6] * lc_flux_unit,
-                    flux_err=[0.01, 0.02, 0.03, 0.04, 0.05, 0.06] * lc_flux_unit
-                    )
+    lc = LightCurve(
+        time=[1, 2, 3, 4, 5, 6],
+        flux=[10.1, 20.2, 30.3, 40.4, 50.5, 60.6] * lc_flux_unit,
+        flux_err=[0.01, 0.02, 0.03, 0.04, 0.05, 0.06] * lc_flux_unit,
+    )
     flat_lc, trend_lc = lc.flatten(window_length=3, polyorder=1, return_trend=True)
 
-    assert(flat_lc.flux.unit is lc_flux_unit)
-    assert(flat_lc.flux_err.unit is lc_flux_unit)
-    assert(trend_lc.flux.unit is lc_flux_unit)
-    assert(trend_lc.flux_err.unit is lc_flux_unit)
+    assert flat_lc.flux.unit is lc_flux_unit
+    assert flat_lc.flux_err.unit is lc_flux_unit
+    assert trend_lc.flux.unit is lc_flux_unit
+    assert trend_lc.flux_err.unit is lc_flux_unit
 
     # once the above assertions pass, the normalize() should work
     # but we test it anyway just in case something else goes wrong
-    flat_lc.normalize(unit='percent')
-    trend_lc.normalize(unit='percent')
+    flat_lc.normalize(unit="percent")
+    trend_lc.normalize(unit="percent")
 
 
 def test_iterative_flatten():
-    '''Test the iterative sigma clipping in flatten '''
+    """Test the iterative sigma clipping in flatten """
     # Test a light curve with a single, buried outlier.
     x = np.arange(2000)
-    y = np.sin(x/200)/100 + 1
+    y = np.sin(x / 200) / 100 + 1
     y[250] -= 0.01
     lc = LightCurve(time=x, flux=y)
     # Flatten it
@@ -837,33 +919,36 @@ def test_iterative_flatten():
     mask = np.zeros(2000, dtype=bool)
     mask[250] = True
     # Flatten it using a mask to remove the bad data point.
-    c, f = lc.flatten(window_length=25, niters=1, sigma=3, mask=mask,
-                      return_trend=True)
+    c, f = lc.flatten(window_length=25, niters=1, sigma=3, mask=mask, return_trend=True)
     # Only one outlier should remain.
     assert np.isclose(c.flux, 1, rtol=0.00001).sum() == 1999
 
 
 def test_fill_gaps():
-    lc = LightCurve(time=[1,2,3,4,6,7,8], flux=[1,1,1,1,1,1,1])
+    lc = LightCurve(time=[1, 2, 3, 4, 6, 7, 8], flux=[1, 1, 1, 1, 1, 1, 1])
     nlc = lc.fill_gaps()
-    assert(len(lc.time) < len(nlc.time))
-    assert(np.any(nlc.time.value == 5))
-    assert(np.all(nlc.flux == 1))
+    assert len(lc.time) < len(nlc.time)
+    assert np.any(nlc.time.value == 5)
+    assert np.all(nlc.flux == 1)
 
-    lc = LightCurve(time=[1,2,3,4,6,7,8], flux=[1,1,np.nan,1,1,1,1])
+    lc = LightCurve(time=[1, 2, 3, 4, 6, 7, 8], flux=[1, 1, np.nan, 1, 1, 1, 1])
     nlc = lc.fill_gaps()
-    assert(len(lc.time) < len(nlc.time))
-    assert(np.any(nlc.time.value == 5))
-    assert(np.all(nlc.flux == 1))
-    assert(np.all(np.isfinite(nlc.flux)))
+    assert len(lc.time) < len(nlc.time)
+    assert np.any(nlc.time.value == 5)
+    assert np.all(nlc.flux == 1)
+    assert np.all(np.isfinite(nlc.flux))
 
     # Because fill_gaps() uses pandas, check that it works regardless of endianness
     # For details see https://github.com/lightkurve/lightkurve/issues/188
-    lc = LightCurve(time=np.array([1, 2, 3, 4, 6, 7, 8], dtype='>f8'),
-                    flux=np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype='>f8'))
+    lc = LightCurve(
+        time=np.array([1, 2, 3, 4, 6, 7, 8], dtype=">f8"),
+        flux=np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype=">f8"),
+    )
     lc.fill_gaps()
-    lc = LightCurve(time=np.array([1, 2, 3, 4, 6, 7, 8], dtype='<f8'),
-                    flux=np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype='<f8'))
+    lc = LightCurve(
+        time=np.array([1, 2, 3, 4, 6, 7, 8], dtype="<f8"),
+        flux=np.array([1, 1, 1, np.nan, np.nan, 1, 1], dtype="<f8"),
+    )
     lc.fill_gaps()
 
 
@@ -891,7 +976,10 @@ def test_regression_346():
     with warnings.catch_warnings():  # KeplerLightCurveFile is deprecated
         warnings.simplefilter("ignore", LightkurveDeprecationWarning)
         from lightkurve import KeplerLightCurveFile
-        KeplerLightCurveFile(K2_C08).PDCSAP_FLUX.remove_nans().to_corrector().correct().estimate_cdpp()
+
+        KeplerLightCurveFile(
+            K2_C08
+        ).PDCSAP_FLUX.remove_nans().to_corrector().correct().estimate_cdpp()
 
 
 def test_flux_unit():
@@ -907,12 +995,12 @@ def test_flux_unit():
         lc = LightCurve(time=time, flux=flux, flux_unit="electron/second")
         assert lc.flux.unit == unit_obj
         # Can we pass a quantity to flux?
-        lc = LightCurve(time=time, flux=flux*unit_obj)
+        lc = LightCurve(time=time, flux=flux * unit_obj)
         assert lc.flux.unit == unit_obj
         # Can we retrieve correct flux quantities?
         with warnings.catch_warnings():  # flux_quantity is deprecated
             warnings.simplefilter("ignore", LightkurveDeprecationWarning)
-            assert lc.flux_quantity.unit ==unit_obj
+            assert lc.flux_quantity.unit == unit_obj
             assert_array_equal(lc.flux_quantity.value, flux)
         # Is invalid user input validated?
         with pytest.raises(ValueError) as err:
@@ -923,26 +1011,26 @@ def test_flux_unit():
 def test_astropy_time_initialization():
     """Does the `LightCurve` constructor accept Astropy time objects?"""
     time = [1, 2, 3]
-    lc = LightCurve(time=Time(2.454e6+np.array(time), format='jd', scale='utc'))
-    assert lc.time.format == 'jd'
-    assert lc.time.scale == 'utc'
+    lc = LightCurve(time=Time(2.454e6 + np.array(time), format="jd", scale="utc"))
+    assert lc.time.format == "jd"
+    assert lc.time.scale == "utc"
     with warnings.catch_warnings():  # we deprecated `astropy_time` in v2.0
         warnings.simplefilter("ignore", LightkurveDeprecationWarning)
-        assert lc.astropy_time.format == 'jd'
-        assert lc.astropy_time.scale == 'utc'
-    lc = LightCurve(time=time, time_format='bkjd', time_scale='tdb')
-    assert lc.time.format == 'bkjd'
-    assert lc.time.scale == 'tdb'
+        assert lc.astropy_time.format == "jd"
+        assert lc.astropy_time.scale == "utc"
+    lc = LightCurve(time=time, time_format="bkjd", time_scale="tdb")
+    assert lc.time.format == "bkjd"
+    assert lc.time.scale == "tdb"
     with warnings.catch_warnings():  # we deprecated `astropy_time` in v2.0
         warnings.simplefilter("ignore", LightkurveDeprecationWarning)
-        assert lc.astropy_time.format == 'bkjd'
-        assert lc.astropy_time.scale == 'tdb'
+        assert lc.astropy_time.format == "bkjd"
+        assert lc.astropy_time.scale == "tdb"
 
 
 def test_normalize_unit():
     """Can the units of a normalized light curve be set?"""
     lc = LightCurve(flux=[1, 2, 3])
-    for unit in ['percent', 'ppt', 'ppm']:
+    for unit in ["percent", "ppt", "ppm"]:
         assert lc.normalize(unit=unit).flux.unit.name == unit
 
 
@@ -969,6 +1057,7 @@ def test_from_stingray():
     """Test the `LightCurve.from_stingray()` method."""
     try:
         from stingray import sampledata
+
         sr = sampledata.sample_data()
         lc = LightCurve.from_stingray(sr)
         assert_allclose(sr.time, lc.time)
@@ -979,9 +1068,11 @@ def test_from_stingray():
 
 
 def test_river():
-    lc = LightCurve(time=np.arange(100),
-                    flux=np.random.normal(1, 0.01, 100),
-                    flux_err=np.random.normal(0, 0.01, 100))
+    lc = LightCurve(
+        time=np.arange(100),
+        flux=np.random.normal(1, 0.01, 100),
+        flux_err=np.random.normal(0, 0.01, 100),
+    )
     lc.plot_river(10, 1)
     plt.close()
     folded_lc = lc.fold(10, 1)
@@ -989,12 +1080,12 @@ def test_river():
     plt.close()
     folded_lc.plot_river(minimum_phase=-0.1, maximum_phase=0.2)
     plt.close()
-    folded_lc.plot_river(method='median', bin_points=5)
+    folded_lc.plot_river(method="median", bin_points=5)
     plt.close()
-    folded_lc.plot_river(method='sigma', bin_points=5)
+    folded_lc.plot_river(method="sigma", bin_points=5)
     plt.close()
-    with pytest.warns(LightkurveWarning, match='`bin_points` is too high to plot'):
-        folded_lc.plot_river(method='median', bin_points=6)
+    with pytest.warns(LightkurveWarning, match="`bin_points` is too high to plot"):
+        folded_lc.plot_river(method="median", bin_points=6)
         plt.close()
 
 
@@ -1011,20 +1102,24 @@ def test_bin_issue705():
 @pytest.mark.remote_data
 def test_SSOs():
     # TESS test
-    lc = TessTargetPixelFile(asteroid_TPF).to_lightcurve(aperture_mask='all')
-    lc.meta['MISSION'] = 'TESS' # needed to resolve default value for location argument
-    result = lc.query_solar_system_objects(cadence_mask='all', cache=False)
-    assert(len(result) == 1)
+    lc = TessTargetPixelFile(asteroid_TPF).to_lightcurve(aperture_mask="all")
+    lc.meta["MISSION"] = "TESS"  # needed to resolve default value for location argument
+    result = lc.query_solar_system_objects(cadence_mask="all", cache=False)
+    assert len(result) == 1
     result = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
-    assert(len(result) == 1)
+    assert len(result) == 1
     result = lc.query_solar_system_objects(cadence_mask=[True], cache=False)
-    assert(len(result) == 1)
+    assert len(result) == 1
     result = lc.query_solar_system_objects(cadence_mask=(True), cache=False)
-    assert(len(result) == 1)
-    result, mask = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
-    assert(len(mask) == len(lc.flux))
+    assert len(result) == 1
+    result, mask = lc.query_solar_system_objects(
+        cadence_mask=np.asarray([True]), cache=True, return_mask=True
+    )
+    assert len(mask) == len(lc.flux)
     try:
-        result = lc.query_solar_system_objects(cadence_mask='str-not-supported', cache=False)
+        result = lc.query_solar_system_objects(
+            cadence_mask="str-not-supported", cache=False
+        )
         pytest.fail("Unsupported cadence_mask should have thrown Error")
     except ValueError:
         pass
@@ -1034,21 +1129,21 @@ def test_SSOs():
 def test_get_header():
     """Test the basic functionality of ``tpf.get_header()``"""
     lcf = TessLightCurveFile(filename_tess_custom)
-    assert lcf.get_header()['CREATOR'] == lcf.get_keyword("CREATOR")
-    assert lcf.get_header(ext=2)['EXTNAME'] == "APERTURE"
+    assert lcf.get_header()["CREATOR"] == lcf.get_keyword("CREATOR")
+    assert lcf.get_header(ext=2)["EXTNAME"] == "APERTURE"
     # ``tpf.header`` is deprecated
-    with pytest.warns(LightkurveWarning, match='deprecated'):
+    with pytest.warns(LightkurveWarning, match="deprecated"):
         lcf.header()
 
 
 def test_fold_v2():
     """The API of LightCurve.fold() changed in Lightkurve v2.x when we adopted
     AstroPy's TimeSeries.fold() method. This test verifies the new API."""
-    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100)+1)
+    lc = LightCurve(time=np.linspace(0, 10, 100), flux=np.zeros(100) + 1)
 
     # Can period be passed as a float?
     fld = lc.fold(period=1)
-    fld2 = lc.fold(period=1*u.day)
+    fld2 = lc.fold(period=1 * u.day)
     assert_array_equal(fld.phase, fld2.phase)
     assert isinstance(fld.time, TimeDelta)
     fld.plot_river()
@@ -1064,188 +1159,215 @@ def test_fold_v2():
 @pytest.mark.remote_data
 def test_combine_kepler_tess():
     """Can we append or stitch a TESS light curve to a Kepler light curve?"""
-    lc_kplr = search_lightcurve("Kepler-10", mission='Kepler', author="Kepler")[0].download()
-    lc_tess = search_lightcurve("Kepler-10", mission='TESS', author="SPOC")[0].download()
+    lc_kplr = search_lightcurve("Kepler-10", mission="Kepler", author="Kepler")[
+        0
+    ].download()
+    lc_tess = search_lightcurve("Kepler-10", mission="TESS", author="SPOC")[
+        0
+    ].download()
     # Can we use append()?
     lc = lc_kplr.append(lc_tess)
-    assert(len(lc) == len(lc_kplr)+len(lc_tess))
+    assert len(lc) == len(lc_kplr) + len(lc_tess)
     # Can we use stitch()?
     coll = LightCurveCollection((lc_kplr, lc_tess))
     lc = coll.stitch()
-    assert(len(lc) == len(lc_kplr)+len(lc_tess))
+    assert len(lc) == len(lc_kplr) + len(lc_tess)
 
 
 def test_mixed_instantiation():
     """Can a LightCurve be instantianted using a mix of keywords and colums?"""
-    LightCurve(flux=[4,5,6], flux_err=[7,8,9], data={'time': [1,2,3]})
-    LightCurve(flux=[4,5,6], flux_err=[7,8,9], data=Table({'time': [1,2,3]}))
+    LightCurve(flux=[4, 5, 6], flux_err=[7, 8, 9], data={"time": [1, 2, 3]})
+    LightCurve(flux=[4, 5, 6], flux_err=[7, 8, 9], data=Table({"time": [1, 2, 3]}))
 
-    LightCurve(time=[1,2,3], flux_err=[7,8,9], data={'flux': [4,5,6]})
-    LightCurve(time=[1,2,3], flux_err=[7,8,9], data=Table({'flux': [4,5,6]}))
+    LightCurve(time=[1, 2, 3], flux_err=[7, 8, 9], data={"flux": [4, 5, 6]})
+    LightCurve(time=[1, 2, 3], flux_err=[7, 8, 9], data=Table({"flux": [4, 5, 6]}))
 
-    LightCurve(data=Table({'time': [1,2,3]}), flux=[4,5,6])
-    LightCurve(data={'time': [1,2,3]}, flux=[4,5,6])
+    LightCurve(data=Table({"time": [1, 2, 3]}), flux=[4, 5, 6])
+    LightCurve(data={"time": [1, 2, 3]}, flux=[4, 5, 6])
 
-    LightCurve(time=[1,2,3], flux=[1,2,3], data=Table({'flux_err': [3,4,5]}))
-    LightCurve(time=[1,2,3], flux=[1,2,3], data={'flux_err': [3,4,5]})
+    LightCurve(time=[1, 2, 3], flux=[1, 2, 3], data=Table({"flux_err": [3, 4, 5]}))
+    LightCurve(time=[1, 2, 3], flux=[1, 2, 3], data={"flux_err": [3, 4, 5]})
 
 
 def test_assignment_time():
     """Ensure time property can be reassigned"""
-    lc = KeplerLightCurve(time=Time([1,2,3], scale='tdb', format='bkjd'), flux=[4,5,6], flux_err=[7,8,9])
+    lc = KeplerLightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="bkjd"),
+        flux=[4, 5, 6],
+        flux_err=[7, 8, 9],
+    )
     time_adjusted = lc.time - 0.5
     lc.time = time_adjusted
     assert_array_equal(lc.time, time_adjusted)
 
     # case the input is not given format / scale, ensure default format / scale is applied
-    time_adjusted_raw = [11., 12., 13.]
+    time_adjusted_raw = [11.0, 12.0, 13.0]
     lc.time = time_adjusted_raw
-    assert_array_equal(lc.time, Time(time_adjusted_raw, scale='tdb', format='bkjd'))
+    assert_array_equal(lc.time, Time(time_adjusted_raw, scale="tdb", format="bkjd"))
 
     # case the input is scalar, it'd be broadcasted to the existing time's length
     lc.time = 21
-    assert_array_equal(lc.time, Time([21, 21, 21], scale='tdb', format='bkjd'))
+    assert_array_equal(lc.time, Time([21, 21, 21], scale="tdb", format="bkjd"))
 
 
 def test_attr_access_columns():
     """Test accessing columns as attributes"""
 
     u_e_s = u.electron / u.second
-    lc = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
+    lc = LightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="jd"), flux=[4, 5, 6] * u_e_s
+    )
 
     # Read/Write access of flux: explicitly defined as property
-    assert_array_equal(lc.flux, lc['flux'])
+    assert_array_equal(lc.flux, lc["flux"])
     flux_updated = [7, 8, 9] * u_e_s
     lc.flux = flux_updated
     assert_array_equal(lc.flux, flux_updated)
 
     # Read/Write access of cadenceno: not an explicit property, but present in most LightCurve objects in practice.
     cadenceno_unitless = [101, 102, 103]
-    lc['cadenceno'] = cadenceno_unitless
-    assert_array_equal(lc['cadenceno'], cadenceno_unitless)
-    assert(lc.cadenceno is lc['cadenceno'])
+    lc["cadenceno"] = cadenceno_unitless
+    assert_array_equal(lc["cadenceno"], cadenceno_unitless)
+    assert lc.cadenceno is lc["cadenceno"]
 
     # Read/Write access of new column
     flux_adjusted = [7.1, 8.1, 9.1] * u_e_s
-    lc['flux_adjusted'] = flux_adjusted
-    assert_array_equal(lc['flux_adjusted'], flux_adjusted)
-    assert(lc.flux_adjusted is lc['flux_adjusted'])
+    lc["flux_adjusted"] = flux_adjusted
+    assert_array_equal(lc["flux_adjusted"], flux_adjusted)
+    assert lc.flux_adjusted is lc["flux_adjusted"]
 
     # column name is an existing method / attribute: attribute access not available
     info_col = [9, 8, 7] * u_e_s
-    lc['info'] = info_col  # .info is a built-in attribute (from base TimeSeries)
-    assert(type(lc.info) is not type(info_col))
+    lc["info"] = info_col  # .info is a built-in attribute (from base TimeSeries)
+    assert type(lc.info) is not type(info_col)
 
-    bin_col = [5, 6, 7 ] * u_e_s
-    lc['bin'] = bin_col  # .bin is a built-in method
-    assert(type(lc.bin) is not type(bin_col))
+    bin_col = [5, 6, 7] * u_e_s
+    lc["bin"] = bin_col  # .bin is a built-in method
+    assert type(lc.bin) is not type(bin_col)
 
     # Create a new column directly as an attribute: only attribute is created, not a column
     flux2_unitless = [6, 7, 8]
     with pytest.warns(UserWarning, match="new attribute name"):
         lc.flux2 = flux2_unitless
     with pytest.raises(KeyError):
-        lc['flux2']
+        lc["flux2"]
     assert_array_equal(lc.flux2, flux2_unitless)
-    assert(type(lc.flux2) is list)  # as it's just an attribute, there is no conversion done to Quantity
+    assert (
+        type(lc.flux2) is list
+    )  # as it's just an attribute, there is no conversion done to Quantity
 
     # ensure no warning is raised when updating an existing attribute
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        lc.foo = 'bar'
+        lc.foo = "bar"
     with pytest.warns(None) as warn_record:
-        lc.foo = 'bar2'
+        lc.foo = "bar2"
     assert len(warn_record) == 0
+
 
 u_e_s = u.electron / u.second
 
 
-@pytest.mark.parametrize("new_col_val", [([2, 3, 4] * u_e_s),   # Quantity
-                                         (np.array([2, 3, 4])), # ndarray
-                                         ([2, 3, 4])            # list
-                                         ])
+@pytest.mark.parametrize(
+    "new_col_val",
+    [
+        ([2, 3, 4] * u_e_s),  # Quantity
+        (np.array([2, 3, 4])),  # ndarray
+        ([2, 3, 4]),  # list
+    ],
+)
 def test_attr_access_columns_consistent_update(new_col_val):
     """Replace/Update a column: ensure consistent behavior across column API and attribute API"""
 
-    lc1 = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
-    lc1['flux'] = new_col_val
+    lc1 = LightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="jd"), flux=[4, 5, 6] * u_e_s
+    )
+    lc1["flux"] = new_col_val
 
-    lc2 = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
+    lc2 = LightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="jd"), flux=[4, 5, 6] * u_e_s
+    )
     lc2.flux = new_col_val
 
     # ensure the result type is the same,
     # irrespective whether the update is done via column API or attribute API
-    assert(type(lc1['flux']) is type(lc2['flux']))
+    assert type(lc1["flux"]) is type(lc2["flux"])
 
 
 def test_attr_access_meta():
     """Test accessing meta values as attributes"""
     u_e_s = u.electron / u.second
-    lc = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
+    lc = LightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="jd"), flux=[4, 5, 6] * u_e_s
+    )
 
     # Read/Write access of meta via attribute
-    lc.meta['SECTOR'] = 14
-    assert(lc.sector == 14)  # uppercased meta key is accessed as lowercased attributes
+    lc.meta["SECTOR"] = 14
+    assert lc.sector == 14  # uppercased meta key is accessed as lowercased attributes
 
     sector_corrected = 15
     lc.sector = sector_corrected
-    assert(lc.sector == sector_corrected)
-    assert(lc.sector == lc.meta['SECTOR'])
+    assert lc.sector == sector_corrected
+    assert lc.sector == lc.meta["SECTOR"]
 
     # meta key is an existing attribute / method: : attribute access not available
-    lc.meta['INFO'] = 'Some information'  # .info: an existing attribute
-    assert(lc.info != lc.meta['INFO'])
+    lc.meta["INFO"] = "Some information"  # .info: an existing attribute
+    assert lc.info != lc.meta["INFO"]
 
-    lc.meta['BIN'] = 'Some value'  # .bin: an existing method
-    assert(lc.bin != lc.meta['BIN'])
+    lc.meta["BIN"] = "Some value"  # .bin: an existing method
+    assert lc.bin != lc.meta["BIN"]
 
     # Create a attribute: it is created as a object attribute, rather than meta
-    attr_value = 'bar_value'
+    attr_value = "bar_value"
     with pytest.warns(UserWarning, match="new attribute name"):
         lc.foo = attr_value
-    assert(lc.meta.get('foo', None) is None)
-    assert(lc.foo == attr_value)
+    assert lc.meta.get("foo", None) is None
+    assert lc.foo == attr_value
 
     # Case meta has 2 keys that only differs in case
-    lc.meta['KEYCASE'] = 'VALUE UPPER'
-    lc.meta['keycase'] = 'value lower'
+    lc.meta["KEYCASE"] = "VALUE UPPER"
+    lc.meta["keycase"] = "value lower"
     # they are two different entries (case sensitive)
-    assert(lc.meta['KEYCASE'] == 'VALUE UPPER')
-    assert(lc.meta['keycase'] == 'value lower')
-    assert(lc.keycase == 'value lower')  # the meta entry with exact case is retrieved
+    assert lc.meta["KEYCASE"] == "VALUE UPPER"
+    assert lc.meta["keycase"] == "value lower"
+    assert lc.keycase == "value lower"  # the meta entry with exact case is retrieved
 
 
 def test_attr_access_others():
     """Test accessing attributes, misc. boundary cases"""
     u_e_s = u.electron / u.second
-    lc = LightCurve(time=Time([1, 2, 3], scale='tdb', format='jd'), flux=[4, 5, 6] * u_e_s)
+    lc = LightCurve(
+        time=Time([1, 2, 3], scale="tdb", format="jd"), flux=[4, 5, 6] * u_e_s
+    )
 
     # case the name is present both as a column name and a meta key: column is returned
     val_of_col = [5, 6, 7]
-    val_of_meta_key = 'value'
-    lc['foo'] = val_of_col
-    lc.meta['FOO'] = val_of_meta_key
-    assert_array_equal(lc.foo, val_of_col) # lc.foo refers to the column
+    val_of_meta_key = "value"
+    lc["foo"] = val_of_col
+    lc.meta["FOO"] = val_of_meta_key
+    assert_array_equal(lc.foo, val_of_col)  # lc.foo refers to the column
 
     val_of_col_updated = [6, 7, 8] * u_e_s
     lc.foo = val_of_col_updated  # should update the column rather than meta
     assert_array_equal(lc.foo, val_of_col_updated)
 
     # case the same name is present as column name, meta key, and actual attribute
-    lc.bar = 'bar_attr_val'
-    lc['bar'] = [7, 8, 9]
-    lc.meta['BAR'] = 'bar_meta_val'
-    assert(lc.bar == 'bar_attr_val') # actual attribute takes priority
+    lc.bar = "bar_attr_val"
+    lc["bar"] = [7, 8, 9]
+    lc.meta["BAR"] = "bar_meta_val"
+    assert lc.bar == "bar_attr_val"  # actual attribute takes priority
 
-    lc.bar = 'bar_attr_val_updated'
-    assert(lc.bar == 'bar_attr_val_updated') # the update should be done on actual attribute
+    lc.bar = "bar_attr_val_updated"
+    assert (
+        lc.bar == "bar_attr_val_updated"
+    )  # the update should be done on actual attribute
 
 
 def test_create_transit_mask():
     """Test for `LightCurve.create_transit_mask()`."""
     # Set planet parameters
     period = 2.0
-    transit_time = Time(2450000., format='jd')
+    transit_time = Time(2450000.0, format="jd")
     duration = 0.1
     depth = 0.2
     flux_err = 0.01
@@ -1253,42 +1375,51 @@ def test_create_transit_mask():
     # Create the synthetic light curve
     time = np.arange(0, 100, 0.1)
     flux = np.ones_like(time)
-    transit_mask = np.abs((time-transit_time.value+0.5*period) % period-0.5*period) < 0.5*duration
+    transit_mask = (
+        np.abs((time - transit_time.value + 0.5 * period) % period - 0.5 * period)
+        < 0.5 * duration
+    )
     flux[transit_mask] = 1.0 - depth
     flux += flux_err * np.random.randn(len(time))
     synthetic_lc = LightCurve(time=time, flux=flux)
 
     # Create planet mask
-    mask = synthetic_lc.create_transit_mask(period=period, duration=duration,
-                                            transit_time=transit_time)
+    mask = synthetic_lc.create_transit_mask(
+        period=period, duration=duration, transit_time=transit_time
+    )
 
     # Are all masked values out of transit?
-    assert(all(f > 0.9 for f in synthetic_lc[~mask].flux.value))
+    assert all(f > 0.9 for f in synthetic_lc[~mask].flux.value)
     # Are all unmasked values in transit?
-    assert(all(f < 0.9 for f in synthetic_lc[mask].flux.value))
+    assert all(f < 0.9 for f in synthetic_lc[mask].flux.value)
 
     # Can it handle multi-planet masks?
     period_2 = 3.0
     transit_time_2 = 0.75
     duration_2 = 0.1
-    transit_mask_2 = np.abs((time-transit_time_2+0.5*period_2) % period_2-0.5*period_2) < 0.5*duration_2
+    transit_mask_2 = (
+        np.abs((time - transit_time_2 + 0.5 * period_2) % period_2 - 0.5 * period_2)
+        < 0.5 * duration_2
+    )
     flux[transit_mask_2] = 1.0 - depth
     synthetic_lc = LightCurve(time=time, flux=flux)
 
     # Create multi-planet planet mask
-    mask = synthetic_lc.create_transit_mask(period=[period, period_2],
-                                            duration=[duration, duration_2],
-                                            transit_time=[transit_time, transit_time_2])
+    mask = synthetic_lc.create_transit_mask(
+        period=[period, period_2],
+        duration=[duration, duration_2],
+        transit_time=[transit_time, transit_time_2],
+    )
 
     # Are all masked values out of transit?
-    assert(all(f > 0.9 for f in synthetic_lc[~mask].flux.value))
+    assert all(f > 0.9 for f in synthetic_lc[~mask].flux.value)
     # Are all unmasked values in transit?
-    assert(all(f < 0.9 for f in synthetic_lc[mask].flux.value))
+    assert all(f < 0.9 for f in synthetic_lc[mask].flux.value)
 
 
 def test_row_repr():
     """Regression test for #830: ensure the repr works for a single row."""
-    lc = LightCurve({'time': [1,2,3], 'flux':[1.,1.,1.]})
+    lc = LightCurve({"time": [1, 2, 3], "flux": [1.0, 1.0, 1.0]})
     lc[0].__repr__()
     lc[0]._repr_html_()
 
@@ -1296,64 +1427,69 @@ def test_row_repr():
 def test_fill_gaps_with_cadenceno():
     """Does `fill_gaps` work when a ``cadenceno`` column is present?
     This is a regression test for #868."""
-    lc = LightCurve({'time': [1, 2, 4, 5],
-                     'flux': [1, 1, 1, 1],
-                     'cadenceno': [11, 12, 14, 15]})
+    lc = LightCurve(
+        {"time": [1, 2, 4, 5], "flux": [1, 1, 1, 1], "cadenceno": [11, 12, 14, 15]}
+    )
     lc.fill_gaps()  # raised a `UnitConversionError` in the past, cf. #868
 
 
 def test_fill_gaps_after_normalization():
     """Does `fill_gaps` work correctly after normalization?
     This is a regression test for #868."""
-    lc = LightCurve({'time': [1, 2, 4, 5],
-                     'flux': [1, 1, 1, 1],
-                     'flux_err':[0.1, 0.1, 0.1, 0.1]})
+    lc = LightCurve(
+        {"time": [1, 2, 4, 5], "flux": [1, 1, 1, 1], "flux_err": [0.1, 0.1, 0.1, 0.1]}
+    )
     lc = lc.normalize("ppm")
     lc2 = lc.fill_gaps()
-    assert lc2.time[2].value == 3.
+    assert lc2.time[2].value == 3.0
     assert lc2.flux[2].value == 1e6
     assert lc2.flux[2].unit == u.cds.ppm
     assert lc2.flux_err[2] == 0.1
 
 
-@pytest.mark.parametrize("new_col_val", [([2, 3, 4] * u_e_s),   # Quantity
-                                         (np.array([2, 3, 4])), # ndarray
-                                         ([2, 3, 4]),           # list
-                                         Column([2, 3, 4]),     # Column
-                                         MaskedColumn([2, -1, 4], mask=[False, True, False], fill_value=-999)
-                                         ])
+@pytest.mark.parametrize(
+    "new_col_val",
+    [
+        ([2, 3, 4] * u_e_s),  # Quantity
+        (np.array([2, 3, 4])),  # ndarray
+        ([2, 3, 4]),  # list
+        Column([2, 3, 4]),  # Column
+        MaskedColumn([2, -1, 4], mask=[False, True, False], fill_value=-999),
+    ],
+)
 def test_columns_have_value_accessor(new_col_val):
     """Ensure resulting column has  ``.value`` accessor to raw data, irrespective of type of input.
 
-       The test won't be needed once https://github.com/astropy/astropy/pull/10962 is in astropy release
-       and Lightkurve requires the correspond astropy release.
+    The test won't be needed once https://github.com/astropy/astropy/pull/10962 is in astropy release
+    and Lightkurve requires the correspond astropy release.
     """
     expected_raw_value = new_col_val
-    if hasattr(new_col_val, 'value'):
+    if hasattr(new_col_val, "value"):
         expected_raw_value = new_col_val.value
-    elif hasattr(new_col_val, 'data'):
+    elif hasattr(new_col_val, "data"):
         expected_raw_value = new_col_val.data
 
     lc = LightCurve(time=[1, 2, 3])
-    lc['col1'] = new_col_val
-    assert_array_equal(lc['col1'].value, expected_raw_value)
+    lc["col1"] = new_col_val
+    assert_array_equal(lc["col1"].value, expected_raw_value)
     # additional check for MaskedColumn, to ensure we don't lose its properties
     if isinstance(new_col_val, MaskedColumn):
-        assert_array_equal(lc['col1'].mask, new_col_val.mask)
-        assert lc['col1'].fill_value == new_col_val.fill_value
+        assert_array_equal(lc["col1"].mask, new_col_val.mask)
+        assert lc["col1"].fill_value == new_col_val.fill_value
+
 
 def test_support_non_numeric_columns():
     lc = LightCurve(time=[1, 2, 3], flux=[2, 3, 4])
-    lc['col1'] = ['a', 'b', 'c']
+    lc["col1"] = ["a", "b", "c"]
     lc_copy = lc.copy()
-    assert_array_equal(lc_copy['col1'], lc['col1'])
+    assert_array_equal(lc_copy["col1"], lc["col1"])
 
 
 def test_timedelta():
     """Can the time column be initialized using TimeDelta?"""
     td = TimeDelta([-0.5, 0, +0.5])
     LightCurve(time=td)
-    LightCurve(data={'time': td})
+    LightCurve(data={"time": td})
 
 
 def test_issue_916():
@@ -1368,4 +1504,4 @@ def test_search_neighbors():
     search = lc.search_neighbors(limit=1, radius=300, author="spoc", sector="11")
     assert len(search) == 1
     assert search.distance.value < 300
-    assert search.target_name[0] == '388852407'
+    assert search.target_name[0] == "388852407"

--- a/tests/test_periodogram.py
+++ b/tests/test_periodogram.py
@@ -16,13 +16,16 @@ from lightkurve.utils import LightkurveWarning
 
 def test_periodogram_basics():
     """Sanity check to verify that periodogram plotting works"""
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     lc = lc.normalize()
     pg = lc.to_periodogram()
     pg.plot()
     plt.close()
-    pg.plot(view='period')
+    pg.plot(view="period")
     plt.close()
     pg.show_properties()
     pg.to_table()
@@ -33,67 +36,86 @@ def test_periodogram_basics():
 
 def test_periodogram_normalization():
     """Tests the normalization options"""
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1, flux_unit='electron/second')
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+        flux_unit="electron/second",
+    )
     # Test amplitude normalization and correct units
-    pg = lc.to_periodogram(normalization='amplitude')
+    pg = lc.to_periodogram(normalization="amplitude")
     assert pg.power.unit == u.electron / u.second
-    pg = lc.normalize(unit='ppm').to_periodogram(normalization='amplitude')
+    pg = lc.normalize(unit="ppm").to_periodogram(normalization="amplitude")
     assert pg.power.unit == u.cds.ppm
 
     # Test PSD normalization and correct units
-    pg = lc.to_periodogram(freq_unit=u.microhertz, normalization='psd')
-    assert pg.power.unit ==  (u.electron/u.second)**2 / u.microhertz
-    pg = lc.normalize(unit='ppm').to_periodogram(freq_unit=u.microhertz, normalization='psd')
-    assert pg.power.unit == u.cds.ppm**2 / u.microhertz
+    pg = lc.to_periodogram(freq_unit=u.microhertz, normalization="psd")
+    assert pg.power.unit == (u.electron / u.second) ** 2 / u.microhertz
+    pg = lc.normalize(unit="ppm").to_periodogram(
+        freq_unit=u.microhertz, normalization="psd"
+    )
+    assert pg.power.unit == u.cds.ppm ** 2 / u.microhertz
 
 
 def test_periodogram_warnings():
     """Tests if warnings are raised for non-normalized periodogram input"""
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
-    lc = lc.normalize(unit='ppm')
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
+    lc = lc.normalize(unit="ppm")
     # Test amplitude normalization and correct units
-    pg = lc.to_periodogram(normalization='amplitude')
+    pg = lc.to_periodogram(normalization="amplitude")
     assert pg.power.unit == u.cds.ppm
-    pg = lc.to_periodogram(freq_unit=u.microhertz, normalization='psd')
-    assert pg.power.unit == u.cds.ppm**2 / u.microhertz
+    pg = lc.to_periodogram(freq_unit=u.microhertz, normalization="psd")
+    assert pg.power.unit == u.cds.ppm ** 2 / u.microhertz
 
 
 def test_periodogram_units():
     """Tests whether periodogram has correct units"""
     # Fake, noisy data
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1, flux_unit='electron/second')
-    p = lc.to_periodogram(normalization='amplitude')
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+        flux_unit="electron/second",
+    )
+    p = lc.to_periodogram(normalization="amplitude")
     # Has units
-    assert hasattr(p.frequency, 'unit')
+    assert hasattr(p.frequency, "unit")
 
     # Has the correct units
-    assert p.frequency.unit == 1./u.day
+    assert p.frequency.unit == 1.0 / u.day
     assert p.power.unit == u.electron / u.second
     assert p.period.unit == u.day
-    assert p.frequency_at_max_power.unit == 1./u.day
+    assert p.frequency_at_max_power.unit == 1.0 / u.day
     assert p.max_power.unit == u.electron / u.second
 
 
 def test_periodogram_can_find_periods():
     """Periodogram should recover the correct period"""
     # Light curve that is noisy
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     # Add a 100 day period signal
-    lc.flux += np.sin((lc.time.value/float(lc.time.value.max())) * 20 * np.pi)
+    lc.flux += np.sin((lc.time.value / float(lc.time.value.max())) * 20 * np.pi)
     lc = lc.normalize()
-    p = lc.to_periodogram(normalization='amplitude')
+    p = lc.to_periodogram(normalization="amplitude")
     assert np.isclose(p.period_at_max_power.value, 100, rtol=1e-3)
 
 
 def test_periodogram_slicing():
     """Tests whether periodograms can be sliced"""
     # Fake, noisy data
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     lc = lc.normalize()
     p = lc.to_periodogram()
     assert len(p[0:200].frequency) == 200
@@ -101,7 +123,7 @@ def test_periodogram_slicing():
     # Test divide
     orig = p.power.sum()
     p /= 2
-    assert np.sum(p.power) == orig/2
+    assert np.sum(p.power) == orig / 2
 
     # Test multiplication
     p *= 0
@@ -118,8 +140,11 @@ def test_periodogram_slicing():
 
 def test_assign_periods():
     """Test if you can assign periods and frequencies."""
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000) + 0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     periods = np.arange(1, 100) * u.day
     lc = lc.normalize()
     p = lc.to_periodogram(period=periods)
@@ -132,42 +157,50 @@ def test_assign_periods():
 
 def test_bin():
     """Test if you can bin the periodogram."""
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000) + 0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     lc = lc.normalize()
     p = lc.to_periodogram()
-    assert len(p.bin(binsize=10, method='mean').frequency) == len(p.frequency)//10
-    assert len(p.bin(binsize=10, method='median').frequency) == len(p.frequency)//10
+    assert len(p.bin(binsize=10, method="mean").frequency) == len(p.frequency) // 10
+    assert len(p.bin(binsize=10, method="median").frequency) == len(p.frequency) // 10
 
 
 def test_smooth():
-    """Test if you can smooth the periodogram and check any pitfalls
-    """
+    """Test if you can smooth the periodogram and check any pitfalls"""
     np.random.seed(42)
-    lc = LightCurve(time=np.arange(1000),
-                    flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     lc = lc.normalize()
-    p = lc.to_periodogram(normalization='psd', freq_unit=u.microhertz)
+    p = lc.to_periodogram(normalization="psd", freq_unit=u.microhertz)
     # Test boxkernel and logmedian methods
-    assert all(p.smooth(method='boxkernel').frequency == p.frequency)
-    assert all(p.smooth(method='logmedian').frequency == p.frequency)
+    assert all(p.smooth(method="boxkernel").frequency == p.frequency)
+    assert all(p.smooth(method="logmedian").frequency == p.frequency)
     # Check output units
     assert p.smooth().power.unit == p.power.unit
 
     # Check logmedian smooth that the mean of the smoothed power should
     # be consistent with the mean of the power
-    assert np.isclose(np.mean(p.smooth(method='logmedian').power.value),
-                     np.mean(p.power.value), atol=0.05*np.mean(p.power.value))
-
+    assert np.isclose(
+        np.mean(p.smooth(method="logmedian").power.value),
+        np.mean(p.power.value),
+        atol=0.05 * np.mean(p.power.value),
+    )
 
     # Can't pass filter_width below 0.
     with pytest.raises(ValueError) as err:
-        p.smooth(method='boxkernel', filter_width=-5.)
+        p.smooth(method="boxkernel", filter_width=-5.0)
     # Can't pass a filter_width in the wrong units
     with pytest.raises(ValueError) as err:
-        p.smooth(method='boxkernel', filter_width=5.*u.day)
-    assert err.value.args[0] == 'the `filter_width` parameter must have frequency units.'
+        p.smooth(method="boxkernel", filter_width=5.0 * u.day)
+    assert (
+        err.value.args[0] == "the `filter_width` parameter must have frequency units."
+    )
 
     # Can't (yet) use a periodogram with a non-evenly spaced frequencies
     with pytest.raises(ValueError) as err:
@@ -177,74 +210,85 @@ def test_smooth():
 
     # Check logmedian doesn't work if I give the filter width units
     with pytest.raises(ValueError) as err:
-        p.smooth(method='logmedian',  filter_width=5.*u.day)
-
+        p.smooth(method="logmedian", filter_width=5.0 * u.day)
 
 
 def test_flatten():
     npts = 10000
     np.random.seed(12069424)
-    lc = LightCurve(time=np.arange(npts),
-                    flux=np.random.normal(1, 0.1, npts),
-                    flux_err=np.zeros(npts)+0.1)
+    lc = LightCurve(
+        time=np.arange(npts),
+        flux=np.random.normal(1, 0.1, npts),
+        flux_err=np.zeros(npts) + 0.1,
+    )
     lc = lc.normalize()
-    p = lc.to_periodogram(normalization='psd', freq_unit=1/u.day)
+    p = lc.to_periodogram(normalization="psd", freq_unit=1 / u.day)
 
     # Check method returns equal frequency
-    assert all(p.flatten(method='logmedian').frequency == p.frequency)
-    assert all(p.flatten(method='boxkernel').frequency == p.frequency)
+    assert all(p.flatten(method="logmedian").frequency == p.frequency)
+    assert all(p.flatten(method="boxkernel").frequency == p.frequency)
 
     # Check logmedian flatten of white noise returns mean of ~unity
-    assert np.isclose(np.mean(p.flatten(method='logmedian').power.value), 1.0,
-                      atol=0.05)
+    assert np.isclose(
+        np.mean(p.flatten(method="logmedian").power.value), 1.0, atol=0.05
+    )
 
     # Check return trend works
     s, b = p.flatten(return_trend=True)
-    assert all(b.power == p.smooth(method='logmedian', filter_width=0.01).power)
+    assert all(b.power == p.smooth(method="logmedian", filter_width=0.01).power)
     assert all(s.power == p.flatten().power)
     str(s)
     s.plot()
     plt.close()
 
+
 def test_index():
-    """Test if you can mask out periodogram
-    """
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    """Test if you can mask out periodogram"""
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
     lc = lc.normalize()
     p = lc.to_periodogram()
-    mask = (p.frequency > 0.1*(1/u.day)) & (p.frequency < 0.2*(1/u.day))
+    mask = (p.frequency > 0.1 * (1 / u.day)) & (p.frequency < 0.2 * (1 / u.day))
     assert len(p[mask].frequency) == mask.sum()
 
 
 def test_bls(caplog):
-    ''' Test that BLS periodogram works and gives reasonable errors
-    '''
-    lc = LightCurve(time=np.linspace(0, 10, 200), flux=np.random.normal(100, 0.1, 200),
-                    flux_err=np.zeros(200)+0.1)
+    """Test that BLS periodogram works and gives reasonable errors"""
+    lc = LightCurve(
+        time=np.linspace(0, 10, 200),
+        flux=np.random.normal(100, 0.1, 200),
+        flux_err=np.zeros(200) + 0.1,
+    )
 
     # should be able to make a periodogram
-    p = lc.to_periodogram(method='bls')
-    keys = ['period', 'power', 'duration', 'transit_time', 'depth', 'snr']
-    assert np.all([key in  dir(p) for key in keys])
+    p = lc.to_periodogram(method="bls")
+    keys = ["period", "power", "duration", "transit_time", "depth", "snr"]
+    assert np.all([key in dir(p) for key in keys])
 
     p.plot()
     plt.close()
 
     # we should be able to specify some keywords
-    lc.to_periodogram(method='bls', minimum_period=0.2, duration=0.1, maximum_period=0.5)
+    lc.to_periodogram(
+        method="bls", minimum_period=0.2, duration=0.1, maximum_period=0.5
+    )
 
     # Ridiculous BLS spectra should break.
     with pytest.raises(ValueError) as err:
-        lc.to_periodogram(method='bls', frequency_factor=0.00001)
-        assert err.value.args[0] == ('`period` contains over 72000001 points.Periodogram is too large to evaluate. Consider setting `frequency_factor` to a higher value.')
+        lc.to_periodogram(method="bls", frequency_factor=0.00001)
+        assert err.value.args[0] == (
+            "`period` contains over 72000001 points.Periodogram is too large to evaluate. Consider setting `frequency_factor` to a higher value."
+        )
 
     # Some errors should occur
     p.compute_stats()
     for record in caplog.records:
-        assert record.levelname == 'WARNING'
+        assert record.levelname == "WARNING"
     assert len(caplog.records) == 3
-    assert 'No period specified.' in caplog.text
+    assert "No period specified." in caplog.text
 
     # No more errors
     stats = p.compute_stats(1, 0.1, 0)
@@ -254,9 +298,9 @@ def test_bls(caplog):
     # Some errors should occur
     p.get_transit_model()
     for record in caplog.records:
-        assert record.levelname == 'WARNING'
+        assert record.levelname == "WARNING"
     assert len(caplog.records) == 6
-    assert 'No period specified.' in caplog.text
+    assert "No period specified." in caplog.text
 
     model = p.get_transit_model(1, 0.1, 0)
     # No more errors
@@ -290,7 +334,10 @@ def test_bls_period_recovery():
     # Create the synthetic light curve
     time = np.arange(0, 20, 0.02)
     flux = np.ones_like(time)
-    transit_mask = np.abs((time-transit_time+0.5*period) % period-0.5*period) < 0.5*duration
+    transit_mask = (
+        np.abs((time - transit_time + 0.5 * period) % period - 0.5 * period)
+        < 0.5 * duration
+    )
     flux[transit_mask] = 1.0 - depth
     flux += flux_err * np.random.randn(len(time))
     synthetic_lc = LightCurve(time=time, flux=flux)
@@ -309,11 +356,13 @@ def test_bls_period_recovery():
 
 
 def test_error_messages():
-    """Test periodogram raises reasonable errors
-    """
+    """Test periodogram raises reasonable errors"""
     # Fake, noisy data
-    lc = LightCurve(time=np.arange(1000), flux=np.random.normal(1, 0.1, 1000),
-                    flux_err=np.zeros(1000)+0.1)
+    lc = LightCurve(
+        time=np.arange(1000),
+        flux=np.random.normal(1, 0.1, 1000),
+        flux_err=np.zeros(1000) + 0.1,
+    )
 
     # Can't specify period range and frequency range
     with pytest.raises(ValueError) as err:
@@ -322,57 +371,58 @@ def test_error_messages():
     # Can't have a minimum frequency > maximum frequency
     with pytest.raises(ValueError) as err:
         lc.to_periodogram(maximum_frequency=0.1, minimum_frequency=10)
-    assert err.value.args[0] == 'minimum_frequency cannot be larger than maximum_frequency'
+    assert (
+        err.value.args[0] == "minimum_frequency cannot be larger than maximum_frequency"
+    )
 
     # Can't have a minimum period > maximum period
     with pytest.raises(ValueError) as err:
         lc.to_periodogram(maximum_period=0.1, minimum_period=10)
-    assert err.value.args[0] == 'minimum_period cannot be larger than maximum_period'
+    assert err.value.args[0] == "minimum_period cannot be larger than maximum_period"
 
     # Can't specify periods and frequencies
     with pytest.raises(ValueError) as err:
         lc.to_periodogram(frequency=np.arange(10), period=np.arange(10))
 
-
     # No unitless periodograms
     with pytest.raises(ValueError) as err:
         Periodogram([0], [1])
-    assert err.value.args[0] == 'frequency must be an `astropy.units.Quantity` object.'
+    assert err.value.args[0] == "frequency must be an `astropy.units.Quantity` object."
 
     # No unitless periodograms
     with pytest.raises(ValueError) as err:
-        Periodogram([0]*u.Hz, [1])
-    assert err.value.args[0] == 'power must be an `astropy.units.Quantity` object.'
+        Periodogram([0] * u.Hz, [1])
+    assert err.value.args[0] == "power must be an `astropy.units.Quantity` object."
 
     # No single value periodograms
     with pytest.raises(ValueError) as err:
-        Periodogram([0]*u.Hz, [1]*u.K)
-    assert err.value.args[0] == 'frequency and power must have a length greater than 1.'
+        Periodogram([0] * u.Hz, [1] * u.K)
+    assert err.value.args[0] == "frequency and power must have a length greater than 1."
 
     # No uneven arrays
     with pytest.raises(ValueError) as err:
-        Periodogram([0, 1, 2, 3]*u.Hz, [1, 1]*u.K)
-    assert err.value.args[0] == 'frequency and power must have the same length.'
+        Periodogram([0, 1, 2, 3] * u.Hz, [1, 1] * u.K)
+    assert err.value.args[0] == "frequency and power must have the same length."
 
     # Bad frequency units
     with pytest.raises(ValueError) as err:
-        Periodogram([0, 1, 2]*u.K, [1, 1, 1]*u.K)
-    assert err.value.args[0] == 'Frequency must be in units of 1/time.'
+        Periodogram([0, 1, 2] * u.K, [1, 1, 1] * u.K)
+    assert err.value.args[0] == "Frequency must be in units of 1/time."
 
     # Bad binning
     with pytest.raises(ValueError) as err:
-        Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).bin(binsize=-2)
-    assert err.value.args[0] == 'binsize must be larger than or equal to 1'
+        Periodogram([0, 1, 2] * u.Hz, [1, 1, 1] * u.K).bin(binsize=-2)
+    assert err.value.args[0] == "binsize must be larger than or equal to 1"
 
     # Bad binning method
     with pytest.raises(ValueError) as err:
-        Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).bin(method='not-implemented')
-    assert("method 'not-implemented' is not supported" in err.value.args[0])
+        Periodogram([0, 1, 2] * u.Hz, [1, 1, 1] * u.K).bin(method="not-implemented")
+    assert "method 'not-implemented' is not supported" in err.value.args[0]
 
     # Bad smooth method
     with pytest.raises(ValueError) as err:
-        Periodogram([0, 1, 2]*u.Hz, [1, 1, 1]*u.K).smooth(method="not-implemented")
-    assert("method 'not-implemented' is not supported" in err.value.args[0])
+        Periodogram([0, 1, 2] * u.Hz, [1, 1, 1] * u.K).smooth(method="not-implemented")
+    assert "method 'not-implemented' is not supported" in err.value.args[0]
 
 
 def test_bls_period():
@@ -383,4 +433,4 @@ def test_bls_period():
     assert_array_equal(pg.period.value, period)
     with pytest.raises(ValueError) as err:  # NaNs should raise a nice error message
         lc.to_periodogram(method="bls", period=[1, 2, 3, np.nan, 4])
-    assert("period" in err.value.args[0])
+    assert "period" in err.value.args[0]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,31 +17,68 @@ import astropy.units as u
 from astropy.table import Table
 
 from lightkurve.utils import LightkurveWarning, LightkurveError
-from lightkurve.search import search_lightcurve, search_targetpixelfile, \
-                     search_tesscut, SearchResult, SearchError, log
-from lightkurve import KeplerTargetPixelFile, TessTargetPixelFile, TargetPixelFileCollection
+from lightkurve.search import (
+    search_lightcurve,
+    search_targetpixelfile,
+    search_tesscut,
+    SearchResult,
+    SearchError,
+    log,
+)
+from lightkurve import (
+    KeplerTargetPixelFile,
+    TessTargetPixelFile,
+    TargetPixelFileCollection,
+)
 
 
 @pytest.mark.remote_data
 def test_search_targetpixelfile():
     # EPIC 210634047 was observed twice in long cadence
-    assert(len(search_targetpixelfile('EPIC 210634047', mission='K2').table) == 2)
+    assert len(search_targetpixelfile("EPIC 210634047", mission="K2").table) == 2
     # ...including Campaign 4
-    assert(len(search_targetpixelfile('EPIC 210634047', mission='K2', campaign=4).table) == 1)
+    assert (
+        len(search_targetpixelfile("EPIC 210634047", mission="K2", campaign=4).table)
+        == 1
+    )
     # KIC 11904151 (Kepler-10) was observed in LC in 15 Quarters
-    assert(len(search_targetpixelfile('KIC 11904151', mission='Kepler', cadence='long').table) == 15)
+    assert (
+        len(
+            search_targetpixelfile(
+                "KIC 11904151", mission="Kepler", cadence="long"
+            ).table
+        )
+        == 15
+    )
     # ...including quarter 11 but not 12:
-    assert(len(search_targetpixelfile('KIC 11904151', mission='Kepler', cadence='long', quarter=11).unique_targets) == 1)
-    assert(len(search_targetpixelfile('KIC 11904151', mission='Kepler', cadence='long', quarter=12).table) == 0)
-    search_targetpixelfile('KIC 11904151', quarter=11, cadence='long').download()
+    assert (
+        len(
+            search_targetpixelfile(
+                "KIC 11904151", mission="Kepler", cadence="long", quarter=11
+            ).unique_targets
+        )
+        == 1
+    )
+    assert (
+        len(
+            search_targetpixelfile(
+                "KIC 11904151", mission="Kepler", cadence="long", quarter=12
+            ).table
+        )
+        == 0
+    )
+    search_targetpixelfile("KIC 11904151", quarter=11, cadence="long").download()
     # with mission='TESS', it should return TESS observations
-    tic = 'TIC 273985862'  # Has been observed in multiple sectors including 1
-    assert(len(search_targetpixelfile(tic, mission='TESS').table) > 1)
-    assert(len(search_targetpixelfile(tic, mission='TESS', sector=1, radius=100).table) == 2)
-    search_targetpixelfile(tic, mission='TESS', sector=1).download()
-    assert(len(search_targetpixelfile("pi Mensae", sector=1).table) == 1)
+    tic = "TIC 273985862"  # Has been observed in multiple sectors including 1
+    assert len(search_targetpixelfile(tic, mission="TESS").table) > 1
+    assert (
+        len(search_targetpixelfile(tic, mission="TESS", sector=1, radius=100).table)
+        == 2
+    )
+    search_targetpixelfile(tic, mission="TESS", sector=1).download()
+    assert len(search_targetpixelfile("pi Mensae", sector=1).table) == 1
     # Issue #445: indexing with -1 should return the last index of the search result
-    assert(len(search_targetpixelfile("pi Men")[-1]) == 1)
+    assert len(search_targetpixelfile("pi Men")[-1]) == 1
 
 
 @pytest.mark.remote_data
@@ -53,32 +90,35 @@ def test_search_split_campaigns():
     We expect most targets from those campaigns to return two TPFs.
     """
     campaigns = [9, 10, 11]
-    ids = ['EPIC 228162462', 'EPIC 228726301', 'EPIC 202975993']
+    ids = ["EPIC 228162462", "EPIC 228726301", "EPIC 202975993"]
     for c, idx in zip(campaigns, ids):
-        search = search_targetpixelfile(idx, campaign=c, cadence='long').table
-        assert(len(search) == 2)
+        search = search_targetpixelfile(idx, campaign=c, cadence="long").table
+        assert len(search) == 2
 
 
 @pytest.mark.remote_data
 def test_search_lightcurve(caplog):
     # We should also be able to resolve it by its name instead of KIC ID
-    assert(len(search_lightcurve('Kepler-10', mission='Kepler', cadence='long').table) == 15)
+    assert (
+        len(search_lightcurve("Kepler-10", mission="Kepler", cadence="long").table)
+        == 15
+    )
     # An invalid KIC/EPIC ID or target name should be dealt with gracefully
     search_lightcurve(-999)
     assert "Could not resolve" in caplog.text
     search_lightcurve("DOES_NOT_EXIST (UNIT TEST)")
     assert "Could not resolve" in caplog.text
     # If we ask for all cadence types, there should be four Kepler files given
-    assert(len(search_lightcurve('KIC 4914423', quarter=6, cadence='any').table) == 4)
+    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="any").table) == 4
     # ...and only one should have long cadence
-    assert(len(search_lightcurve('KIC 4914423', quarter=6, cadence='long').table) == 1)
+    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="long").table) == 1
     # Should be able to resolve an ra/dec
-    assert(len(search_lightcurve('297.5835, 40.98339', quarter=6).table) == 1)
+    assert len(search_lightcurve("297.5835, 40.98339", quarter=6).table) == 1
     # Should be able to resolve a SkyCoord
-    c = SkyCoord('297.5835 40.98339', unit=(u.deg, u.deg))
+    c = SkyCoord("297.5835 40.98339", unit=(u.deg, u.deg))
     search = search_lightcurve(c, quarter=6)
-    assert(len(search.table) == 1)
-    assert(len(search) == 1)
+    assert len(search.table) == 1
+    assert len(search) == 1
     # We should be able to download a light curve
     search.download()
     # The second call to download should use the local cache
@@ -87,30 +127,37 @@ def test_search_lightcurve(caplog):
     search.download()
     assert "found in local cache" in caplog.text
     # with mission='TESS', it should return TESS observations
-    tic = 'TIC 273985862'
-    assert(len(search_lightcurve(tic, mission='TESS').table) > 1)
-    assert(len(search_lightcurve(tic, mission='TESS', author='spoc', sector=1, radius=100).table) == 2)
-    search_lightcurve(tic, mission='TESS', author='SPOC', sector=1).download()
-    assert(len(search_lightcurve("pi Mensae", author='SPOC', sector=1).table) == 1)
+    tic = "TIC 273985862"
+    assert len(search_lightcurve(tic, mission="TESS").table) > 1
+    assert (
+        len(
+            search_lightcurve(
+                tic, mission="TESS", author="spoc", sector=1, radius=100
+            ).table
+        )
+        == 2
+    )
+    search_lightcurve(tic, mission="TESS", author="SPOC", sector=1).download()
+    assert len(search_lightcurve("pi Mensae", author="SPOC", sector=1).table) == 1
 
 
 @pytest.mark.remote_data
 def test_search_tesscut():
     # Cutout by target name
-    assert(len(search_tesscut("pi Mensae", sector=1).table) == 1)
-    assert(len(search_tesscut("pi Mensae").table) > 1)
+    assert len(search_tesscut("pi Mensae", sector=1).table) == 1
+    assert len(search_tesscut("pi Mensae").table) > 1
     # Cutout by TIC ID
-    assert(len(search_tesscut('TIC 206669860', sector=2).table) == 1)
+    assert len(search_tesscut("TIC 206669860", sector=2).table) == 1
     # Cutout by RA, dec string
-    search_string = search_tesscut('30.578761, -83.210593')
+    search_string = search_tesscut("30.578761, -83.210593")
     # Cutout by SkyCoord
-    c = SkyCoord('30.578761 -83.210593', unit=(u.deg, u.deg))
+    c = SkyCoord("30.578761 -83.210593", unit=(u.deg, u.deg))
     search_coords = search_tesscut(c)
     # These should be identical
-    assert(len(search_string.table) == len(search_coords.table))
+    assert len(search_string.table) == len(search_coords.table)
     # The coordinates below are beyond the edge of the sector 4 (camera 1-4) FFI
-    search_edge = search_tesscut('30.578761, 6.210593', sector=4)
-    assert(len(search_edge.table) == 0)
+    search_edge = search_tesscut("30.578761, 6.210593", sector=4)
+    assert len(search_edge.table) == 0
 
 
 @pytest.mark.remote_data
@@ -118,30 +165,30 @@ def test_search_tesscut_download(caplog):
     """Can we download TESS cutouts via `search_cutout().download()?"""
     try:
         ra, dec = 30.578761, -83.210593
-        search_string = search_tesscut('{}, {}'.format(ra, dec), sector=[1, 12])
+        search_string = search_tesscut("{}, {}".format(ra, dec), sector=[1, 12])
         # Make sure they can be downloaded with default size
         tpf = search_string[1].download()
         # Ensure the correct object has been returned
-        assert(isinstance(tpf, TessTargetPixelFile))
+        assert isinstance(tpf, TessTargetPixelFile)
         # Ensure default size is 5x5
-        assert(tpf.flux[0].shape == (5, 5))
-        assert(len(tpf.targetid) > 0)  # Regression test #473
-        assert(tpf.sector == 12)  # Regression test #696
+        assert tpf.flux[0].shape == (5, 5)
+        assert len(tpf.targetid) > 0  # Regression test #473
+        assert tpf.sector == 12  # Regression test #696
         # Ensure the WCS is valid (#434 regression test)
         center_ra, center_dec = tpf.wcs.all_pix2world([[2.5, 2.5]], 1)[0]
         assert_almost_equal(ra, center_ra, decimal=1)
         assert_almost_equal(dec, center_dec, decimal=1)
         # Download with different dimensions
-        tpfc = search_string.download_all(cutout_size=4, quality_bitmask='hard')
-        assert(isinstance(tpfc, TargetPixelFileCollection))
-        assert(tpfc[0].quality_bitmask == 'hard')  # Regression test for #494
-        assert(tpfc[0].sector == 1)  # Regression test #696
-        assert(tpfc[1].sector == 12) # Regression test #696
+        tpfc = search_string.download_all(cutout_size=4, quality_bitmask="hard")
+        assert isinstance(tpfc, TargetPixelFileCollection)
+        assert tpfc[0].quality_bitmask == "hard"  # Regression test for #494
+        assert tpfc[0].sector == 1  # Regression test #696
+        assert tpfc[1].sector == 12  # Regression test #696
         # Ensure correct dimensions
-        assert(tpfc[0].flux[0].shape == (4, 4))
+        assert tpfc[0].flux[0].shape == (4, 4)
         # Download with rectangular dimennsions?
         rect_tpf = search_string[0].download(cutout_size=(3, 5))
-        assert(rect_tpf.flux[0].shape == (3, 5))
+        assert rect_tpf.flux[0].shape == (3, 5)
         # If we ask for the exact same cutout, do we get it from cache?
         caplog.clear()
         log.setLevel("DEBUG")
@@ -157,25 +204,41 @@ def test_search_tesscut_download(caplog):
 @pytest.mark.remote_data
 def test_search_with_skycoord():
     """Can we pass both names, SkyCoord objects, and coordinate strings?"""
-    sr_name = search_targetpixelfile("Kepler-10", mission='Kepler', cadence='long')
-    assert len(sr_name) == 15  # Kepler-10 as observed during 15 quarters in long cadence
+    sr_name = search_targetpixelfile("Kepler-10", mission="Kepler", cadence="long")
+    assert (
+        len(sr_name) == 15
+    )  # Kepler-10 as observed during 15 quarters in long cadence
     # Can we search using a SkyCoord objects?
-    sr_skycoord = search_targetpixelfile(SkyCoord.from_name("Kepler_10"), mission='Kepler', cadence='long')
-    assert_array_equal(sr_name.table['productFilename'], sr_skycoord.table['productFilename'])
+    sr_skycoord = search_targetpixelfile(
+        SkyCoord.from_name("Kepler_10"), mission="Kepler", cadence="long"
+    )
+    assert_array_equal(
+        sr_name.table["productFilename"], sr_skycoord.table["productFilename"]
+    )
     # Can we search using a string of "ra dec" decimals?
-    sr_decimal = search_targetpixelfile("285.67942179 +50.24130576", mission='Kepler', cadence='long')
-    assert_array_equal(sr_name.table['productFilename'], sr_decimal.table['productFilename'])
+    sr_decimal = search_targetpixelfile(
+        "285.67942179 +50.24130576", mission="Kepler", cadence="long"
+    )
+    assert_array_equal(
+        sr_name.table["productFilename"], sr_decimal.table["productFilename"]
+    )
     # Can we search using a sexagesimal string?
-    sr_sexagesimal = search_targetpixelfile("19:02:43.1 +50:14:28.7", mission='Kepler', cadence='long')
-    assert_array_equal(sr_name.table['productFilename'], sr_sexagesimal.table['productFilename'])
+    sr_sexagesimal = search_targetpixelfile(
+        "19:02:43.1 +50:14:28.7", mission="Kepler", cadence="long"
+    )
+    assert_array_equal(
+        sr_name.table["productFilename"], sr_sexagesimal.table["productFilename"]
+    )
     # Can we search using the KIC ID?
-    sr_kic = search_targetpixelfile('KIC 11904151', mission='Kepler', cadence='long')
-    assert_array_equal(sr_name.table['productFilename'], sr_kic.table['productFilename'])
+    sr_kic = search_targetpixelfile("KIC 11904151", mission="Kepler", cadence="long")
+    assert_array_equal(
+        sr_name.table["productFilename"], sr_kic.table["productFilename"]
+    )
 
 
 @pytest.mark.remote_data
 def test_searchresult():
-    sr = search_lightcurve('Kepler-10', mission='Kepler')
+    sr = search_lightcurve("Kepler-10", mission="Kepler")
     assert len(sr) == len(sr.table)  # Tests SearchResult.__len__
     assert len(sr[2:7]) == 5  # Tests SearchResult.__get__
     assert len(sr[2]) == 1
@@ -186,33 +249,54 @@ def test_searchresult():
 @pytest.mark.remote_data
 def test_month():
     # In short cadence, if we specify both quarter and month
-    sr = search_targetpixelfile('Kepler-10', quarter=11, month=1, cadence='short')
-    assert(len(sr) == 1)
-    sr = search_targetpixelfile('Kepler-10', quarter=11, month=[1, 3], cadence='short')
-    assert(len(sr) == 2)
+    sr = search_targetpixelfile("Kepler-10", quarter=11, month=1, cadence="short")
+    assert len(sr) == 1
+    sr = search_targetpixelfile("Kepler-10", quarter=11, month=[1, 3], cadence="short")
+    assert len(sr) == 2
 
 
 @pytest.mark.remote_data
 def test_collections():
     # TargetPixelFileCollection class
-    assert(len(search_targetpixelfile('EPIC 205998445', mission='K2',radius=900).table) == 4)
+    assert (
+        len(search_targetpixelfile("EPIC 205998445", mission="K2", radius=900).table)
+        == 4
+    )
     # LightCurveFileCollection class with set targetlimit
-    assert(len(search_lightcurve('EPIC 205998445', mission='K2', radius=900, limit=3, author='K2').download_all()) == 3)
+    assert (
+        len(
+            search_lightcurve(
+                "EPIC 205998445", mission="K2", radius=900, limit=3, author="K2"
+            ).download_all()
+        )
+        == 3
+    )
     # if fewer targets are found than targetlimit, should still download all available
-    assert(len(search_targetpixelfile('EPIC 205998445', mission='K2', radius=900, limit=6).table) == 4)
+    assert (
+        len(
+            search_targetpixelfile(
+                "EPIC 205998445", mission="K2", radius=900, limit=6
+            ).table
+        )
+        == 4
+    )
     # if download() is used when multiple files are available, should only download 1
-    with pytest.warns(LightkurveWarning, match='4 files available to download'):
-        assert(isinstance(search_targetpixelfile('EPIC 205998445', mission='K2', radius=900, author="K2").download(),
-                          KeplerTargetPixelFile))
+    with pytest.warns(LightkurveWarning, match="4 files available to download"):
+        assert isinstance(
+            search_targetpixelfile(
+                "EPIC 205998445", mission="K2", radius=900, author="K2"
+            ).download(),
+            KeplerTargetPixelFile,
+        )
 
 
 @pytest.mark.remote_data
 def test_properties():
-    c = SkyCoord('297.5835 40.98339', unit=(u.deg, u.deg))
+    c = SkyCoord("297.5835 40.98339", unit=(u.deg, u.deg))
     assert_almost_equal(search_targetpixelfile(c, quarter=6).ra, 297.5835)
     assert_almost_equal(search_targetpixelfile(c, quarter=6).dec, 40.98339)
-    assert(len(search_targetpixelfile(c, quarter=6).target_name) == 1)
-    assert(len(search_targetpixelfile(c, quarter=6).obsid) == 1)
+    assert len(search_targetpixelfile(c, quarter=6).target_name) == 1
+    assert len(search_targetpixelfile(c, quarter=6).obsid) == 1
 
 
 @pytest.mark.remote_data
@@ -231,9 +315,9 @@ def test_empty_searchresult():
     sr = SearchResult(Table())
     assert len(sr) == 0
     str(sr)
-    with pytest.warns(LightkurveWarning, match='empty search'):
+    with pytest.warns(LightkurveWarning, match="empty search"):
         sr.download()
-    with pytest.warns(LightkurveWarning, match='empty search'):
+    with pytest.warns(LightkurveWarning, match="empty search"):
         sr.download_all()
 
 
@@ -259,15 +343,18 @@ def test_corrupt_download_handling():
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Pretend a corrupt file exists at the expected cache location
-        expected_dir = os.path.join(tmpdirname,
-                                   "mastDownload",
-                                   "Kepler",
-                                   "kplr011904151_lc_Q111111110111011101")
-        expected_fn = os.path.join(expected_dir, "kplr011904151-2010009091648_lpd-targ.fits.gz")
+        expected_dir = os.path.join(
+            tmpdirname, "mastDownload", "Kepler", "kplr011904151_lc_Q111111110111011101"
+        )
+        expected_fn = os.path.join(
+            expected_dir, "kplr011904151-2010009091648_lpd-targ.fits.gz"
+        )
         os.makedirs(expected_dir)
-        open(expected_fn, 'w').close()  # create "corrupt" i.e. empty file
+        open(expected_fn, "w").close()  # create "corrupt" i.e. empty file
         with pytest.raises(LightkurveError) as err:
-            search_targetpixelfile("Kepler-10", quarter=4, cadence='long').download(download_dir=tmpdirname)
+            search_targetpixelfile("Kepler-10", quarter=4, cadence="long").download(
+                download_dir=tmpdirname
+            )
         assert "may be corrupt" in err.value.args[0]
 
 
@@ -279,7 +366,9 @@ def test_indexerror_631():
     assert len(result) == 1
 
 
-@pytest.mark.skip(reason="TODO: issue re-appeared on 2020-01-11; needs to be revisited.")
+@pytest.mark.skip(
+    reason="TODO: issue re-appeared on 2020-01-11; needs to be revisited."
+)
 @pytest.mark.remote_data
 def test_name_resolving_regression_764():
     """Due to a bug, MAST resolved "EPIC250105131" to a different position than
@@ -287,6 +376,7 @@ def test_name_resolving_regression_764():
     not re-appear. Details: https://github.com/lightkurve/lightkurve/issues/764
     """
     from astroquery.mast import MastClass
+
     c1 = MastClass().resolve_object(objectname="EPIC250105131")
     c2 = MastClass().resolve_object(objectname="EPIC 250105131")
     assert c1.separation(c2).to("arcsec").value < 0.1
@@ -297,19 +387,21 @@ def test_overlapping_targets_718():
     """Regression test for #718."""
     # Searching for the following targets without radius should only return
     # the requested targets, not their overlapping neighbors.
-    targets = ['KIC 5112705', 'KIC 10058374', 'KIC 5385723']
+    targets = ["KIC 5112705", "KIC 10058374", "KIC 5385723"]
     for target in targets:
         search = search_lightcurve(target, quarter=11)
         assert len(search) == 1
-        assert search.target_name[0] == f'kplr{target[4:].zfill(9)}'
+        assert search.target_name[0] == f"kplr{target[4:].zfill(9)}"
 
     # When using `radius=1` we should also retrieve the overlapping targets
-    search = search_lightcurve('KIC 5112705', quarter=11, radius=1*u.arcsec)
+    search = search_lightcurve("KIC 5112705", quarter=11, radius=1 * u.arcsec)
     assert len(search) > 1
 
     # Searching by `target_name` should not preven a KIC identifier to work
     # in a TESS data search
-    search = search_targetpixelfile('KIC 8462852', mission='TESS', sector=15, author="spoc")
+    search = search_targetpixelfile(
+        "KIC 8462852", mission="TESS", sector=15, author="spoc"
+    )
     assert len(search) == 1
 
 
@@ -317,13 +409,15 @@ def test_overlapping_targets_718():
 def test_tesscut_795():
     """Regression test for #795: make sure the __repr__.of a TESSCut
     SearchResult works."""
-    str(search_tesscut('KIC 8462852'))  # This raised a KeyError
+    str(search_tesscut("KIC 8462852"))  # This raised a KeyError
 
 
 @pytest.mark.remote_data
 def test_download_flux_column():
     """Can we pass reader keyword arguments to the download method?"""
-    lc = search_lightcurve("Pi Men", author='SPOC', sector=12).download(flux_column='sap_flux')
+    lc = search_lightcurve("Pi Men", author="SPOC", sector=12).download(
+        flux_column="sap_flux"
+    )
     assert_array_equal(lc.flux, lc.sap_flux)
 
 
@@ -332,33 +426,33 @@ def test_cadence_filtering():
     """Can we pass "fast", "short", exposure time to the cadence argument?"""
     # Try `cadence="fast"`
     res = search_lightcurve("AU Mic", sector=27, cadence="fast")
-    assert(len(res) == 1)
+    assert len(res) == 1
     assert res.exptime[0].value == 20
     # Try `cadence="short"`
     res = search_lightcurve("AU Mic", sector=27, cadence="short")
-    assert(len(res) == 1)
-    assert res.table['t_exptime'][0] == 120
+    assert len(res) == 1
+    assert res.table["t_exptime"][0] == 120
     # Try `cadence=20`
     res = search_lightcurve("AU Mic", sector=27, cadence=20)
-    assert(len(res) == 1)
-    assert res.table['t_exptime'][0] == 20
-    assert "fast" in res.table['productFilename'][0]
+    assert len(res) == 1
+    assert res.table["t_exptime"][0] == 20
+    assert "fast" in res.table["productFilename"][0]
 
     # Now do the same with the new exptime argument,
     # because `cadence` may be deprecated.
     # Try `exptime="fast"`
     res = search_lightcurve("AU Mic", sector=27, exptime="fast")
-    assert(len(res) == 1)
+    assert len(res) == 1
     assert res.exptime[0].value == 20
     # Try `exptime="short"`
     res = search_lightcurve("AU Mic", sector=27, exptime="short")
-    assert(len(res) == 1)
-    assert res.table['t_exptime'][0] == 120
+    assert len(res) == 1
+    assert res.table["t_exptime"][0] == 120
     # Try `exptime=20`
     res = search_lightcurve("AU Mic", sector=27, exptime=20)
-    assert(len(res) == 1)
-    assert res.table['t_exptime'][0] == 20
-    assert "fast" in res.table['productFilename'][0]
+    assert len(res) == 1
+    assert res.table["t_exptime"][0] == 20
+    assert "fast" in res.table["productFilename"][0]
 
 
 @pytest.mark.remote_data
@@ -372,7 +466,9 @@ def test_search_slicing_regression():
 @pytest.mark.remote_data
 def test_ffi_hlsp():
     """Can SPOC, QLP (FFI), and TESS-SPOC (FFI) light curves be accessed?"""
-    search = search_lightcurve("TrES-2b", mission="tess", author="any", sector=26)  # aka TOI 2140.01
+    search = search_lightcurve(
+        "TrES-2b", mission="tess", author="any", sector=26
+    )  # aka TOI 2140.01
     assert "QLP" in search.table["author"]
     assert "TESS-SPOC" in search.table["author"]
     assert "SPOC" in search.table["author"]
@@ -388,7 +484,7 @@ def test_qlp_ffi_lightcurve():
     search = search_lightcurve("TrES-2b", sector=26, author="qlp")
     assert len(search) == 1
     assert search.author[0] == "QLP"
-    assert search.exptime[0] == 30*u.minute  # Sector 26 had 30-minute FFIs
+    assert search.exptime[0] == 30 * u.minute  # Sector 26 had 30-minute FFIs
     lc = search.download()
     all(lc.flux == lc.kspsap_flux)
 
@@ -399,6 +495,6 @@ def test_spoc_ffi_lightcurve():
     search = search_lightcurve("TrES-2b", sector=26, author="tess-spoc")
     assert len(search) == 1
     assert search.author[0] == "TESS-SPOC"
-    assert search.exptime[0] == 30*u.minute  # Sector 26 had 30-minute FFIs
+    assert search.exptime[0] == 30 * u.minute  # Sector 26 had 30-minute FFIs
     lc = search.download()
     all(lc.flux == lc.pdcsap_flux)

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -13,136 +13,193 @@ from lightkurve.targetpixelfile import KeplerTargetPixelFile
 from lightkurve.correctors import SFFCorrector, PLDCorrector
 
 # See `data/synthetic/README.md` for details about these synthetic test files
-filename_synthetic_sine = get_pkg_data_filename("data/synthetic/synthetic-k2-sinusoid.targ.fits.gz")
-filename_synthetic_transit = get_pkg_data_filename("data/synthetic/synthetic-k2-planet.targ.fits.gz")
-filename_synthetic_flat = get_pkg_data_filename("data/synthetic/synthetic-k2-flat.targ.fits.gz")
+filename_synthetic_sine = get_pkg_data_filename(
+    "data/synthetic/synthetic-k2-sinusoid.targ.fits.gz"
+)
+filename_synthetic_transit = get_pkg_data_filename(
+    "data/synthetic/synthetic-k2-planet.targ.fits.gz"
+)
+filename_synthetic_flat = get_pkg_data_filename(
+    "data/synthetic/synthetic-k2-flat.targ.fits.gz"
+)
 
 
 def test_sine_sff():
     """Can we recover a synthetic sine curve using SFF and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header['PERIOD'])
-    true_amplitude = np.float(tpf.hdu[3].header['SINE_AMP'])
+    true_period = np.float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the SFF algorithm
     lc = tpf.to_lightcurve()
     corrector = SFFCorrector(lc)
-    cor_lc = corrector.correct(tpf.pos_corr2, tpf.pos_corr1,
-                               niters=4, windows=1, bins=7, restore_trend=True, timescale=0.5)
+    cor_lc = corrector.correct(
+        tpf.pos_corr2,
+        tpf.pos_corr1,
+        niters=4,
+        windows=1,
+        bins=7,
+        restore_trend=True,
+        timescale=0.5,
+    )
 
     # Verify that we get the period within ~20%
-    pg = cor_lc.to_periodogram(method='lombscargle', minimum_period=1,
-                               maximum_period=10, oversample_factor=10)
+    pg = cor_lc.to_periodogram(
+        method="lombscargle", minimum_period=1, maximum_period=10, oversample_factor=10
+    )
     ret_period = pg.period_at_max_power.value
     threshold = 0.2
-    assert ((ret_period > true_period*(1-threshold)) &
-            (ret_period < true_period*(1+threshold)) )
+    assert (ret_period > true_period * (1 - threshold)) & (
+        ret_period < true_period * (1 + threshold)
+    )
 
     # Verify that we get the amplitude to within 10%
     n_cad = len(tpf.time)
-    design_matrix = np.vstack([np.ones(n_cad),
-                              np.sin(2.0*np.pi*cor_lc.time.value/ret_period),
-                              np.cos(2.0*np.pi*cor_lc.time.value/ret_period)]).T
-    ATA = np.dot(design_matrix.T,  design_matrix / cor_lc.flux_err[:, None]**2)
-    least_squares_coeffs = np.linalg.solve(ATA, np.dot(design_matrix.T, cor_lc.flux/cor_lc.flux_err**2 ))
+    design_matrix = np.vstack(
+        [
+            np.ones(n_cad),
+            np.sin(2.0 * np.pi * cor_lc.time.value / ret_period),
+            np.cos(2.0 * np.pi * cor_lc.time.value / ret_period),
+        ]
+    ).T
+    ATA = np.dot(design_matrix.T, design_matrix / cor_lc.flux_err[:, None] ** 2)
+    least_squares_coeffs = np.linalg.solve(
+        ATA, np.dot(design_matrix.T, cor_lc.flux / cor_lc.flux_err ** 2)
+    )
     const, sin_weight, cos_weight = least_squares_coeffs
 
-    fractional_amplitude = (sin_weight**2+cos_weight**2)**(0.5) / const
-    assert ((fractional_amplitude > true_amplitude/1.1) &
-            (fractional_amplitude < true_amplitude*1.1) )
+    fractional_amplitude = (sin_weight ** 2 + cos_weight ** 2) ** (0.5) / const
+    assert (fractional_amplitude > true_amplitude / 1.1) & (
+        fractional_amplitude < true_amplitude * 1.1
+    )
 
 
 def test_transit_sff():
     """Can we recover a synthetic exoplanet signal using SFF and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header['PERIOD'])
-    true_rprs = np.float(tpf.hdu[3].header['RPRS'])
-    true_transit_lc = tpf.hdu[3].data['NOISELESS_INPUT']
-    max_depth = 1-np.min(true_transit_lc)
+    true_period = np.float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
+    max_depth = 1 - np.min(true_transit_lc)
 
     # Run the SFF algorithm
     lc = tpf.to_lightcurve().normalize()
     corrector = SFFCorrector(lc)
-    cor_lc = corrector.correct(tpf.pos_corr2, tpf.pos_corr1,
-                               niters=4, windows=1, bins=7, restore_trend=False, timescale=0.5)
+    cor_lc = corrector.correct(
+        tpf.pos_corr2,
+        tpf.pos_corr1,
+        niters=4,
+        windows=1,
+        bins=7,
+        restore_trend=False,
+        timescale=0.5,
+    )
 
     # Verify that we get the transit period within 5%
-    pg = cor_lc.to_periodogram(method='bls', minimum_period=1, maximum_period=9,
-                               frequency_factor=0.05, duration=np.arange(0.1, 0.6, 0.1))
+    pg = cor_lc.to_periodogram(
+        method="bls",
+        minimum_period=1,
+        maximum_period=9,
+        frequency_factor=0.05,
+        duration=np.arange(0.1, 0.6, 0.1),
+    )
     ret_period = pg.period_at_max_power.value
     threshold = 0.05
-    assert ((ret_period > true_period*(1-threshold)) &
-            (ret_period < true_period*(1+threshold)))
+    assert (ret_period > true_period * (1 - threshold)) & (
+        ret_period < true_period * (1 + threshold)
+    )
 
     # Verify that we get the transit depth in expected bounds
-    assert ((pg.depth_at_max_power >= true_rprs**2) &
-            (pg.depth_at_max_power < max_depth))
+    assert (pg.depth_at_max_power >= true_rprs ** 2) & (
+        pg.depth_at_max_power < max_depth
+    )
 
 
 def test_transit_pld():
     """Can we recover a synthetic exoplanet signal using PLD and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header['PERIOD'])
-    true_rprs = np.float(tpf.hdu[3].header['RPRS'])
-    true_transit_lc = tpf.hdu[3].data['NOISELESS_INPUT']
-    max_depth = 1-np.min(true_transit_lc)
+    true_period = np.float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
+    max_depth = 1 - np.min(true_transit_lc)
 
     # Run the PLD algorithm on a first pass
     corrector = PLDCorrector(tpf)
     cor_lc = corrector.correct()
-    pg = cor_lc.to_periodogram(method='bls', minimum_period=1, maximum_period=9,
-                               frequency_factor=0.05, duration=np.arange(0.1, 0.6, 0.1))
+    pg = cor_lc.to_periodogram(
+        method="bls",
+        minimum_period=1,
+        maximum_period=9,
+        frequency_factor=0.05,
+        duration=np.arange(0.1, 0.6, 0.1),
+    )
 
     # Re-do PLD with the suspected transits masked
     cor_lc = corrector.correct(cadence_mask=~pg.get_transit_mask()).normalize()
-    pg = cor_lc.to_periodogram(method='bls', minimum_period=1, maximum_period=9,
-                               frequency_factor=0.05, duration=np.arange(0.1, 0.6, 0.1))
+    pg = cor_lc.to_periodogram(
+        method="bls",
+        minimum_period=1,
+        maximum_period=9,
+        frequency_factor=0.05,
+        duration=np.arange(0.1, 0.6, 0.1),
+    )
 
     # Verify that we get the period within ~5%
     ret_period = pg.period_at_max_power.value
     threshold = 0.05
-    assert ((ret_period > true_period*(1-threshold)) &
-            (ret_period < true_period*(1+threshold)))
+    assert (ret_period > true_period * (1 - threshold)) & (
+        ret_period < true_period * (1 + threshold)
+    )
 
     # Verify that we get the transit depth in expected bounds
-    assert ((pg.depth_at_max_power >= true_rprs**2) &
-            (pg.depth_at_max_power < max_depth))
+    assert (pg.depth_at_max_power >= true_rprs ** 2) & (
+        pg.depth_at_max_power < max_depth
+    )
 
 
 def test_sine_pld():
     """Can we recover a synthetic sine wave using PLD and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header['PERIOD'])
-    true_amplitude = np.float(tpf.hdu[3].header['SINE_AMP'])
+    true_period = np.float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the PLD algorithm
-    corrector = tpf.to_corrector('pld')
+    corrector = tpf.to_corrector("pld")
     cor_lc = corrector.correct()
 
     # Verify that we get the period within ~20%
-    pg = cor_lc.to_periodogram(method='lombscargle', minimum_period=1,
-                               maximum_period=10, oversample_factor=10)
+    pg = cor_lc.to_periodogram(
+        method="lombscargle", minimum_period=1, maximum_period=10, oversample_factor=10
+    )
     ret_period = pg.period_at_max_power.value
     threshold = 0.2
-    assert ((ret_period > true_period*(1-threshold)) &
-            (ret_period < true_period*(1+threshold)) )
+    assert (ret_period > true_period * (1 - threshold)) & (
+        ret_period < true_period * (1 + threshold)
+    )
 
     # Verify that we get the amplitude to within 20%
     n_cad = len(tpf.time)
-    design_matrix = np.vstack([np.ones(n_cad),
-                              np.sin(2.0*np.pi*cor_lc.time.value/ret_period),
-                              np.cos(2.0*np.pi*cor_lc.time.value/ret_period)]).T
-    ATA = np.dot(design_matrix.T,  design_matrix / cor_lc.flux_err[:, None]**2)
-    least_squares_coeffs = np.linalg.solve(ATA, np.dot(design_matrix.T, cor_lc.flux/cor_lc.flux_err**2 ))
+    design_matrix = np.vstack(
+        [
+            np.ones(n_cad),
+            np.sin(2.0 * np.pi * cor_lc.time.value / ret_period),
+            np.cos(2.0 * np.pi * cor_lc.time.value / ret_period),
+        ]
+    ).T
+    ATA = np.dot(design_matrix.T, design_matrix / cor_lc.flux_err[:, None] ** 2)
+    least_squares_coeffs = np.linalg.solve(
+        ATA, np.dot(design_matrix.T, cor_lc.flux / cor_lc.flux_err ** 2)
+    )
     const, sin_weight, cos_weight = least_squares_coeffs
 
-    fractional_amplitude = (sin_weight**2+cos_weight**2)**(0.5) / const
-    assert ((fractional_amplitude > true_amplitude/1.1) &
-            (fractional_amplitude < true_amplitude*1.1) )
+    fractional_amplitude = (sin_weight ** 2 + cos_weight ** 2) ** (0.5) / const
+    assert (fractional_amplitude > true_amplitude / 1.1) & (
+        fractional_amplitude < true_amplitude * 1.1
+    )
 
 
 def test_detrending_residuals():
@@ -153,8 +210,9 @@ def test_detrending_residuals():
     # Run the SFF algorithm
     lc = tpf.to_lightcurve()
     corrector = SFFCorrector(lc)
-    cor_lc = corrector.correct(tpf.pos_corr2, tpf.pos_corr1,
-                               niters=10, windows=5, bins=7, restore_trend=True)
+    cor_lc = corrector.correct(
+        tpf.pos_corr2, tpf.pos_corr1, niters=10, windows=5, bins=7, restore_trend=True
+    )
 
     # Verify that we get a significant reduction in RMS
     cdpp_improvement = lc.estimate_cdpp() / cor_lc.estimate_cdpp()
@@ -164,22 +222,22 @@ def test_detrending_residuals():
     # Table 4.1 of Ivezic, Connolly, Vanerplas, Gray 2014
     anderson_threshold = 1.57
 
-    resid_n_sigmas = (cor_lc.flux - np.mean(cor_lc.flux))/cor_lc.flux_err
+    resid_n_sigmas = (cor_lc.flux - np.mean(cor_lc.flux)) / cor_lc.flux_err
     A_value, _, _ = stats.anderson(resid_n_sigmas)
-    assert A_value**2 < anderson_threshold
+    assert A_value ** 2 < anderson_threshold
 
     n_sigma = np.std(resid_n_sigmas)
     assert n_sigma < 2.0
 
-    corrector = tpf.to_corrector('pld')
+    corrector = tpf.to_corrector("pld")
     cor_lc = corrector.correct(restore_trend=False)
 
-    cdpp_improvement = lc.estimate_cdpp()/cor_lc.estimate_cdpp()
+    cdpp_improvement = lc.estimate_cdpp() / cor_lc.estimate_cdpp()
     assert cdpp_improvement > 10.0
 
-    resid_n_sigmas = (cor_lc.flux - np.mean(cor_lc.flux))/cor_lc.flux_err
+    resid_n_sigmas = (cor_lc.flux - np.mean(cor_lc.flux)) / cor_lc.flux_err
     A_value, crit, sig = stats.anderson(resid_n_sigmas)
-    assert A_value**2 < anderson_threshold
+    assert A_value ** 2 < anderson_threshold
 
     n_sigma = np.std(resid_n_sigmas)
     assert n_sigma < 2.0
@@ -187,14 +245,17 @@ def test_detrending_residuals():
 
 def test_centroids():
     """Test the estimate centroid method."""
-    for fn in (filename_synthetic_sine, filename_synthetic_transit,
-               filename_synthetic_flat):
+    for fn in (
+        filename_synthetic_sine,
+        filename_synthetic_transit,
+        filename_synthetic_flat,
+    ):
         tpf = KeplerTargetPixelFile(fn)
         xraw, yraw = tpf.estimate_centroids()
         xnorm = xraw - np.median(xraw)
         ynorm = yraw - np.median(yraw)
         xposc = tpf.pos_corr2 - np.median(tpf.pos_corr2)
         yposc = tpf.pos_corr1 - np.median(tpf.pos_corr1)
-        rmax = np.max(np.sqrt((xnorm.value-xposc)**2 + (ynorm.value-yposc)**2))
+        rmax = np.max(np.sqrt((xnorm.value - xposc) ** 2 + (ynorm.value - yposc) ** 2))
         # The centroids should agree to within a hundredth of a pixel.
         assert rmax < 0.01

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -29,24 +29,30 @@ filename_tpf_all_zeros = get_pkg_data_filename("data/test-tpf-all-zeros.fits")
 filename_tpf_one_center = get_pkg_data_filename("data/test-tpf-non-zero-center.fits")
 filename_tess = get_pkg_data_filename("data/tess25155310-s01-first-cadences.fits.gz")
 
-TABBY_Q8 = ("https://archive.stsci.edu/missions/kepler/lightcurves"
-            "/0084/008462852/kplr008462852-2011073133259_llc.fits")
-TABBY_TPF = ("https://archive.stsci.edu/missions/kepler/target_pixel_files"
-             "/0084/008462852/kplr008462852-2011073133259_lpd-targ.fits.gz")
-TESS_SIM = ("https://archive.stsci.edu/missions/tess/ete-6/tid/00/000"
-            "/004/176/tess2019128220341-0000000417699452-0016-s_tp.fits")
+TABBY_Q8 = (
+    "https://archive.stsci.edu/missions/kepler/lightcurves"
+    "/0084/008462852/kplr008462852-2011073133259_llc.fits"
+)
+TABBY_TPF = (
+    "https://archive.stsci.edu/missions/kepler/target_pixel_files"
+    "/0084/008462852/kplr008462852-2011073133259_lpd-targ.fits.gz"
+)
+TESS_SIM = (
+    "https://archive.stsci.edu/missions/tess/ete-6/tid/00/000"
+    "/004/176/tess2019128220341-0000000417699452-0016-s_tp.fits"
+)
 asteroid_TPF = get_pkg_data_filename("data/asteroid_test.fits")
 
 
 @pytest.mark.remote_data
 def test_load_bad_file():
-    '''Test if a light curve can be opened without exception.'''
+    """Test if a light curve can be opened without exception."""
     with pytest.raises(ValueError) as exc:
         KeplerTargetPixelFile(TABBY_Q8)
-    assert('is this a target pixel file?' in exc.value.args[0])
+    assert "is this a target pixel file?" in exc.value.args[0]
     with pytest.raises(ValueError) as exc:
         TessTargetPixelFile(TABBY_Q8)
-    assert('is this a target pixel file?' in exc.value.args[0])
+    assert "is this a target pixel file?" in exc.value.args[0]
 
 
 def test_tpf_shapes():
@@ -54,10 +60,12 @@ def test_tpf_shapes():
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]
+        tpfs = [
+            KeplerTargetPixelFile(filename_tpf_all_zeros),
+            TessTargetPixelFile(filename_tpf_all_zeros),
+        ]
     for tpf in tpfs:
-        assert tpf.quality_mask.shape == tpf.hdu[1].data['TIME'].shape
+        assert tpf.quality_mask.shape == tpf.hdu[1].data["TIME"].shape
         assert tpf.flux.shape == tpf.flux_err.shape
 
 
@@ -66,8 +74,10 @@ def test_tpf_math():
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tpf_all_zeros)]
+        tpfs = [
+            KeplerTargetPixelFile(filename_tpf_all_zeros),
+            TessTargetPixelFile(filename_tpf_all_zeros),
+        ]
 
         # These should work
         for tpf in tpfs:
@@ -84,18 +94,38 @@ def test_tpf_math():
 
         # These should fail with a value error because their shape is wrong.
         for tpf in tpfs:
-            for other in [np.asarray([1, 2]), np.arange(len(tpf.time) - 1),
-                          np.ones([100, 1]), np.ones([1, 2, 3])]:
+            for other in [
+                np.asarray([1, 2]),
+                np.arange(len(tpf.time) - 1),
+                np.ones([100, 1]),
+                np.ones([1, 2, 3]),
+            ]:
                 with pytest.raises(ValueError):
                     tpf + other
 
         # Check the values are correct
-        assert np.all(((tpf.flux.value + 2) == (tpf + 2).flux.value)[np.isfinite(tpf.flux)])
-        assert np.all(((tpf.flux.value - 2) == (tpf - 2).flux.value)[np.isfinite(tpf.flux)])
-        assert np.all(((tpf.flux.value * 2) == (tpf * 2).flux.value)[np.isfinite(tpf.flux)])
-        assert np.all(((tpf.flux.value / 2) == (tpf / 2).flux.value)[np.isfinite(tpf.flux)])
-        assert np.all(((tpf.flux_err.value * 2) == (tpf * 2).flux_err.value)[np.isfinite(tpf.flux)])
-        assert np.all(((tpf.flux_err.value / 2) == (tpf / 2).flux_err.value)[np.isfinite(tpf.flux)])
+        assert np.all(
+            ((tpf.flux.value + 2) == (tpf + 2).flux.value)[np.isfinite(tpf.flux)]
+        )
+        assert np.all(
+            ((tpf.flux.value - 2) == (tpf - 2).flux.value)[np.isfinite(tpf.flux)]
+        )
+        assert np.all(
+            ((tpf.flux.value * 2) == (tpf * 2).flux.value)[np.isfinite(tpf.flux)]
+        )
+        assert np.all(
+            ((tpf.flux.value / 2) == (tpf / 2).flux.value)[np.isfinite(tpf.flux)]
+        )
+        assert np.all(
+            ((tpf.flux_err.value * 2) == (tpf * 2).flux_err.value)[
+                np.isfinite(tpf.flux)
+            ]
+        )
+        assert np.all(
+            ((tpf.flux_err.value / 2) == (tpf / 2).flux_err.value)[
+                np.isfinite(tpf.flux)
+            ]
+        )
 
 
 def test_tpf_plot():
@@ -103,12 +133,14 @@ def test_tpf_plot():
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]
+        tpfs = [
+            KeplerTargetPixelFile(filename_tpf_one_center),
+            TessTargetPixelFile(filename_tpf_one_center),
+        ]
     for tpf in tpfs:
         tpf.plot()
         tpf.plot(aperture_mask=tpf.pipeline_mask)
-        tpf.plot(aperture_mask='all')
+        tpf.plot(aperture_mask="all")
         tpf.plot(frame=3)
         with pytest.raises(ValueError):
             tpf.plot(frame=999999)
@@ -120,16 +152,16 @@ def test_tpf_plot():
         tpf.plot(scale="log")
         with pytest.raises(ValueError):
             tpf.plot(scale="blabla")
-        tpf.plot(column='FLUX')
-        tpf.plot(column='FLUX_ERR')
-        tpf.plot(column='FLUX_BKG')
-        tpf.plot(column='FLUX_BKG_ERR')
-        tpf.plot(column='RAW_CNTS')
-        tpf.plot(column='COSMIC_RAYS')
+        tpf.plot(column="FLUX")
+        tpf.plot(column="FLUX_ERR")
+        tpf.plot(column="FLUX_BKG")
+        tpf.plot(column="FLUX_BKG_ERR")
+        tpf.plot(column="RAW_CNTS")
+        tpf.plot(column="COSMIC_RAYS")
         with pytest.raises(ValueError):
-            tpf.plot(column='not a column')
+            tpf.plot(column="not a column")
 
-        plt.close('all')
+        plt.close("all")
 
 
 def test_tpf_zeros():
@@ -140,16 +172,19 @@ def test_tpf_zeros():
         warnings.simplefilter("ignore", LightkurveWarning)
         lc = tpf.to_lightcurve()
     # If you don't mask out bad data, time contains NaNs
-    assert np.any(lc.time.value != tpf.time)  # Using the property that NaN does not equal NaN
+    assert np.any(
+        lc.time.value != tpf.time
+    )  # Using the property that NaN does not equal NaN
     # When you do mask out bad data everything should work.
     assert (tpf.time.value == 0).any()
-    tpf = KeplerTargetPixelFile(filename_tpf_all_zeros, quality_bitmask='hard')
+    tpf = KeplerTargetPixelFile(filename_tpf_all_zeros, quality_bitmask="hard")
     lc = tpf.to_lightcurve(aperture_mask="all")
     assert len(lc.time) == len(lc.flux)
     assert np.all(lc.time == tpf.time)
-    assert np.all(np.isnan(lc.flux)) # we expect all NaNs because of #874
+    assert np.all(np.isnan(lc.flux))  # we expect all NaNs because of #874
     # The default QUALITY bitmask should have removed all NaNs in the TIME
     assert ~np.any(np.isnan(tpf.time.value))
+
 
 @pytest.mark.parametrize("centroid_method", [("moments"), ("quadratic")])
 def test_tpf_ones(centroid_method):
@@ -157,24 +192,41 @@ def test_tpf_ones(centroid_method):
     with warnings.catch_warnings():
         # Ignore the "TELESCOP is not equal to TESS" warning
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpfs = [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tpf_one_center)]
+        tpfs = [
+            KeplerTargetPixelFile(filename_tpf_one_center),
+            TessTargetPixelFile(filename_tpf_one_center),
+        ]
     for tpf in tpfs:
-        lc = tpf.to_lightcurve(aperture_mask='all', centroid_method=centroid_method)
+        lc = tpf.to_lightcurve(aperture_mask="all", centroid_method=centroid_method)
         assert np.all(lc.flux.value == 1)
-        assert np.all((lc.centroid_col.value < tpf.column+tpf.shape[1]).all()
-                      * (lc.centroid_col.value > tpf.column).all())
-        assert np.all((lc.centroid_row.value < tpf.row+tpf.shape[2]).all()
-                      * (lc.centroid_row.value > tpf.row).all())
+        assert np.all(
+            (lc.centroid_col.value < tpf.column + tpf.shape[1]).all()
+            * (lc.centroid_col.value > tpf.column).all()
+        )
+        assert np.all(
+            (lc.centroid_row.value < tpf.row + tpf.shape[2]).all()
+            * (lc.centroid_row.value > tpf.row).all()
+        )
 
 
-@pytest.mark.parametrize("quality_bitmask,answer", [(None, 1290), ('none', 1290),
-                                                    ('default', 1233),
-                                                    ('hard', 1101), ('hardest', 1101),
-                                                    (1, 1290), (100, 1278), (2096639, 1101)])
+@pytest.mark.parametrize(
+    "quality_bitmask,answer",
+    [
+        (None, 1290),
+        ("none", 1290),
+        ("default", 1233),
+        ("hard", 1101),
+        ("hardest", 1101),
+        (1, 1290),
+        (100, 1278),
+        (2096639, 1101),
+    ],
+)
 def test_bitmasking(quality_bitmask, answer):
     """Test whether the bitmasking behaves like it should"""
-    tpf = KeplerTargetPixelFile(filename_tpf_one_center, quality_bitmask=quality_bitmask)
+    tpf = KeplerTargetPixelFile(
+        filename_tpf_one_center, quality_bitmask=quality_bitmask
+    )
     with warnings.catch_warnings():
         # Ignore "LightCurve contains NaN times" warnings triggered by liberal masks
         warnings.simplefilter("ignore", LightkurveWarning)
@@ -184,19 +236,21 @@ def test_bitmasking(quality_bitmask, answer):
 
 def test_wcs():
     """Test the wcs property."""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_one_center),
+        TessTargetPixelFile(filename_tess),
+    ]:
         w = tpf.wcs
         ra, dec = tpf.get_coordinates()
         assert ra.shape == tpf.shape
         assert dec.shape == tpf.shape
-        assert type(w).__name__ == 'WCS'
+        assert type(w).__name__ == "WCS"
 
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize("method", [("moments"), ("quadratic")])
 def test_wcs_tabby(method):
-    '''Test the centroids from Tabby's star against simbad values'''
+    """Test the centroids from Tabby's star against simbad values"""
     tpf = KeplerTargetPixelFile(TABBY_TPF)
     tpf.wcs
     ra, dec = tpf.get_coordinates(0)
@@ -212,82 +266,102 @@ def test_wcs_tabby(method):
 def test_centroid_methods_consistency():
     """Are the centroid methods consistent for a well behaved target?"""
     pixels = read(filename_synthetic_flat)
-    centr_moments = pixels.estimate_centroids(method='moments')
-    centr_quadratic = pixels.estimate_centroids(method='quadratic')
+    centr_moments = pixels.estimate_centroids(method="moments")
+    centr_quadratic = pixels.estimate_centroids(method="quadratic")
     # check that the maximum relative difference doesnt exceed 1%
-    assert np.max(np.abs(centr_moments[0] - centr_quadratic[0]) / centr_moments[0]) < 1e-2
-    assert np.max(np.abs(centr_moments[1] - centr_quadratic[1]) / centr_moments[1]) < 1e-2
+    assert (
+        np.max(np.abs(centr_moments[0] - centr_quadratic[0]) / centr_moments[0]) < 1e-2
+    )
+    assert (
+        np.max(np.abs(centr_moments[1] - centr_quadratic[1]) / centr_moments[1]) < 1e-2
+    )
 
 
 def test_properties():
     """Test the short-hand properties."""
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
-    assert(tpf.channel == tpf.hdu[0].header['CHANNEL'])
-    assert(tpf.module == tpf.hdu[0].header['MODULE'])
-    assert(tpf.output == tpf.hdu[0].header['OUTPUT'])
-    assert(tpf.ra == tpf.hdu[0].header['RA_OBJ'])
-    assert(tpf.dec == tpf.hdu[0].header['DEC_OBJ'])
-    assert_array_equal(tpf.flux.value, tpf.hdu[1].data['FLUX'][tpf.quality_mask])
-    assert_array_equal(tpf.flux_err.value, tpf.hdu[1].data['FLUX_ERR'][tpf.quality_mask])
-    assert_array_equal(tpf.flux_bkg.value, tpf.hdu[1].data['FLUX_BKG'][tpf.quality_mask])
-    assert_array_equal(tpf.flux_bkg_err.value, tpf.hdu[1].data['FLUX_BKG_ERR'][tpf.quality_mask])
-    assert_array_equal(tpf.quality, tpf.hdu[1].data['QUALITY'][tpf.quality_mask])
-    assert(tpf.campaign == tpf.hdu[0].header['CAMPAIGN'])
-    assert(tpf.quarter is None)
+    assert tpf.channel == tpf.hdu[0].header["CHANNEL"]
+    assert tpf.module == tpf.hdu[0].header["MODULE"]
+    assert tpf.output == tpf.hdu[0].header["OUTPUT"]
+    assert tpf.ra == tpf.hdu[0].header["RA_OBJ"]
+    assert tpf.dec == tpf.hdu[0].header["DEC_OBJ"]
+    assert_array_equal(tpf.flux.value, tpf.hdu[1].data["FLUX"][tpf.quality_mask])
+    assert_array_equal(
+        tpf.flux_err.value, tpf.hdu[1].data["FLUX_ERR"][tpf.quality_mask]
+    )
+    assert_array_equal(
+        tpf.flux_bkg.value, tpf.hdu[1].data["FLUX_BKG"][tpf.quality_mask]
+    )
+    assert_array_equal(
+        tpf.flux_bkg_err.value, tpf.hdu[1].data["FLUX_BKG_ERR"][tpf.quality_mask]
+    )
+    assert_array_equal(tpf.quality, tpf.hdu[1].data["QUALITY"][tpf.quality_mask])
+    assert tpf.campaign == tpf.hdu[0].header["CAMPAIGN"]
+    assert tpf.quarter is None
 
 
 def test_repr():
     """Do __str__ and __repr__ work?"""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_all_zeros),
+        TessTargetPixelFile(filename_tess),
+    ]:
         str(tpf)
         repr(tpf)
 
 
 def test_to_lightcurve():
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_all_zeros),
+        TessTargetPixelFile(filename_tess),
+    ]:
         tpf.to_lightcurve()
         tpf.to_lightcurve(aperture_mask=None)
-        tpf.to_lightcurve(aperture_mask='all')
-        lc = tpf.to_lightcurve(aperture_mask='threshold')
-        assert lc.time.scale == 'tdb'
-        assert lc.label == tpf.hdu[0].header['OBJECT']
+        tpf.to_lightcurve(aperture_mask="all")
+        lc = tpf.to_lightcurve(aperture_mask="threshold")
+        assert lc.time.scale == "tdb"
+        assert lc.label == tpf.hdu[0].header["OBJECT"]
         if np.any(tpf.pipeline_mask):
-            tpf.to_lightcurve(aperture_mask='pipeline')
+            tpf.to_lightcurve(aperture_mask="pipeline")
         else:
             with pytest.raises(ValueError):
-                tpf.to_lightcurve(aperture_mask='pipeline')
+                tpf.to_lightcurve(aperture_mask="pipeline")
 
 
 def test_bkg_lightcurve():
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_all_zeros),
+        TessTargetPixelFile(filename_tess),
+    ]:
         lc = tpf.get_bkg_lightcurve()
         lc = tpf.get_bkg_lightcurve(aperture_mask=None)
-        lc = tpf.get_bkg_lightcurve(aperture_mask='all')
-        assert lc.time.scale == 'tdb'
+        lc = tpf.get_bkg_lightcurve(aperture_mask="all")
+        assert lc.time.scale == "tdb"
         assert lc.flux.shape == lc.flux_err.shape
         assert len(lc.time) == len(lc.flux)
 
 
 def test_aperture_photometry():
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_all_zeros),
+        TessTargetPixelFile(filename_tess),
+    ]:
         tpf.extract_aperture_photometry()
-        for mask in [None, 'all', 'default', 'threshold', 'background']:
+        for mask in [None, "all", "default", "threshold", "background"]:
             tpf.extract_aperture_photometry(aperture_mask=mask)
         if np.any(tpf.pipeline_mask):
-            tpf.extract_aperture_photometry(aperture_mask='pipeline')
+            tpf.extract_aperture_photometry(aperture_mask="pipeline")
         else:
             with pytest.raises(ValueError):
-                tpf.extract_aperture_photometry(aperture_mask='pipeline')
+                tpf.extract_aperture_photometry(aperture_mask="pipeline")
 
 
 def test_tpf_to_fits():
     """Can we write a TPF back to a fits file?"""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_all_zeros),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_all_zeros),
+        TessTargetPixelFile(filename_tess),
+    ]:
         # `delete=False` is necessary to enable writing to the file on Windows
         # but it means we have to clean up the tmp file ourselves
         tmp = tempfile.NamedTemporaryFile(delete=False)
@@ -304,57 +378,65 @@ def test_tpf_factory():
 
     factory = TargetPixelFileFactory(n_cadences=10, n_rows=6, n_cols=8)
     flux_0 = np.ones((6, 8))
-    factory.add_cadence(frameno=0, flux=flux_0,
-                        header={'TSTART': 0, 'TSTOP': 10})
+    factory.add_cadence(frameno=0, flux=flux_0, header={"TSTART": 0, "TSTOP": 10})
     flux_9 = 3 * np.ones((6, 8))
-    factory.add_cadence(frameno=9, flux=flux_9,
-                        header={'TSTART': 90, 'TSTOP': 100})
+    factory.add_cadence(frameno=9, flux=flux_9, header={"TSTART": 90, "TSTOP": 100})
 
     # You shouldn't be able to build a TPF like this...because TPFs shouldn't
     # have extensions where time stamps are duplicated (here frames 1-8 will have)
     # time stamp zero
-    with pytest.warns(LightkurveWarning, match='identical TIME values'):
+    with pytest.warns(LightkurveWarning, match="identical TIME values"):
         tpf = factory.get_tpf()
-    [factory.add_cadence(frameno=i, flux=flux_0,
-                         header={'TSTART': i*10, 'TSTOP': (i*10)+10})
-     for i in np.arange(2, 9)]
+    [
+        factory.add_cadence(
+            frameno=i, flux=flux_0, header={"TSTART": i * 10, "TSTOP": (i * 10) + 10}
+        )
+        for i in np.arange(2, 9)
+    ]
 
     # This should fail because the time stamps of the images are not in order...
-    with pytest.warns(LightkurveWarning, match='chronological order'):
+    with pytest.warns(LightkurveWarning, match="chronological order"):
         tpf = factory.get_tpf()
 
-    [factory.add_cadence(frameno=i, flux=flux_0,
-                         header={'TSTART': i*10, 'TSTOP': (i*10)+10})
-     for i in np.arange(1, 9)]
+    [
+        factory.add_cadence(
+            frameno=i, flux=flux_0, header={"TSTART": i * 10, "TSTOP": (i * 10) + 10}
+        )
+        for i in np.arange(1, 9)
+    ]
 
     # This should pass
-    tpf = factory.get_tpf(hdu0_keywords={'TELESCOP':'TESS'})
+    tpf = factory.get_tpf(hdu0_keywords={"TELESCOP": "TESS"})
 
     assert_array_equal(tpf.flux[0].value, flux_0)
     assert_array_equal(tpf.flux[9].value, flux_9)
 
-    tpf = factory.get_tpf(hdu0_keywords={'TELESCOP':'Kepler'})
+    tpf = factory.get_tpf(hdu0_keywords={"TELESCOP": "Kepler"})
 
     assert_array_equal(tpf.flux[0].value, flux_0)
     assert_array_equal(tpf.flux[9].value, flux_9)
-    assert(tpf.time[0].value == 5)
-    assert(tpf.time[9].value == 95)
+    assert tpf.time[0].value == 5
+    assert tpf.time[9].value == 95
 
     # Can you add the WRONG sized frame?
     flux_wrong = 3 * np.ones((6, 9))
     with pytest.raises(FactoryError):
-        factory.add_cadence(frameno=2, flux=flux_wrong,
-                            header={'TSTART': 90, 'TSTOP': 100})
+        factory.add_cadence(
+            frameno=2, flux=flux_wrong, header={"TSTART": 90, "TSTOP": 100}
+        )
 
     # Can you add the WRONG cadence?
     flux_wrong = 3 * np.ones((6, 8))
     with pytest.raises(FactoryError):
-        factory.add_cadence(frameno=11, flux=flux_wrong,
-                            header={'TSTART': 90, 'TSTOP': 100})
+        factory.add_cadence(
+            frameno=11, flux=flux_wrong, header={"TSTART": 90, "TSTOP": 100}
+        )
 
     # Can we add our own keywords?
-    tpf = factory.get_tpf(hdu0_keywords={'creator': 'Christina TargetPixelFileWriter', 'TELESCOP':'TESS'})
-    assert tpf.get_keyword('CREATOR') == 'Christina TargetPixelFileWriter'
+    tpf = factory.get_tpf(
+        hdu0_keywords={"creator": "Christina TargetPixelFileWriter", "TELESCOP": "TESS"}
+    )
+    assert tpf.get_keyword("CREATOR") == "Christina TargetPixelFileWriter"
 
 
 def _create_image_array(header=None, shape=(5, 5)):
@@ -363,17 +445,21 @@ def _create_image_array(header=None, shape=(5, 5)):
         header = fits.Header()
     images = []
     for i in range(5):
-        header['TSTART'] = i
-        header['TSTOP'] = i + 1
+        header["TSTART"] = i
+        header["TSTOP"] = i + 1
         images.append(fits.ImageHDU(data=np.ones(shape), header=header))
     return images
+
 
 def test_tpf_from_images():
     """Basic tests of tpf.from_fits_images()"""
     # Not without a wcs...
     with pytest.raises(Exception):
-        TargetPixelFile.from_fits_images(_create_image_array(), size=(3, 3),
-                                         position=SkyCoord(-234.75, 8.3393, unit='deg'))
+        TargetPixelFile.from_fits_images(
+            _create_image_array(),
+            size=(3, 3),
+            position=SkyCoord(-234.75, 8.3393, unit="deg"),
+        )
 
     # Make a fake WCS based on astropy.docs...
     w = wcs.WCS(naxis=2)
@@ -384,20 +470,19 @@ def test_tpf_from_images():
     w.wcs.set_pv([(2, 1, 45.0)])
     pixcrd = np.array([[0, 0], [24, 38], [45, 98]], np.float_)
     header = w.to_header()
-    header['CRVAL1P'] = 10
-    header['CRVAL2P'] = 20
+    header["CRVAL1P"] = 10
+    header["CRVAL2P"] = 20
     ra, dec = 268.21686048, -73.66991904
 
     # Now this should work.
     images = _create_image_array(header=header)
     with warnings.catch_warnings():
-        # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead." 
+        # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead."
         warnings.simplefilter("ignore", LightkurveWarning)
-        tpf = TargetPixelFile.from_fits_images(images,
-                                               size=(3, 3),
-                                               position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
+        tpf = TargetPixelFile.from_fits_images(
+            images, size=(3, 3), position=SkyCoord(ra, dec, unit=(u.deg, u.deg))
+        )
         assert isinstance(tpf, TargetPixelFile)
-
 
     with warnings.catch_warnings():
         # Some cards are too long -- to be investigated.
@@ -423,17 +508,19 @@ def test_tpf_from_images():
             hdus.append(hdu)
 
         with warnings.catch_warnings():
-            # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead." 
+            # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead."
             warnings.simplefilter("ignore", LightkurveWarning)
             # Should be able to run with a list of file names
-            tpf_tmpfiles = TargetPixelFile.from_fits_images(tmpfile_names,
-                                size=(3, 3),
-                                position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
+            tpf_tmpfiles = TargetPixelFile.from_fits_images(
+                tmpfile_names,
+                size=(3, 3),
+                position=SkyCoord(ra, dec, unit=(u.deg, u.deg)),
+            )
 
             # Should be able to run with a list of HDUlists
-            tpf_hdus = TargetPixelFile.from_fits_images(hdus,
-                                size=(3, 3),
-                                position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
+            tpf_hdus = TargetPixelFile.from_fits_images(
+                hdus, size=(3, 3), position=SkyCoord(ra, dec, unit=(u.deg, u.deg))
+            )
 
         # Clean up the temporary files we created
         for filename in tmpfile_names:
@@ -447,42 +534,48 @@ def test_tpf_wcs_from_images():
     """Test to see if tpf.from_fits_images() output a tpf with WCS in the header"""
     # Not without a wcs...
     with pytest.raises(Exception):
-        TargetPixelFile.from_fits_images(_create_image_array(), size=(3, 3),
-                                               position=SkyCoord(-234.75, 8.3393, unit='deg'))
+        TargetPixelFile.from_fits_images(
+            _create_image_array(),
+            size=(3, 3),
+            position=SkyCoord(-234.75, 8.3393, unit="deg"),
+        )
 
     # Make a fake WCS based on astropy.docs...
     w = wcs.WCS(naxis=2)
-    w.wcs.crpix = [0., 0.]
+    w.wcs.crpix = [0.0, 0.0]
     w.wcs.cdelt = np.array([0.001111, 0.001111])
     w.wcs.crval = [23.2334, 45.2333]
     w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
     header = w.to_header()
-    header['CRVAL1P'] = 10
-    header['CRVAL2P'] = 20
+    header["CRVAL1P"] = 10
+    header["CRVAL2P"] = 20
     ra, dec = 23.2336, 45.235
 
     with warnings.catch_warnings():
-        # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead." 
+        # Ignore "LightkurveWarning: Could not detect filetype as TESSTargetPixelFile or KeplerTargetPixelFile, returning generic TargetPixelFile instead."
         warnings.simplefilter("ignore", LightkurveWarning)
         # Now this should work.
-        tpf = TargetPixelFile.from_fits_images(_create_image_array(header=header), size=(3, 3),
-                                               position=SkyCoord(ra, dec, unit=(u.deg, u.deg)))
-    assert tpf.hdu[1].header['1CRPX5'] != UNDEFINED
-    assert tpf.hdu[1].header['1CTYP5'] == 'RA---TAN'
-    assert tpf.hdu[1].header['2CTYP5'] == 'DEC--TAN'
-    assert tpf.hdu[1].header['1CRPX5'] != UNDEFINED
-    assert tpf.hdu[1].header['2CRPX5'] != UNDEFINED
-    assert tpf.hdu[1].header['1CUNI5'] == 'deg'
-    assert tpf.hdu[1].header['2CUNI5'] == 'deg'
+        tpf = TargetPixelFile.from_fits_images(
+            _create_image_array(header=header),
+            size=(3, 3),
+            position=SkyCoord(ra, dec, unit=(u.deg, u.deg)),
+        )
+    assert tpf.hdu[1].header["1CRPX5"] != UNDEFINED
+    assert tpf.hdu[1].header["1CTYP5"] == "RA---TAN"
+    assert tpf.hdu[1].header["2CTYP5"] == "DEC--TAN"
+    assert tpf.hdu[1].header["1CRPX5"] != UNDEFINED
+    assert tpf.hdu[1].header["2CRPX5"] != UNDEFINED
+    assert tpf.hdu[1].header["1CUNI5"] == "deg"
+    assert tpf.hdu[1].header["2CUNI5"] == "deg"
     with warnings.catch_warnings():
         # Ignore the warning: "PC1_1 = a floating-point value was expected."
         warnings.simplefilter("ignore", AstropyWarning)
-        assert tpf.wcs.to_header()['CDELT1'] == w.wcs.cdelt[0]
+        assert tpf.wcs.to_header()["CDELT1"] == w.wcs.cdelt[0]
 
 
 def test_properties2(capfd):
-    '''Test if the describe function produces an output.
-    The output is 1870 characters at the moment, but we might add more properties.'''
+    """Test if the describe function produces an output.
+    The output is 1870 characters at the moment, but we might add more properties."""
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
     tpf.show_properties()
     out, err = capfd.readouterr()
@@ -491,16 +584,20 @@ def test_properties2(capfd):
 
 def test_interact():
     """Test the Jupyter notebook interact() widget."""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_one_center),
+        TessTargetPixelFile(filename_tess),
+    ]:
         tpf.interact()
 
 
 @pytest.mark.remote_data
 def test_interact_sky():
     """Test the Jupyter notebook interact() widget."""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tess)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_one_center),
+        TessTargetPixelFile(filename_tess),
+    ]:
         tpf.interact_sky()
 
 
@@ -518,8 +615,8 @@ def test_get_models():
 def test_tess_simulation():
     """Can we read simulated TESS data?"""
     tpf = TessTargetPixelFile(TESS_SIM)
-    assert tpf.mission == 'TESS'
-    assert tpf.time.scale == 'tdb'
+    assert tpf.mission == "TESS"
+    assert tpf.time.scale == "tdb"
     assert tpf.flux.shape == tpf.flux_err.shape
     tpf.wcs
     col, row = tpf.estimate_centroids()
@@ -530,16 +627,18 @@ def test_tess_simulation():
 def test_threshold_aperture_mask():
     """Does the threshold mask work?"""
     tpf = KeplerTargetPixelFile(filename_tpf_one_center)
-    tpf.plot(aperture_mask='threshold')
+    tpf.plot(aperture_mask="threshold")
     lc = tpf.to_lightcurve(aperture_mask=tpf.create_threshold_mask(threshold=1))
     assert (lc.flux.value == 1).all()
     # The TESS file shows three pixel regions above a 2-sigma threshold;
     # let's make sure the `reference_pixel` argument allows them to be selected.
     tpf = TessTargetPixelFile(filename_tess)
-    assert tpf.create_threshold_mask(threshold=2.).sum() == 25
-    assert tpf.create_threshold_mask(threshold=2., reference_pixel='center').sum() == 25
-    assert tpf.create_threshold_mask(threshold=2., reference_pixel=None).sum() == 28
-    assert tpf.create_threshold_mask(threshold=2., reference_pixel=(5, 0)).sum() == 2
+    assert tpf.create_threshold_mask(threshold=2.0).sum() == 25
+    assert (
+        tpf.create_threshold_mask(threshold=2.0, reference_pixel="center").sum() == 25
+    )
+    assert tpf.create_threshold_mask(threshold=2.0, reference_pixel=None).sum() == 28
+    assert tpf.create_threshold_mask(threshold=2.0, reference_pixel=(5, 0)).sum() == 2
     # A mask which contains zero-flux pixels should work without crashing
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
     assert tpf.create_threshold_mask().sum() == 9
@@ -548,7 +647,7 @@ def test_threshold_aperture_mask():
 def test_tpf_tess():
     """Does a TESS Sector 1 TPF work?"""
     tpf = TessTargetPixelFile(filename_tess, quality_bitmask=None)
-    assert tpf.mission == 'TESS'
+    assert tpf.mission == "TESS"
     assert tpf.targetid == 25155310
     assert tpf.sector == 1
     assert tpf.camera == 4
@@ -558,7 +657,7 @@ def test_tpf_tess():
     lc = tpf.to_lightcurve()
     assert isinstance(lc, TessLightCurve)
     assert_array_equal(lc.time, tpf.time)
-    assert tpf.time.scale == 'tdb'
+    assert tpf.time.scale == "tdb"
     assert tpf.flux.shape == tpf.flux_err.shape
     tpf.wcs
     col, row = tpf.estimate_centroids()
@@ -568,7 +667,7 @@ def test_tpf_tess():
 def test_tpf_slicing(tpf_type):
     """Test indexing and slicing of TargetPixelFile objects."""
     with warnings.catch_warnings():
-        # Ignore "LightkurveWarning: A Kepler data product is being opened using the `TessTargetPixelFile` class. Please use `KeplerTargetPixelFile` instead." 
+        # Ignore "LightkurveWarning: A Kepler data product is being opened using the `TessTargetPixelFile` class. Please use `KeplerTargetPixelFile` instead."
         warnings.simplefilter("ignore", LightkurveWarning)
         tpf = tpf_type(filename_tpf_one_center)
 
@@ -606,8 +705,10 @@ def test_get_keyword():
 
 def test_cutout():
     """Test tpf.cutout() function."""
-    for tpf in [KeplerTargetPixelFile(filename_tpf_one_center),
-                TessTargetPixelFile(filename_tess, quality_bitmask=None)]:
+    for tpf in [
+        KeplerTargetPixelFile(filename_tpf_one_center),
+        TessTargetPixelFile(filename_tess, quality_bitmask=None),
+    ]:
         ntpf = tpf.cutout(size=2)
         assert ntpf.flux[0].shape == (2, 2)
         assert ntpf.flux_err[0].shape == (2, 2)
@@ -616,10 +717,10 @@ def test_cutout():
         ntpf = tpf.cutout(size=(1, 2))
         assert ntpf.flux.shape[1] == 2
         assert ntpf.flux.shape[2] == 1
-        ntpf = tpf.cutout(SkyCoord(tpf.ra, tpf.dec, unit='deg'), size=2)
+        ntpf = tpf.cutout(SkyCoord(tpf.ra, tpf.dec, unit="deg"), size=2)
         ntpf = tpf.cutout(size=2)
         assert np.product(ntpf.flux.shape[1:]) == 4
-        assert ntpf.targetid == '{}_CUTOUT'.format(tpf.targetid)
+        assert ntpf.targetid == "{}_CUTOUT".format(tpf.targetid)
 
 
 def test_aperture_photometry_nan():
@@ -628,9 +729,9 @@ def test_aperture_photometry_nan():
     When FLUX or FLUX_ERR is entirely NaN in a TPF, the resulting light curve
     should report NaNs in that cadence rather than zero."""
     tpf = read(filename_tpf_one_center)
-    tpf.hdu[1].data['FLUX'][2] = np.nan
-    tpf.hdu[1].data['FLUX_ERR'][2] = np.nan
-    lc = tpf.to_lightcurve(aperture_mask='all')
+    tpf.hdu[1].data["FLUX"][2] = np.nan
+    tpf.hdu[1].data["FLUX_ERR"][2] = np.nan
+    lc = tpf.to_lightcurve(aperture_mask="all")
     assert ~np.isnan(lc.flux[1])
     assert ~np.isnan(lc.flux_err[1])
     assert np.isnan(lc.flux[2])
@@ -641,20 +742,28 @@ def test_aperture_photometry_nan():
 def test_SSOs():
     # TESS test
     tpf = TessTargetPixelFile(asteroid_TPF)
-    result = tpf.query_solar_system_objects() # default cadence_mask = 'outliers'
-    assert(result is None) # the TPF has only data for 1 epoch. The lone time is removed as outlier
-    result = tpf.query_solar_system_objects(cadence_mask='all', cache=False)
-    assert(len(result) == 1)
-    result = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
-    assert(len(result) == 1)
+    result = tpf.query_solar_system_objects()  # default cadence_mask = 'outliers'
+    assert (
+        result is None
+    )  # the TPF has only data for 1 epoch. The lone time is removed as outlier
+    result = tpf.query_solar_system_objects(cadence_mask="all", cache=False)
+    assert len(result) == 1
+    result = tpf.query_solar_system_objects(
+        cadence_mask=np.asarray([True]), cache=False
+    )
+    assert len(result) == 1
     result = tpf.query_solar_system_objects(cadence_mask=[True], cache=False)
-    assert(len(result) == 1)
+    assert len(result) == 1
     result = tpf.query_solar_system_objects(cadence_mask=(True), cache=False)
-    assert(len(result) == 1)
-    result, mask = tpf.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=True, return_mask=True)
-    assert(len(mask) == len(tpf.flux))
+    assert len(result) == 1
+    result, mask = tpf.query_solar_system_objects(
+        cadence_mask=np.asarray([True]), cache=True, return_mask=True
+    )
+    assert len(mask) == len(tpf.flux)
     try:
-        result = tpf.query_solar_system_objects(cadence_mask='str-not-supported', cache=False)
+        result = tpf.query_solar_system_objects(
+            cadence_mask="str-not-supported", cache=False
+        )
         pytest.fail("Unsupported cadence_mask should have thrown Error")
     except ValueError:
         pass
@@ -663,11 +772,11 @@ def test_SSOs():
 def test_get_header():
     """Test the basic functionality of ``tpf.get_header()``"""
     tpf = read(filename_tpf_one_center)
-    assert tpf.get_header()['CHANNEL'] == tpf.get_keyword("CHANNEL")
-    assert tpf.get_header(0)['MISSION'] == tpf.get_keyword("MISSION")
-    assert tpf.get_header(ext=2)['EXTNAME'] == "APERTURE"
+    assert tpf.get_header()["CHANNEL"] == tpf.get_keyword("CHANNEL")
+    assert tpf.get_header(0)["MISSION"] == tpf.get_keyword("MISSION")
+    assert tpf.get_header(ext=2)["EXTNAME"] == "APERTURE"
     # ``tpf.header`` is deprecated
-    with pytest.warns(LightkurveDeprecationWarning, match='deprecated'):
+    with pytest.warns(LightkurveDeprecationWarning, match="deprecated"):
         tpf.header
 
 
@@ -677,12 +786,12 @@ def test_plot_pixels():
     tpf.plot_pixels(normalize=True)
     tpf.plot_pixels(periodogram=True)
     tpf.plot_pixels(periodogram=True, nyquist_factor=0.5)
-    tpf.plot_pixels(aperture_mask='all')
+    tpf.plot_pixels(aperture_mask="all")
     tpf.plot_pixels(aperture_mask=tpf.pipeline_mask)
     tpf.plot_pixels(aperture_mask=tpf.create_threshold_mask())
     tpf.plot_pixels(show_flux=True)
-    tpf.plot_pixels(corrector_func=lambda x:x)
-    plt.close('all')
+    tpf.plot_pixels(corrector_func=lambda x: x)
+    plt.close("all")
 
 
 @pytest.mark.remote_data
@@ -695,19 +804,19 @@ def test_missing_pipeline_mask():
     tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=1)
     lc = tpf.to_lightcurve()
     assert np.isfinite(lc.flux).any()
-    assert lc.meta.get('APERTURE_MASK', None) == 'threshold'
+    assert lc.meta.get("APERTURE_MASK", None) == "threshold"
 
     with pytest.raises(ValueError):
         # if aperture_mask is explicitly set as pipeline,
         # the logic will throw an error as it is missing in the TPF
-        lc = tpf.to_lightcurve(aperture_mask='pipeline')
+        lc = tpf.to_lightcurve(aperture_mask="pipeline")
 
 
 def test_cutout_quality_masking():
     """Regression test for #813: Does tpf.cutout() maintain the quality mask?"""
     tpf = read(filename_tpf_one_center, quality_bitmask=8192)
     tpfcut = tpf.cutout()
-    assert(len(tpf) == len(tpfcut))
+    assert len(tpf) == len(tpfcut)
 
 
 def test_parse_numeric_aperture_masks():
@@ -715,31 +824,31 @@ def test_parse_numeric_aperture_masks():
     interpreted as boolean masks."""
     tpf = read(filename_tpf_one_center)
     mask = tpf._parse_aperture_mask(np.zeros(tpf.shape[1:], dtype=float))
-    assert(mask.dtype == bool)
+    assert mask.dtype == bool
     mask = tpf._parse_aperture_mask(np.zeros(tpf.shape[1:], dtype=int))
-    assert(mask.dtype == bool)
+    assert mask.dtype == bool
 
 
 def test_tpf_meta():
     """Can we access meta data using tpf.meta?"""
     tpf = read(filename_tpf_one_center)
-    assert tpf.meta.get('MISSION') == 'K2'
-    assert tpf.meta['MISSION'] == 'K2'
-    assert tpf.meta.get('mission', None) is None  # key is case in-sensitive
-    assert tpf.meta.get('CHANNEL') == 45
+    assert tpf.meta.get("MISSION") == "K2"
+    assert tpf.meta["MISSION"] == "K2"
+    assert tpf.meta.get("mission", None) is None  # key is case in-sensitive
+    assert tpf.meta.get("CHANNEL") == 45
     # ensure meta is read-only view of the underlying self.hdu[0].header
     with pytest.raises(TypeError):
-        tpf.meta['CHANNEL'] = 44
+        tpf.meta["CHANNEL"] = 44
     with pytest.raises(TypeError):
-        tpf.meta['KEY-NEW'] = 44
+        tpf.meta["KEY-NEW"] = 44
 
 
 def test_estimate_background():
     """Verifies tpf.estimate_background()."""
     # Create a TPF with 100 electron/second in every pixel
-    tpf = read(filename_tpf_all_zeros) + 100.
+    tpf = read(filename_tpf_all_zeros) + 100.0
     # The resulting background should be 100 e/s/pixel
-    bg = tpf.estimate_background(aperture_mask='all')
+    bg = tpf.estimate_background(aperture_mask="all")
     assert_array_equal(bg.flux.value, 100)
     assert bg.flux.unit == tpf.flux.unit / u.pixel
 
@@ -755,5 +864,3 @@ def test_fluxmode():
     assert lc_sum.flux.value[0] == np.nansum(tpf.flux.value[0])
     assert lc_med.flux.value[0] == np.nanmedian(tpf.flux.value[0])
     assert lc_mean.flux.value[0] == np.nanmean(tpf.flux.value[0])
-    
-    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,9 +47,15 @@ def test_quality_flag_decoding_kepler():
     for key, value in flags:
         assert KeplerQualityFlags.decode(key)[0] == value
     # Can we recover combinations of flags?
-    assert KeplerQualityFlags.decode(flags[5][0] + flags[7][0]) == [flags[5][1], flags[7][1]]
-    assert KeplerQualityFlags.decode(flags[3][0] + flags[4][0] + flags[5][0]) \
-        == [flags[3][1], flags[4][1], flags[5][1]]
+    assert KeplerQualityFlags.decode(flags[5][0] + flags[7][0]) == [
+        flags[5][1],
+        flags[7][1],
+    ]
+    assert KeplerQualityFlags.decode(flags[3][0] + flags[4][0] + flags[5][0]) == [
+        flags[3][1],
+        flags[4][1],
+        flags[5][1],
+    ]
 
 
 def test_quality_flag_decoding_tess():
@@ -58,9 +64,15 @@ def test_quality_flag_decoding_tess():
     for key, value in flags:
         assert TessQualityFlags.decode(key)[0] == value
     # Can we recover combinations of flags?
-    assert TessQualityFlags.decode(flags[5][0] + flags[7][0]) == [flags[5][1], flags[7][1]]
-    assert TessQualityFlags.decode(flags[3][0] + flags[4][0] + flags[5][0]) \
-        == [flags[3][1], flags[4][1], flags[5][1]]
+    assert TessQualityFlags.decode(flags[5][0] + flags[7][0]) == [
+        flags[5][1],
+        flags[7][1],
+    ]
+    assert TessQualityFlags.decode(flags[3][0] + flags[4][0] + flags[5][0]) == [
+        flags[3][1],
+        flags[4][1],
+        flags[5][1],
+    ]
 
 
 def test_quality_flag_decoding_quantity_object():
@@ -69,15 +81,19 @@ def test_quality_flag_decoding_quantity_object():
     This is a regression test for https://github.com/lightkurve/lightkurve/issues/804
     """
     from astropy.units.quantity import Quantity
+
     flags = list(TessQualityFlags.STRINGS.items())
     for key, value in flags:
-        assert TessQualityFlags.decode(Quantity(key, dtype='int32'))[0] == value
+        assert TessQualityFlags.decode(Quantity(key, dtype="int32"))[0] == value
     # Can we recover combinations of flags?
-    assert TessQualityFlags.decode(Quantity(flags[5][0], dtype='int32') + \
-        Quantity(flags[7][0], dtype='int32')) == [flags[5][1], flags[7][1]]
-    assert TessQualityFlags.decode(Quantity(flags[3][0], dtype='int32') + \
-        Quantity(flags[4][0], dtype='int32') + Quantity(flags[5][0], dtype='int32')) \
-        == [flags[3][1], flags[4][1], flags[5][1]]
+    assert TessQualityFlags.decode(
+        Quantity(flags[5][0], dtype="int32") + Quantity(flags[7][0], dtype="int32")
+    ) == [flags[5][1], flags[7][1]]
+    assert TessQualityFlags.decode(
+        Quantity(flags[3][0], dtype="int32")
+        + Quantity(flags[4][0], dtype="int32")
+        + Quantity(flags[5][0], dtype="int32")
+    ) == [flags[3][1], flags[4][1], flags[5][1]]
 
 
 def test_quality_mask():
@@ -85,12 +101,14 @@ def test_quality_mask():
     quality = np.array([0, 0, 1])
     assert np.all(KeplerQualityFlags.create_quality_mask(quality, bitmask=0))
     assert np.all(KeplerQualityFlags.create_quality_mask(quality, bitmask=None))
-    assert np.all(KeplerQualityFlags.create_quality_mask(quality, bitmask='none'))
+    assert np.all(KeplerQualityFlags.create_quality_mask(quality, bitmask="none"))
     assert (KeplerQualityFlags.create_quality_mask(quality, bitmask=1)).sum() == 2
-    assert (KeplerQualityFlags.create_quality_mask(quality, bitmask='hardest')).sum() == 2
+    assert (
+        KeplerQualityFlags.create_quality_mask(quality, bitmask="hardest")
+    ).sum() == 2
     # Do we see a ValueError if an invalid bitmask is passed?
     with pytest.raises(ValueError) as err:
-        KeplerQualityFlags.create_quality_mask(quality, bitmask='invalidoption')
+        KeplerQualityFlags.create_quality_mask(quality, bitmask="invalidoption")
     assert "not supported" in err.value.args[0]
 
 
@@ -98,7 +116,7 @@ def test_quality_mask():
 def test_lightkurve_warning():
     """Can we ignore Lightkurve warnings?"""
     with warnings.catch_warnings(record=True) as warns:
-        warnings.simplefilter('ignore', LightkurveWarning)
+        warnings.simplefilter("ignore", LightkurveWarning)
         time = np.array([1, 2, 3, np.nan])
         flux = np.array([1, 2, 3, 4])
         lc = LightCurve(time=time, flux=flux)
@@ -109,25 +127,26 @@ def test_validate_method():
     assert validate_method("foo", ["foo", "bar"]) == "foo"
     assert validate_method("FOO", ["foo", "bar"]) == "foo"
     with pytest.raises(ValueError):
-          validate_method("foo", ["bar"])
+        validate_method("foo", ["bar"])
 
 
 def test_import():
     """Regression test for #605; `lk.utils` resolved to `lk.seismology.utils`"""
     from lightkurve import utils
+
     assert hasattr(utils, "btjd_to_astropy_time")
 
 
 def test_btjd_bkjd_input():
     """Regression test for #607: are the bkjd/btjd functions tolerant?"""
     # Kepler
-    assert bkjd_to_astropy_time(0).jd[0] == 2454833.
+    assert bkjd_to_astropy_time(0).jd[0] == 2454833.0
     for user_input in [[0], np.array([0])]:
-        assert_array_equal(bkjd_to_astropy_time(user_input).jd, np.array([2454833.]))
+        assert_array_equal(bkjd_to_astropy_time(user_input).jd, np.array([2454833.0]))
     # TESS
-    assert btjd_to_astropy_time(0).jd[0] == 2457000.
+    assert btjd_to_astropy_time(0).jd[0] == 2457000.0
     for user_input in [[0], np.array([0])]:
-        assert_array_equal(btjd_to_astropy_time(user_input).jd, np.array([2457000.]))
+        assert_array_equal(btjd_to_astropy_time(user_input).jd, np.array([2457000.0]))
 
 
 def test_centroid_quadratic():


### PR DESCRIPTION
This PR applies the [black](https://github.com/psf/black) code formatting tool across the source tree to bring Lightkurve in line with ~PEP8.

Going forward, I propose that Lightkurve 2 will utilize black to automatically check and format the code in a consistent way, which would free up developer brain cycles to focus on functionality rather than formatting.