### PR TITLE
Fix installation of Lightkurve 2 under Python 3.9

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -1,12 +1,13 @@
 # GitHub Actions workflow for Lightkurve's continuous integration.
 #
-# This file configures six different jobs:
+# This file configures seven different jobs:
 # 1) pytest on Linux, Python 3.7.
-# 2) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
-# 3) pytest on Linux, Python 3.8, without installing optional dependencies.
-# 4) pytest on Windows, Python 3.8, with --remote-data enabled.
-# 5) pytest on OSX, Python 3.8.
-# 6) flake8 syntax check.
+# 2) pytest on Linux, Python 3.7.
+# 3) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
+# 4) pytest on Linux, Python 3.9.
+# 5) pytest on Windows, Python 3.8.
+# 6) pytest on OSX, Python 3.8.
+# 7) flake8 syntax check.
 
 name: Lightkurve-tests
 
@@ -19,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data]
+        name: [3.6, 3.7, 3.8-remote-data, 3.9]
         include:
           - name: 3.6
             python-version: 3.6
@@ -30,6 +31,9 @@ jobs:
           - name: 3.8-remote-data
             python-version: 3.8
             pytest-command: poetry run pytest --remote-data --doctest-modules
+          - name: 3.9
+            python-version: 3.9
+            pytest-command: poetry run pytest
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.0.1 (2020-02-16)
+==================
+
+- Fixed an issue which caused the installation of Lightkurve 2.0 to fail
+  under Python 3.9. [#951]
+
+
 2.0.0 (2020-02-15)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pandas = "^1.1.4"
 uncertainties = "^3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"
-numba = ">=0.39.0"
+numba = { version = ">=0.53.0rc1.post1", python = ">=3.6,<3.10" }  # numba does not allow >=3.10
 bokeh = ">=1.0"
 ipython = ">=6.0.0"
 memoization = ">=0.3.1"


### PR DESCRIPTION
Over in #951, @warrickball correctly pointed out that it is currently impossible to `pip install lightkurve` under Python 3.9 because one of the dependencies (`numba`) fails to install. (Also see #940.)

The solution is to update the minimum version requirement for numba to be `>=0.53.0rc1.post1`.

This PR also adds Python 3.9 to the continuous integration matrix, to help make sure we properly support Python 3.9 from now on.