### PR TITLE
:bug: fixing issue #927 when binning a folded light curve

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1278,10 +1278,15 @@ class LightCurve(QTimeSeries):
             time_bin_size *= u.day
         if time_bin_start is None:
             time_bin_start = self.time[0]
-        if not isinstance(time_bin_start, Time):
-            time_bin_start = Time(
-                time_bin_start, format=self.time.format, scale=self.time.scale
-            )
+        if not isinstance(time_bin_start, (Time, TimeDelta)):
+            if isinstance(self.time, TimeDelta):
+                time_bin_start = TimeDelta(
+                    time_bin_start, format=self.time.format, scale=self.time.scale
+                )
+            else:
+                time_bin_start = Time(
+                    time_bin_start, format=self.time.format, scale=self.time.scale
+                )
 
         # Call AstroPy's aggregate_downsample
         with warnings.catch_warnings():

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -508,6 +508,15 @@ def test_bin():
         assert np.round(lc.bin(2000).flux_err[0], 2) == 0.01
 
 
+def test_bin_folded():
+    # bin folded light curves issue #927
+    lc = LightCurve(
+        time=np.arange(2000), flux=np.random.normal(loc=42, scale=0.01, size=2000)
+    )
+    binned_folded_lc = lc.fold(period=100).bin(time_bin_size=100)
+    assert np.round(binned_folded_lc.flux_err[0], 2) == 0.01
+
+
 @pytest.mark.xfail
 def test_bins_kwarg():
     """Does binning work with user-defined bin placement?"""


### PR DESCRIPTION
Here's an easy fix to this issue (#927)
This works when binning folded and non-folded light curves, for the cases when `time_bin_start` is passed to `bin()` as a `float` or as a `Time`/`TimeDelta` class for non-folded/folded light curves. 
Also added a simple testing function.
