### PR TITLE
Ensure lightkurve enables "ppt" and "ppm" as valid AstroPy units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@
 
 - Fixed a bug which made it impossible to use ``bin()`` after ``fold()``. [#953]
 
-- Fixed a bug which caused "ppt" and "ppm" not to be enabled as AstroPy units.
+- Added ``lightkurve.units`` to ensure "ppt" and "ppm" are enabled as AstroPy units
+  when lightkurve is imported. [#959]
 
 
 2.0.1 (2020-02-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@
 
 - Fixed a bug which made it impossible to use ``bin()`` after ``fold()``. [#953]
 
-- Added ``lightkurve.units`` to ensure "ppt" and "ppm" are enabled as AstroPy units
-  when lightkurve is imported. [#959]
+- Added the ``lightkurve.units`` module to ensure "ppt" and "ppm" are enabled
+  AstroPy units when Lightkurve is imported. [#959]
 
 
 2.0.1 (2020-02-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Fixed a bug which made it impossible to use ``bin()`` after ``fold()``. [#953]
 
+- Fixed a bug which caused "ppt" and "ppm" not to be enabled as AstroPy units.
+
 
 2.0.1 (2020-02-16)
 ==================

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 
 from .version import __version__
+from .units import *
 from .time import *
 from .lightcurve import *
 from .lightcurvefile import *

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 
 from .version import __version__
-from .units import *
+from . import units  # enable ppt and ppm as units
 from .time import *
 from .lightcurve import *
 from .lightcurvefile import *

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -1,5 +1,6 @@
 """Defines collections of data products."""
 import logging
+import warnings
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -223,7 +224,9 @@ class LightCurveCollection(Collection):
         """
         if corrector_func is None:
             corrector_func = lambda x: x  # noqa: E731
-        lcs = [corrector_func(lc) for lc in self]
+        with warnings.catch_warnings():  # ignore "already normalized" message
+            warnings.filterwarnings("ignore", message=".*already.*")
+            lcs = [corrector_func(lc) for lc in self]
         # Need `join_type='inner'` until AstroPy supports masked Quantities
         return vstack(lcs, join_type="inner", metadata_conflicts="silent")
 

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ..utils import validate_method
 from ..lightcurve import LightCurve
+from ..units import ppm
 
 
 log = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ def read_generic_lightcurve(
             tab[colname].unit = "pixel"
         elif unitstr == "ppm" and repr(tab[colname].unit).startswith("Unrecognized"):
             # Workaround for issue #956
-            tab[colname].unit = "pixel"
+            tab[colname].unit = ppm
 
         # Rename columns to lowercase
         tab.rename_column(colname, colname.lower())

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -52,6 +52,9 @@ def read_generic_lightcurve(
             tab[colname].unit = "electron/s"
         elif unitstr == "pixels":
             tab[colname].unit = "pixel"
+        elif unitstr == "ppm" and repr(tab[colname].unit).startswith("Unrecognized"):
+            # Workaround for issue #956
+            tab[colname].unit = "pixel"
 
         # Rename columns to lowercase
         tab.rename_column(colname, colname.lower())

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -983,14 +983,9 @@ class LightCurve(QTimeSeries):
         if unit == "percent":
             lc.flux = lc.flux.to(u.percent)
             lc.flux_err = lc.flux_err.to(u.percent)
-        elif unit == "ppt":  # parts per thousand
-            # ppt is not included in astropy, so we define it here
-            ppt = u.def_unit(["ppt", "parts per thousand"], u.Unit(1e-3))
-            lc.flux = lc.flux.to(ppt)
-        elif unit == "ppm":  # parts per million
-            from astropy.units import cds
-
-            lc.flux = lc.flux.to(cds.ppm)
+        elif unit in ("ppt", "ppm"):
+            lc.flux = lc.flux.to(unit)
+            lc.flux_err = lc.flux_err.to(unit)
 
         lc.meta["NORMALIZED"] = True
         return lc

--- a/src/lightkurve/units.py
+++ b/src/lightkurve/units.py
@@ -1,0 +1,8 @@
+"""Define custom AstroPy units commonly used by the Kepler/TESS community."""
+from astropy import units as u
+
+__all__ = ["ppt", "ppm"]
+
+ppt = u.def_unit(["ppt", "parts per thousand"], u.Unit(1e-3))
+ppm = u.def_unit(["ppm", "parts per million"], u.Unit(1e-6))
+u.add_enabled_units([ppt, ppm])

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1452,8 +1452,9 @@ def test_fill_gaps_after_normalization():
     lc2 = lc.fill_gaps()
     assert lc2.time[2].value == 3.0
     assert lc2.flux[2].value == 1e6
-    assert lc2.flux[2].unit == u.cds.ppm
-    assert lc2.flux_err[2] == 0.1
+    assert lc2.flux[2].unit == "ppm"
+    assert lc2.flux_err[2].value == 1e5
+    assert lc2.flux_err[2].unit == "ppm"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -13,6 +13,6 @@ def test_custom_units():
 
 @pytest.mark.remote_data
 def test_tasoc_ppm_units():
-    """Regression test"""
+    """Regression test for #956."""
     lc = lk.search_lightcurve('HV 2112', author='TASOC', sector=1, exptime=1800).download()
     assert "Unrecognized" not in lc['flux_corr'].unit.__repr__()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,18 @@
+import pytest
+
+import lightkurve as lk  # necessary to enable the units tested below
+from astropy import units as u
+
+
+def test_custom_units():
+    """Are ppt, ppm, and percent enabled AstroPy units?"""
+    u.Unit("ppt")     # custom unit defined in lightkurve.units
+    u.Unit("ppm")     # not enabled by default; enabled in lightkurve.units
+    u.Unit("percent") # standard AstroPy unit
+
+
+@pytest.mark.remote_data
+def test_tasoc_ppm_units():
+    """Regression test"""
+    lc = lk.search_lightcurve('HV 2112', author='TASOC', sector=1, exptime=1800).download()
+    assert "Unrecognized" not in lc['flux_corr'].unit.__repr__()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -15,4 +15,5 @@ def test_custom_units():
 def test_tasoc_ppm_units():
     """Regression test for #956."""
     lc = lk.search_lightcurve('HV 2112', author='TASOC', sector=1, exptime=1800).download()
-    assert "Unrecognized" not in lc['flux_corr'].unit.__repr__()
+    assert lc['flux_corr'].unit == "ppm"
+    assert "Unrecognized" not in repr(lc['flux_corr'].unit)


### PR DESCRIPTION
This PR attempts to resolve #956 by making sure that "ppm" and "ppt" can be used as valid units after Lightkurve has been imported.  AstroPy does not enable these units by default, but they are very popular in the Kepler/TESS community.