### PR TITLE
Bugfix: `lc.plot(offset=N)` permanently increased lc.flux by N

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 2.0.2 (unreleased)
 ==================
 
-- Fixed a bug which made it impossible to use ``bin()`` after ``fold()``. [#953]
-
 - Added the ``lightkurve.units`` module to ensure "ppt" and "ppm" are enabled
   AstroPy units when Lightkurve is imported. [#959]
+
+- Fixed a bug which made it impossible to use ``bin()`` after ``fold()``. [#953]
+
+- Fixed a bug which caused ``LightCurve.plot(offset=N)`` to permanently increase
+  a light curve's flux by N. [#961]
 
 
 2.0.1 (2020-02-16)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1580,7 +1580,7 @@ class LightCurve(QTimeSeries):
         offset : float
             Offset value to apply to the Y axis values before plotting. Use this
             to avoid light curves from overlapping on the same plot. By default,
-            no offset is applies.
+            no offset is applied.
         clip_outliers : bool
             If ``True``, clip the y axis limit to the 95%-percentile range.
         kwargs : dict
@@ -1642,7 +1642,7 @@ class LightCurve(QTimeSeries):
 
         # Apply offset if requested
         if offset:
-            flux += offset * flux.unit
+            flux = flux.copy() + offset * flux.unit
 
         # Make the plot
         with plt.style.context(style):
@@ -1714,7 +1714,7 @@ class LightCurve(QTimeSeries):
         offset : float
             Offset value to apply to the Y axis values before plotting. Use this
             to avoid light curves from overlapping on the same plot. By default,
-            no offset is applies.
+            no offset is applied.
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.plot`.
 
@@ -1756,7 +1756,7 @@ class LightCurve(QTimeSeries):
         offset : float
             Offset value to apply to the Y axis values before plotting. Use this
             to avoid light curves from overlapping on the same plot. By default,
-            no offset is applies.
+            no offset is applied.
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.scatter`.
 
@@ -1803,7 +1803,7 @@ class LightCurve(QTimeSeries):
         offset : float
             Offset value to apply to the Y axis values before plotting. Use this
             to avoid light curves from overlapping on the same plot. By default,
-            no offset is applies.
+            no offset is applied.
         kwargs : dict
             Dictionary of arguments to be passed to `matplotlib.pyplot.errorbar`.
 

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1515,3 +1515,11 @@ def test_search_neighbors():
     assert len(search) == 1
     assert search.distance.value < 300
     assert search.target_name[0] == "388852407"
+
+
+def test_plot_with_offset():
+    """Regression test for #961: `lc.plot(offset=N)` increased `lc.flux` by N."""
+    lc = LightCurve(flux=[1.0])
+    ax = lc.plot(offset=1)
+    plt.close(ax.figure)
+    assert lc.flux[0].value == 1.0


### PR DESCRIPTION
This PR fixes #961 and adds a regression test. 