### PR TITLE
Add support for reading KEPSEISMIC data products

### DIFF
--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -2,7 +2,7 @@
 from .detect import *
 from .read import *
 
-from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc
+from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, kepseismic
 from .. import LightCurve
 
 from astropy.io import registry
@@ -21,5 +21,6 @@ try:
     registry.register_reader("everest", LightCurve, everest.read_everest_lightcurve)
     registry.register_reader("pathos", LightCurve, pathos.read_pathos_lightcurve)
     registry.register_reader("tasoc", LightCurve, tasoc.read_tasoc_lightcurve)
+    registry.register_reader("kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -25,6 +25,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'QLP'`
         * `'PATHOS'`
         * `'TASOC'`
+        * `'KEPSEISMIC'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -94,6 +95,10 @@ def detect_filetype(hdulist: HDUList) -> str:
             return "EVEREST"
     except Exception:
         pass
+
+    # Is it a KEPSEISMIC file?
+    if hdulist[0].header.get("ORIGIN") == "CEA & SSI":
+        return "KEPSEISMIC"
 
     # Is it an official data product?
     header = hdulist[0].header

--- a/src/lightkurve/io/kepseismic.py
+++ b/src/lightkurve/io/kepseismic.py
@@ -1,0 +1,31 @@
+"""Reader function for KEPSEISMIC community light curve products."""
+from ..lightcurve import KeplerLightCurve
+
+from .generic import read_generic_lightcurve
+
+def read_kepseismic_lightcurve(filename, **kwargs):
+    """Read a KEPSEISMIC light curve file.
+
+    More information: https://archive.stsci.edu/prepds/kepseismic
+
+    Parameters
+    ----------
+    filename : str
+        Path or URL of a K2SFF light curve FITS file.
+
+    Returns
+    -------
+    lc : `KeplerLightCurve`
+        A populated light curve object.
+    """
+
+    lc = read_generic_lightcurve(
+        filename,
+        time_format='bkjd')
+
+    lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
+
+    # KEPSEISMIC light curves are normalized by default
+    lc.meta["NORMALIZED"] = True
+
+    return KeplerLightCurve(data=lc, **kwargs)

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -100,6 +100,8 @@ def read(path_or_url, **kwargs):
         return KeplerLightCurve.read(path_or_url, format="k2sff", **kwargs)
     elif filetype == "EVEREST":
         return KeplerLightCurve.read(path_or_url, format="everest", **kwargs)
+    elif filetype == "KEPSEISMIC":
+        return KeplerLightCurve.read(path_or_url, format="kepseismic", **kwargs)
 
     # Official data products;
     # if the filetype is recognized, instantiate a class of that name

--- a/tests/io/test_kepseismic.py
+++ b/tests/io/test_kepseismic.py
@@ -1,0 +1,30 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+
+from lightkurve.io.kepseismic import read_kepseismic_lightcurve
+from lightkurve.io.detect import detect_filetype
+
+@pytest.mark.remote_data
+def test_detect_kepseismic():
+    """Can we detect the correct format for KEPSEISMIC files?"""
+    url = "https://archive.stsci.edu/hlsps/kepseismic/001200000/92147/20d-filter/hlsp_kepseismic_kepler_phot_kplr001292147-20d_kepler_v1_cor-filt-inp.fits"
+    f = fits.open(url)
+
+    assert detect_filetype(f) == "KEPSEISMIC"
+
+
+@pytest.mark.remote_data
+def test_read_kepseismic():
+    """Can we read KEPSEISMIC files?"""
+    url = "https://archive.stsci.edu/hlsps/kepseismic/001200000/92147/20d-filter/hlsp_kepseismic_kepler_phot_kplr001292147-20d_kepler_v1_cor-filt-inp.fits"
+    with fits.open(url, mode="readonly") as hdulist:
+        fluxes = hdulist[1].data["FLUX"]
+
+    lc = read_kepseismic_lightcurve(url)
+
+    flux_lc = lc.flux.value
+
+    # print(flux_lc, fluxes)
+    assert np.sum(fluxes) == np.sum(flux_lc)


### PR DESCRIPTION
Here goes! This PR adds functions to read KEPSEISMIC data products. This partly resolves issue #967 by allowing the files to be read. PR #969 covers the question of returning the data products in the search.