### PR TITLE
Restore `lightkurve.correctors.*` back in the top level `lightkurve.*` name space

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 
 - Fixed a bug affecting the alignment of vectors in ``CBVCorrector``. [#964]
 
+- Modified the lightkurve namespace to include the contents of `lightkurve.correctors`.
+  These were removed to speed up `import lightkurve` in 2.0.0, but the change appears
+  to affect too much existing code. [#977]
+
 
 2.0.2 (2020-02-19)
 ==================

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -38,6 +38,7 @@ from . import units  # enable ppt and ppm as units
 from .time import *
 from .lightcurve import *
 from .lightcurvefile import *
+from .correctors import *
 from .targetpixelfile import *
 from .utils import *
 from .convenience import *


### PR DESCRIPTION
Lightkurve v2.0.0 removed `from .correctors import *` from the top level `__init__.py` file to speed up `import lightkurve`.

This change already triggered more than one issue, including:
* https://github.com/lightkurve/lightkurve/issues/975
* https://github.com/christinahedges/TESS-SIP/issues/2

While it would be good to simplify the top level namespace, it appears to break too many existing packages, including `eleanor`.  This PR reverts the change for now.