### PR TITLE
[WIP] CDIPS reader, take 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 2.0.7dev (unreleased)
 =====================
 
+- Added support for reading CDIPS light curves. [#980]
+
+- Fixed a bug which caused ``LightCurve`` object instantiation to fail if
+  a string-typed column had a unit set. [#980]
+
 - Fixed a bug in ``CBVCorrector`` causing it to not work on K2 data. [#1012]
 
 - Modified ``LightCurveCollection`` to have a more simple and generic ``__repr__()``

--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -20,6 +20,7 @@ try:
     registry.register_reader("k2sff", LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader("everest", LightCurve, everest.read_everest_lightcurve)
     registry.register_reader("pathos", LightCurve, pathos.read_pathos_lightcurve)
+    registry.register_reader('cdips', LightCurve, cdips.read_cdips_lightcurve)
     registry.register_reader("tasoc", LightCurve, tasoc.read_tasoc_lightcurve)
     registry.register_reader("kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve)
 except registry.IORegistryError:

--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -3,6 +3,7 @@ from .detect import *
 from .read import *
 
 from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, kepseismic
+from . import cdips
 from .. import LightCurve
 
 from astropy.io import registry

--- a/src/lightkurve/io/cdips.py
+++ b/src/lightkurve/io/cdips.py
@@ -22,7 +22,8 @@ def read_cdips_lightcurve(filename,
     do not provide the bitflags necessary for a user to apply a new bitmask.
     Therefore, frames corresponding to "momentum dumps and coarse point modes"
     are removed according to Bouma et al. 2019, and no other quality filtering
-    is allowed.
+    is allowed. The `quality_bitmask` parameter is ignored but accepted for
+    compatibility with other data format readers.
 
     Parameters
     ----------
@@ -53,9 +54,6 @@ def read_cdips_lightcurve(filename,
     # Set the appropriate error column for this aperture
     quality_column = f"irq{ap}"
 
-    if quality_bitmask is not None:
-        log.warning("Quality filtering is not enabled for CDIPS lightcurves")
-
     lc = read_generic_lightcurve(filename,
                                  time_column="tmid_bjd",
                                  flux_column=flux_column.lower(),
@@ -74,6 +72,7 @@ def read_cdips_lightcurve(filename,
     quality_mask = (lc['quality']=="G") | (lc['quality']=="0")
     lc = lc[quality_mask]
 
+    lc.meta["AUTHOR"] = "CDIPS"
     lc.meta['TARGETID'] = lc.meta.get('TICID')
     lc.meta['QUALITY_BITMASK'] = 36
     lc.meta['QUALITY_MASK'] = quality_mask

--- a/src/lightkurve/io/cdips.py
+++ b/src/lightkurve/io/cdips.py
@@ -1,0 +1,81 @@
+"""Reader for A PSF-Based Approach to TESS Cluster Difference Imaging Photometric Survey (CDIPS) light curves
+
+Website: https://archive.stsci.edu/hlsp/cdips
+Product Description: https://archive.stsci.edu/hlsps/cdips/hlsp_cdips_tess_ffi_all_tess_v01_readme.md
+"""
+import logging
+
+from ..lightcurve import TessLightCurve
+from ..utils import TessQualityFlags
+
+from .generic import read_generic_lightcurve
+
+log = logging.getLogger(__name__)
+
+def read_cdips_lightcurve(filename,
+                            flux_column="IRM1",
+                            include_inst_errs=False,
+                            quality_bitmask=None):
+    """Returns a `TessLightCurve`.
+
+    Note: CDIPS light curves have already had quality filtering applied, and
+    do not provide the bitflags necessary for a user to apply a new bitmask.
+    Therefore, frames corresponding to "momentum dumps and coarse point modes"
+    are removed according to Bouma et al. 2019, and no other quality filtering
+    is allowed.
+
+    Parameters
+    ----------
+    filename : str
+        Local path or remote url of CDIPS light curve FITS file.
+    flux_column : str
+        'IFL#', 'IRM#', 'TFA#', or 'PCA#' (# = 1, 2, or 3)
+        Which column in the FITS file contains the preferred flux data?
+    include_inst_errs: bool
+        Whether to include the instrumental flux/magnitude errors
+        (Errors are not provided for trend-filtered magnitudes)
+    """
+    ap = flux_column[-1]
+
+    # Only the instrumental magnitudes are provided, and are not provided for
+    # trend-filtered light curves. User should select whether to include the
+    # instrumental errors or ignore them
+    if include_inst_errs:
+        # If fluxes are requested, return flux errors
+        if flux_column[:-1].lower()=="ifl":
+            flux_err_column = f"ife{ap}"
+        # Otherwise magnitudes are being requested, return magnitude errors
+        else:
+            flux_err_column = f"ire{ap}"
+    else:
+        flux_err_column = ""
+
+    # Set the appropriate error column for this aperture
+    quality_column = f"irq{ap}"
+
+    if quality_bitmask is not None:
+        log.warning("Quality filtering is not enabled for CDIPS lightcurves")
+
+    lc = read_generic_lightcurve(filename,
+                                 time_column="tmid_bjd",
+                                 flux_column=flux_column.lower(),
+                                 flux_err_column=flux_err_column,
+                                 quality_column=quality_column,
+                                 time_format='btjd')
+
+    # Filter out poor-quality data
+    # NOTE: Unfortunately Astropy Table masking does not yet work for columns
+    # that are Quantity objects, so for now we remove poor-quality data instead
+    # of masking. Details: https://github.com/astropy/astropy/issues/10119
+
+    # CDIPS uses their own quality keywords instead of the default bitflags
+    # Based on Bouma+2019, they filter out coarse point (4) and desat (32)
+    # as well as other cadences flagged for particular sectors
+    quality_mask = (lc['quality']=="G") | (lc['quality']=="0")
+    lc = lc[quality_mask]
+
+    lc.meta['TARGETID'] = lc.meta.get('TICID')
+    lc.meta['QUALITY_BITMASK'] = 36
+    lc.meta['QUALITY_MASK'] = quality_mask
+
+    return TessLightCurve(data=lc)

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -26,6 +26,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'PATHOS'`
         * `'TASOC'`
         * `'KEPSEISMIC'`
+        * `'CDIPS'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -67,6 +68,11 @@ def detect_filetype(hdulist: HDUList) -> str:
     # cf. https://tasoc.dk and https://archive.stsci.edu/hlsp/tasoc
     if hdulist[0].header.get("ORIGIN") == "TASOC/Aarhus":
         return "TASOC"
+
+    # Is it a CDIPS TESS light curve?
+    # cf. http://archive.stsci.edu/hlsp/cdips
+    if "cdips" in hdulist[0].header.get("ORIGIN","").lower():
+        return "CDIPS"
 
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -94,6 +94,8 @@ def read(path_or_url, **kwargs):
         return TessLightCurve.read(path_or_url, format="qlp", **kwargs)
     elif filetype == "PATHOS":
         return TessLightCurve.read(path_or_url, format="pathos", **kwargs)
+    elif filetype == "CDIPS":
+        return TessLightCurve.read(path_or_url, format='cdips', **kwargs)
     elif filetype == "TASOC":
         return TessLightCurve.read(path_or_url, format="tasoc", **kwargs)
     elif filetype == "K2SFF":

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -62,6 +62,7 @@ class QTimeSeries(TimeSeries):
         and Lightkurve requires the correspond astropy release.
         """
         # string-typed columns should not have a unit, or it will make convert_col_for_table crash!
+        # see https://github.com/lightkurve/lightkurve/pull/980#issuecomment-806178939
         if hasattr(col, 'dtype'):
             if hasattr(col, 'unit') and col.dtype.kind in {'U', 'S'}:
                 del col.unit

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -61,6 +61,11 @@ class QTimeSeries(TimeSeries):
         It won't be needed once https://github.com/astropy/astropy/pull/10962 is in astropy release
         and Lightkurve requires the correspond astropy release.
         """
+        # string-typed columns should not have a unit, or it will make convert_col_for_table crash!
+        if hasattr(col, 'dtype'):
+            if hasattr(col, 'unit') and col.dtype.kind in {'U', 'S'}:
+                del col.unit
+
         col = super()._convert_col_for_table(col)
         if (
             isinstance(col, Column)

--- a/tests/io/test_cdips.py
+++ b/tests/io/test_cdips.py
@@ -35,14 +35,14 @@ def test_read_cdips():
         lc = read_cdips_lightcurve(url, flux_column=ext)
         assert type(lc).__name__ == "TessLightCurve"
         # Are `time` and `flux` consistent with the FITS file?
-        assert_array_equal(f[1].data['TIME'][lc.meta['QUALITY_MASK']],
+        assert_array_equal(f[1].data['TMID_BJD'][lc.meta['QUALITY_MASK']],
                            lc.time.value)
         assert_array_equal(f[1].data[ext][lc.meta['QUALITY_MASK']],
                            lc.flux.value)
         fluxes.append(lc.flux)
     # Different extensions should show different fluxes
     for i in range(11):
-        assert not np.array_equal(fluxes[i] , fluxes[i+1])
+        assert not np.array_equal(fluxes[i].value , fluxes[i+1].value)
 
 @pytest.mark.remote_data
 def test_search_cdips():

--- a/tests/io/test_cdips.py
+++ b/tests/io/test_cdips.py
@@ -1,0 +1,58 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+from numpy.testing import assert_array_equal
+
+# from ... import search_lightcurve
+# from ..cdips import read_cdips_lightcurve
+# from ..detect import detect_filetype
+from lightkurve import search_lightcurve
+from lightkurve.io.cdips import read_cdips_lightcurve
+from lightkurve.io.detect import detect_filetype
+
+@pytest.mark.remote_data
+def test_detect_cdips():
+    """Can we detect the correct format for CDIPS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/cdips/s0008/cam3_ccd4/hlsp_cdips_tess_ffi_gaiatwo0005318059532750974720-0008-cam3-ccd4_tess_v01_llc.fits"
+    f = fits.open(url)
+
+    assert detect_filetype(f)=="CDIPS"
+
+
+@pytest.mark.remote_data
+def test_read_cdips():
+    """Can we read CDIPS files?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/cdips/s0008/cam3_ccd4/hlsp_cdips_tess_ffi_gaiatwo0005318059532750974720-0008-cam3-ccd4_tess_v01_llc.fits"
+    f = fits.open(url)
+    # Verify different extensions
+    fluxes = []
+
+    # Test instrumental flux and magnitude, and detrended magnitudes
+    exts = [f'IFL{ap}' for ap in [1,2,3]]
+    exts.extend([f'IRM{ap}' for ap in [1,2,3]])
+    exts.extend([f'TFA{ap}' for ap in [1,2,3]])
+    exts.extend([f'PCA{ap}' for ap in [1,2,3]])
+
+    for ext in exts:
+        lc = read_cdips_lightcurve(url, flux_column=ext)
+        assert type(lc).__name__ == "TessLightCurve"
+        # Are `time` and `flux` consistent with the FITS file?
+        assert_array_equal(f[1].data['TIME'][lc.meta['QUALITY_MASK']],
+                           lc.time.value)
+        assert_array_equal(f[1].data[ext][lc.meta['QUALITY_MASK']],
+                           lc.flux.value)
+        fluxes.append(lc.flux)
+    # Different extensions should show different fluxes
+    for i in range(11):
+        assert not np.array_equal(fluxes[i] , fluxes[i+1])
+
+@pytest.mark.remote_data
+def test_search_cdips():
+    """Can we search and download a cdips light curve?"""
+    search = search_lightcurve("TIC 93270923", author="CDIPS", sector=8)
+    assert len(search) == 1
+    assert search.table["author"][0] == "CDIPS"
+    lc = search.download()
+    assert type(lc).__name__ == "TessLightCurve"
+    assert lc.sector == 8

--- a/tests/io/test_cdips.py
+++ b/tests/io/test_cdips.py
@@ -4,9 +4,6 @@ from astropy.io import fits
 import numpy as np
 from numpy.testing import assert_array_equal
 
-# from ... import search_lightcurve
-# from ..cdips import read_cdips_lightcurve
-# from ..detect import detect_filetype
 from lightkurve import search_lightcurve
 from lightkurve.io.cdips import read_cdips_lightcurve
 from lightkurve.io.detect import detect_filetype

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1532,3 +1532,10 @@ def test_plot_with_offset():
     ax = lc.plot(offset=1)
     plt.close(ax.figure)
     assert lc.flux[0].value == 1.0
+
+
+def test_string_column_with_unit():
+    """Regression test for #980."""
+    # string-typed columns with a unit set were making `_convert_col_for_table` crash
+    col = Column(data=["a", "b", "c"], unit='unitless')
+    LightCurve(data={'time': [1, 2, 3], 'x': col})


### PR DESCRIPTION
Includes functions to read in a CDIPS light curve, in response to #918. Follows #945, but redone to follow the new directory structure in the latest version. 

This is a WIP until the tests run. I did get pytest running on my machine (finally), but it won't run on the new directory structure for some reason (Might be be related to [this](https://stackoverflow.com/questions/41748464/pytest-cannot-import-module-while-python-can))