### PR TITLE
DesignMatrix prior_mu and prior_sigma should be arrays not Quantity objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 2.0.4 (unreleased)
 ==================
 
+- Fixed a bug in ``SFFCorrector`` which caused ``prior_mu`` and ``prior_sigma``
+  to be Quantity objects rather than arrays. [#982]
 
 
 2.0.3 (2021-02-23)

--- a/src/lightkurve/correctors/designmatrix.py
+++ b/src/lightkurve/correctors/designmatrix.py
@@ -7,6 +7,7 @@ are design to work with the `RegressionCorrector` class.
 from copy import deepcopy
 import warnings
 
+from astropy import units as u
 import matplotlib.pyplot as plt
 from numba import jit
 import numpy as np
@@ -69,11 +70,17 @@ class DesignMatrix:
             df.columns = columns
         self.columns = list(df.columns)
         self.name = name
+
+        if isinstance(prior_mu, u.Quantity):
+            prior_mu = prior_mu.value
         if prior_mu is None:
             prior_mu = np.zeros(len(df.T))
+        self.prior_mu = np.atleast_1d(prior_mu)
+
+        if isinstance(prior_sigma, u.Quantity):
+            prior_sigma = prior_sigma.value
         if prior_sigma is None:
             prior_sigma = np.ones(len(df.T)) * np.inf
-        self.prior_mu = np.atleast_1d(prior_mu)
         self.prior_sigma = np.atleast_1d(prior_sigma)
 
     @property

--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -195,7 +195,7 @@ class SFFCorrector(RegressionCorrector):
 
         # I'm putting WEAK priors on the spline that it must be around 1
         s_dm.prior_sigma = (
-            np.ones(len(s_dm.prior_mu)) * 1000 * self.lc.flux.std() + 1e-6
+            np.ones(len(s_dm.prior_mu)) * 1000 * self.lc.flux.std().value + 1e-6
         )
 
         # additional

--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -65,7 +65,7 @@ class SFFCorrector(RegressionCorrector):
         super(SFFCorrector, self).__init__(lc=lc)
 
     def __repr__(self):
-        return "SFFCorrector (LC: {})".format(self.lc.targetid)
+        return "SFFCorrector (LC: {})".format(self.lc.meta.get("TARGETID"))
 
     def correct(
         self,

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -126,7 +126,7 @@ class LightCurve(QTimeSeries):
     ----------
     meta : `dict`
         meta data associated with the lightcurve. The header of the underlying FITS file (if applicable)
-        is available here as well.
+        is store in this dictionary. By convention, keys in this dictionary are usually in uppercase.
 
     Notes
     -----

--- a/tests/correctors/test_sffcorrector.py
+++ b/tests/correctors/test_sffcorrector.py
@@ -235,3 +235,15 @@ def test_sff_nan_centroids():
     lc = search_lightcurve("EPIC 211083408", author="K2").download()
     # This previously raised a ValueError:
     lc[200:500].remove_nans().to_corrector("sff").correct()
+
+
+def test_designmatrix_prior_type():
+    """Regression test: prior_mu and prior_sigma should not be Quantity objects."""
+    size = 10
+    lc = LightCurve(flux=np.random.normal(loc=1.0, scale=0.1, size=size))
+    corr = lc.to_corrector("sff")
+    corr.correct(centroid_col=np.random.normal(loc=1.0, scale=0.1, size=size),
+                 centroid_row=np.random.normal(loc=1.0, scale=0.1, size=size),
+                 windows=1)
+    assert "Quantity" not in str(type(corr.design_matrix_collection.prior_mu))
+    assert "Quantity" not in str(type(corr.design_matrix_collection.prior_sigma))

--- a/tests/correctors/test_sffcorrector.py
+++ b/tests/correctors/test_sffcorrector.py
@@ -238,7 +238,7 @@ def test_sff_nan_centroids():
 
 
 def test_designmatrix_prior_type():
-    """Regression test: prior_mu and prior_sigma should not be Quantity objects."""
+    """Regression test for #982: prior_mu and prior_sigma should not be Quantity objects."""
     size = 10
     lc = LightCurve(flux=np.random.normal(loc=1.0, scale=0.1, size=size))
     corr = lc.to_corrector("sff")


### PR DESCRIPTION
This PR will attempt to address https://github.com/christinahedges/TESS-SIP/issues/2.

TL;DR: `SFFCorrector` sets the `prior_mu` and `prior_sigma` attributes of its `DesignMatrix` to Quantity objects.  Because the coefficients of a design matrix are unitless, it would likely be best to have `DesignMatrix` enforce that the priors are always unitless arrays as well.

Related: https://github.com/lightkurve/lightkurve/issues/919