### PR TITLE
MNT: Restored (similar functionality) to `bins` parameter and binsize tests

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1249,7 +1249,7 @@ class LightCurve(QTimeSeries):
         aggregate_func : callable, optional
             The function to use for combining points in the same bin. Defaults
             to np.nanmean.
-        bins : int or iterable of ints
+        bins : int
             The number of bins to divide the lightkurve into. In contrast to
             ``n_bins`` this sets the length of ``time_bin_size`` accordingly.
         binsize : int
@@ -1275,8 +1275,11 @@ class LightCurve(QTimeSeries):
               and (time_bin_size is not None or n_bins is not None)):
             raise ValueError("``bins`` or ``binsize`` conflicts with "
                              "``n_bins`` or ``time_bin_size``.")
-        elif bins is not None and np.array(bins).dtype != np.int:
-            raise TypeError("``bins`` must have integer type.")
+        elif bins is not None:
+            if np.array(bins).dtype != np.int:
+                raise TypeError("``bins`` must have integer type.")
+            elif np.size(bins) != 1:
+                raise ValueError("``bins`` must be a single number.")
 
         if time_bin_start is None:
             time_bin_start = self.time[0]
@@ -1294,8 +1297,7 @@ class LightCurve(QTimeSeries):
         if time_bin_size is None:
             if bins is not None:
                 i = len(self.time) - np.searchsorted(self.time, time_bin_start - 1 * u.ns)
-                time_bin_size = ((self.time[-1] - time_bin_start) * i / ((i -1) * bins)).to(u.day)
-                print(bins, len(self.time), i, self.time[-1] - time_bin_start, time_bin_size)
+                time_bin_size = ((self.time[-1] - time_bin_start) * i / ((i - 1) * bins)).to(u.day)
             elif binsize is not None:
                 i = np.searchsorted(self.time, time_bin_start - 1 * u.ns)
                 time_bin_size = (self.time[i + binsize] - self.time[i]).to(u.day)


### PR DESCRIPTION
Found a leftover branch here where I was trying to address some of the interface changes in 2.x with `timeseries`; namely emulating the old functionality of setting the number of bins with `bins=N`, taking this parameter to calculate the appropriate `time_bin_size` that can then be passed to `aggregate_downsample`.
I was also looking into some of the test failures in #663 and found that the results are not actually wrong; the problem just seems to be that `aggregate_downsample` takes _closed_ intervals of length `time_bin_size`, which results in the first bin having one time point more, and the last one less. Accordingly their errors are scaled down/up by `sqrt(N + 1)`, `sqrt(N - 1)`.
I have re-enabled the tests with the expected results adjusted; if we want all the bins to be of equal size, some further investigation into the `aggregate_downsample` interface would be required.
The failure/NaNs with `time_bin_edges = [0, 10, 20, 30, 40, 50, 60, 70, 80]` ~~also seems to be a problem with how `aggregate_downsample` handles them, as it apparently takes the inverse of the values somewhere. Haven't tracked this down and left that part of the test marked `skip`~~ remains as long as only a single bin size can be handled.

Note that there is also PR https://github.com/astropy/astropy/pull/11266 for extending `aggregate_downsample` that may finally allow to restore more of the former `LightCurve.bin()` functionality.