### PR TITLE
LightCurveCollection.stitch() should ignore unmergeable columns (fixes #954)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 - Modified ``LightCurve.bin()`` to partially restore the ``bins`` parameter which
   was available in Lightkurve v1.x, to improve backwards compatibility. [#995]
 
+- Modified ``LightCurveCollection.stitch()`` to ignore incompatible columns
+  instead of having them raise a ``ValueError``. [#996]
+
+
 
 2.0.4 (2021-03-11)
 ==================

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -11,7 +11,7 @@ from astropy.utils.decorators import deprecated
 
 from . import MPLSTYLE
 from .targetpixelfile import TargetPixelFile
-from .utils import LightkurveDeprecationWarning
+from .utils import LightkurveWarning, LightkurveDeprecationWarning
 
 
 log = logging.getLogger(__name__)
@@ -227,6 +227,25 @@ class LightCurveCollection(Collection):
         with warnings.catch_warnings():  # ignore "already normalized" message
             warnings.filterwarnings("ignore", message=".*already.*")
             lcs = [corrector_func(lc) for lc in self]
+
+        # Address issue #954: ignore incompatible columns with the same name
+        columns_to_remove = set()
+        for col in lcs[0].columns:
+            for lc in lcs[1:]:
+                if col in lc.columns:
+                    if not (issubclass(lcs[0][col].__class__, lc[col].__class__) \
+                            or lcs[0][col].__class__.info is lc[col].__class__.info):
+                        columns_to_remove.add(col)
+                        continue
+
+        if len(columns_to_remove) > 0:
+            warnings.warn(
+                    f"The following columns will be ignored from the stitch because the data types are incompatible: {columns_to_remove}",
+                    LightkurveWarning,
+                )
+            lcs = [lc.copy() for lc in lcs]
+            [lc.remove_columns(columns_to_remove.intersection(lc.columns)) for lc in lcs]
+
         # Need `join_type='inner'` until AstroPy supports masked Quantities
         return vstack(lcs, join_type="inner", metadata_conflicts="silent")
 

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -240,7 +240,7 @@ class LightCurveCollection(Collection):
 
         if len(columns_to_remove) > 0:
             warnings.warn(
-                    f"The following columns will be ignored from the stitch because the data types are incompatible: {columns_to_remove}",
+                    f"The following columns will be excluded from stitching because the column types are incompatible: {columns_to_remove}",
                     LightkurveWarning,
                 )
             lcs = [lc.copy() for lc in lcs]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,6 +1,7 @@
 import warnings
 
 import pytest
+from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 import matplotlib.pyplot as plt
 import numpy as np
@@ -107,7 +108,7 @@ def test_collection_getitem_by_boolean_array():
 
     lcc_f = lcc[[True, False, True]]
     assert lcc_f.data == [lc0, lc2]
-    assert (type(lcc_f), LightCurveCollection)
+    assert type(lcc_f) is LightCurveCollection
 
     # boundary case: 1 element
     lcc_f = lcc[[False, True, False]]
@@ -215,7 +216,7 @@ def test_tpfcollection():
     # ensure index by boolean array also works for TPFs
     tpfc_f = tpfc[[False, True, True]]
     assert tpfc_f.data == [tpf2, tpf2]
-    assert (type(tpfc_f), TargetPixelFileCollection)
+    assert type(tpfc_f) is TargetPixelFileCollection
     # Test __setitem__
     tpf3 = KeplerTargetPixelFile(filename_tpf_one_center, targetid=55)
     tpfc[1] = tpf3
@@ -353,3 +354,11 @@ def test_accessor_k2_campaign():
     tpf1.hdu[0].header["CAMPAIGN"] = 1
     tpfc = TargetPixelFileCollection([tpf0, tpf1])
     assert (tpfc.campaign == [2, 1]).all()
+
+
+def test_unmergeable_columns():
+    """Regression test for #954."""
+    lc1 = LightCurve(data={'time': [1,2,3], 'x': [1,2,3]})
+    lc2 = LightCurve(data={'time': [1,2,3], 'x': [1,2,3]*u.electron/u.second})
+    with pytest.warns(LightkurveWarning, match="column types are incompatible"):
+        LightCurveCollection([lc1, lc2]).stitch()


### PR DESCRIPTION
This PR addresses #954.

The following snippet of code currently raises an exception because column 'x' is a `QColumn` in lc1 and a `Quantity` in lc2:

```python
import lightkurve as lk
from astropy import units as u
lc1 = lk.LightCurve(data={'time': [1,2,3], 'x': [1,2,3]})
lc2 = lk.LightCurve(data={'time': [1,2,3], 'x': [1,2,3]*u.electron/u.second})
lk.LightCurveCollection([lc1, lc2]).stitch()
```

This PR changes the behavior to exclude column 'x' from the stitch and raise a warning about it.