### PR TITLE
Add a LightCurve.to_excel() convenience method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Removed ``ipython`` from the installation requirements. [#999]
 
+- Added the ``LightCurve.to_excel()`` convenience method. [#1000]
 
 
 2.0.5 (2021-03-13)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2001,6 +2001,27 @@ class LightCurve(QTimeSeries):
             return path_or_buf.getvalue()
         return result
 
+    def to_pandas(self, **kwargs):
+        """Converts the light curve to a Pandas `~pandas.DataFrame` object.
+
+        The data frame will be indexed by `time` using values corresponding
+        to the light curve's time format.  This is different from the
+        default behavior of `Table.to_pandas()` in AstroPy, which converts
+        time values into ISO timestamps.
+
+        Returns
+        -------
+        dataframe : `pandas.DataFrame`
+            A data frame indexed by `time`.
+        """
+        df = super().to_pandas(**kwargs)
+        # Default AstroPy behavior is to change the time column into ``np.datetime64``
+        # We override it here because it confuses Kepler/TESS users who are used
+        # to working in BTJD and BKJD rather than ISO timestamps.
+        df.index = self.time.value
+        df.index.name = "time"
+        return df
+
     def to_excel(self, path_or_buf, **kwargs) -> None:
         """Shorthand for `to_pandas().to_excel()`.
 

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2001,9 +2001,21 @@ class LightCurve(QTimeSeries):
             return path_or_buf.getvalue()
         return result
 
-    def to_excel(self, *args, **kwargs):
-        """Shorthand for `to_pandas().to_excel()`."""
-        self.to_pandas().to_excel(*args, **kwargs)
+    def to_excel(self, path_or_buf, **kwargs) -> None:
+        """Shorthand for `to_pandas().to_excel()`.
+
+        Parameters
+        ----------
+        path_or_buf : string or file handle
+            File path or object.
+        **kwargs : dict
+            Dictionary of arguments to be passed to `to_pandas().to_excel(**kwargs)`.
+        """
+        try:
+            import openpyxl  # optional dependency
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("You need to install `openpyxl` to use this feature, e.g. use `pip install openpyxl`.")
+        self.to_pandas().to_excel(path_or_buf, **kwargs)
 
     def to_periodogram(self, method="lombscargle", **kwargs):
         """Converts the light curve to a `~lightkurve.periodogram.Periodogram`

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2001,6 +2001,10 @@ class LightCurve(QTimeSeries):
             return path_or_buf.getvalue()
         return result
 
+    def to_excel(self, *args, **kwargs):
+        """Shorthand for `to_pandas().to_excel()`."""
+        self.to_pandas().to_excel(*args, **kwargs)
+
     def to_periodogram(self, method="lombscargle", **kwargs):
         """Converts the light curve to a `~lightkurve.periodogram.Periodogram`
         power spectrum object.

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -639,6 +639,7 @@ def test_to_pandas():
     lc = LightCurve(time=time, flux=flux, flux_err=flux_err)
     try:
         df = lc.to_pandas()
+        assert_allclose(df.index, lc.time.value)
         assert_allclose(df.flux, flux)
         assert_allclose(df.flux_err, flux_err)
         df.describe()  # Will fail if for Endianness bugs


### PR DESCRIPTION
This PR proposes to add `LightCurve.to_excel()` as a lightweight wrapper around `LightCurve.to_pandas().to_excel()`.