### PR TITLE
Ensure LightCurveCollection.plot() shows the correct y axis label (fixes #1001)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 2.0.7dev (unreleased)
 =====================
 
+- Fixed a bug in ``LightCurveCollection.plot()`` which caused an incorrect y label
+  when the collection contained normalized and non-normalized light curves. [#1002]
+
 
 
 2.0.6 (2021-03-15)

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -291,6 +291,19 @@ class LightCurveCollection(Collection):
                     if jdx != jdxs[0]:  # Avoid multiple labels for same object
                         kwargs["label"] = ""
                     self[jdx].plot(ax=ax, c=f"C{idx}", offset=idx * offset, **kwargs)
+
+            # If some but not all light curves are normalized, ensure the Y label
+            # says "Flux" and not "Normalized Flux"
+            normstatus = [lc.meta.get("NORMALIZED", False) for lc in self]
+            if "normalize" not in kwargs and any(normstatus) and not all(normstatus):
+                warnings.warn(
+                    "Some but not all of the light curves in the collection appear to be normalized. "
+                    "You may wish to use `normalize=True` to ensure all are normalized.",
+                    LightkurveWarning,
+                )
+                if "ylabel" not in kwargs:
+                    ax.set_ylabel("Flux")
+
         return ax
 
 

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1654,14 +1654,20 @@ class LightCurve(QTimeSeries):
 
         # Normalize the data if requested
         if normalize:
-            if column == "flux":
-                lc_normed = self.normalize()
-            else:
-                lc_tmp = self.copy()
-                lc_tmp["flux"] = flux
-                lc_tmp["flux_err"] = flux_err
-                lc_normed = lc_tmp.normalize()
-            flux, flux_err = lc_normed.flux, lc_normed.flux_err
+            # ignore "light curve is already normalized" message because
+            # the user explicitely asked for normalization here
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=".*already.*")
+                if column == "flux":
+                    lc_normed = self.normalize()
+                else:
+                    # Code below is a temporary hack because `normalize()`
+                    # does not have a `column` argument yet
+                    lc_tmp = self.copy()
+                    lc_tmp["flux"] = flux
+                    lc_tmp["flux_err"] = flux_err
+                    lc_normed = lc_tmp.normalize()
+                flux, flux_err = lc_normed.flux, lc_normed.flux_err
 
         # Apply offset if requested
         if offset:


### PR DESCRIPTION
This PR fixes #1001 by ensuring `LightCurveCollection.plot()` shows the correct y axis label when the collection contains a combination of normalized and non-normalized light curves.

### Old behavior

<img width="850" alt="Screen Shot 2021-03-17 at 10 57 05 PM" src="https://user-images.githubusercontent.com/817669/111579968-20223180-8774-11eb-8b05-f7680e980de0.png">


### New behavior

<img width="880" alt="Screen Shot 2021-03-17 at 10 56 21 PM" src="https://user-images.githubusercontent.com/817669/111579900-0a147100-8774-11eb-8e24-bc556294ba8b.png">
