### PR TITLE
Make `LightCurveCollection` more generic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 2.0.7dev (unreleased)
 =====================
 
+- Modified ``LightCurveCollection`` to have a more simple and generic ``__repr__()``
+  which does not group objects by target id.
+
 - Fixed a bug in ``LightCurveCollection.plot()`` which caused an incorrect y label
   when the collection contained normalized and non-normalized light curves. [#1002]
 

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -165,7 +165,7 @@ class LightCurveCollection(Collection):
         will be removed soon."""
         return LightCurveCollection([lc.SAP_FLUX for lc in self])
 
-    def stitch(self, corrector_func=lambda x: x.normalize()) -> "LightCurve":
+    def stitch(self, corrector_func=lambda x: x.normalize()):
         """Stitch all light curves in the collection into a single `LightCurve`.
 
         Any function passed to `corrector_func` will be applied to each light curve

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -91,8 +91,12 @@ class Collection(object):
         result = f"{self.__class__.__name__} of {len(self)} objects:\n    "
         # LightCurve objects provide a special `_repr_simple_` method
         # to avoid printing an entire table here
-        result += "\n    ".join([f"{idx}: " + getattr(obj, "_repr_simple_", obj.__repr__)()
-                                 for idx, obj in enumerate(self)])
+        result += "\n    ".join(
+            [
+                f"{idx}: " + getattr(obj, "_repr_simple_", obj.__repr__)()
+                for idx, obj in enumerate(self)
+            ]
+        )
         return result
 
     def _safeGetScalarAttr(self, attrName):
@@ -195,18 +199,23 @@ class LightCurveCollection(Collection):
         for col in lcs[0].columns:
             for lc in lcs[1:]:
                 if col in lc.columns:
-                    if not (issubclass(lcs[0][col].__class__, lc[col].__class__) \
-                            or lcs[0][col].__class__.info is lc[col].__class__.info):
+                    if not (
+                        issubclass(lcs[0][col].__class__, lc[col].__class__)
+                        or lcs[0][col].__class__.info is lc[col].__class__.info
+                    ):
                         columns_to_remove.add(col)
                         continue
 
         if len(columns_to_remove) > 0:
             warnings.warn(
-                    f"The following columns will be excluded from stitching because the column types are incompatible: {columns_to_remove}",
-                    LightkurveWarning,
-                )
+                f"The following columns will be excluded from stitching because the column types are incompatible: {columns_to_remove}",
+                LightkurveWarning,
+            )
             lcs = [lc.copy() for lc in lcs]
-            [lc.remove_columns(columns_to_remove.intersection(lc.columns)) for lc in lcs]
+            [
+                lc.remove_columns(columns_to_remove.intersection(lc.columns))
+                for lc in lcs
+            ]
 
         # Need `join_type='inner'` until AstroPy supports masked Quantities
         return vstack(lcs, join_type="inner", metadata_conflicts="silent")
@@ -242,7 +251,7 @@ class LightCurveCollection(Collection):
                     kwargs.pop(kwarg)
 
             for idx, lc in enumerate(self):
-                kwargs['label'] = f"{idx}: {lc.meta.get('LABEL', '(missing label)')}"
+                kwargs["label"] = f"{idx}: {lc.meta.get('LABEL', '(missing label)')}"
                 lc.plot(ax=ax, c=f"C{idx}", offset=idx * offset, **kwargs)
 
             # If some but not all light curves are normalized, ensure the Y label

--- a/src/lightkurve/io/everest.py
+++ b/src/lightkurve/io/everest.py
@@ -55,7 +55,7 @@ def read_everest_lightcurve(
     )
     lc = lc[quality_mask]
 
-    lc.meta["LABEL"] = "{} (EVEREST)".format(lc.meta.get("OBJECT"))
+    lc.meta["AUTHOR"] = "EVEREST"
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask

--- a/src/lightkurve/io/k2sff.py
+++ b/src/lightkurve/io/k2sff.py
@@ -27,7 +27,7 @@ def read_k2sff_lightcurve(filename, ext="BESTAPER", **kwargs):
         filename, flux_column="fcor", time_format="bkjd", ext=ext
     )
 
-    lc.meta["LABEL"] = "{} (K2SFF)".format(lc.meta.get("OBJECT"))
+    lc.meta["AUTHOR"] = "K2SFF"
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
 
     return KeplerLightCurve(data=lc, **kwargs)

--- a/src/lightkurve/io/kepler.py
+++ b/src/lightkurve/io/kepler.py
@@ -47,6 +47,7 @@ def read_kepler_lightcurve(
     )
     lc = lc[quality_mask]
 
+    lc.meta["AUTHOR"] = "Kepler"
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask

--- a/src/lightkurve/io/kepseismic.py
+++ b/src/lightkurve/io/kepseismic.py
@@ -23,6 +23,7 @@ def read_kepseismic_lightcurve(filename, **kwargs):
         filename,
         time_format='bkjd')
 
+    lc.meta["AUTHOR"] = "KEPSEISMIC"
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
 
     # KEPSEISMIC light curves are normalized by default

--- a/src/lightkurve/io/pathos.py
+++ b/src/lightkurve/io/pathos.py
@@ -52,6 +52,7 @@ def read_pathos_lightcurve(
     )
     lc = lc[quality_mask]
 
+    lc.meta["AUTHOR"] = "PATHOS"
     lc.meta["TARGETID"] = lc.meta.get("TICID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask

--- a/src/lightkurve/io/qlp.py
+++ b/src/lightkurve/io/qlp.py
@@ -44,6 +44,7 @@ def read_qlp_lightcurve(filename, flux_column="kspsap_flux", quality_bitmask="de
     )
     lc = lc[quality_mask]
 
+    lc.meta["AUTHOR"] = "QLP"
     lc.meta["TARGETID"] = lc.meta.get("TICID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask

--- a/src/lightkurve/io/tasoc.py
+++ b/src/lightkurve/io/tasoc.py
@@ -25,6 +25,8 @@ def read_tasoc_lightcurve(filename, flux_column="FLUX_RAW", quality_bitmask=None
     lc = read_generic_lightcurve(
         filename, flux_column=flux_column.lower(), time_format="btjd"
     )
+
+    lc.meta["AUTHOR"] = "TASOC"
     lc.meta["TARGETID"] = lc.meta.get("TICID")
     # TASOC light curves are normalized by default
     lc.meta["NORMALIZED"] = True

--- a/src/lightkurve/io/tess.py
+++ b/src/lightkurve/io/tess.py
@@ -42,6 +42,7 @@ def read_tess_lightcurve(
     )
     lc = lc[quality_mask]
 
+    lc.meta["AUTHOR"] = "SPOC"
     lc.meta["TARGETID"] = lc.meta.get("TICID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -365,15 +365,32 @@ class LightCurve(QTimeSeries):
                 )
             super().__setattr__(name, value, **kwargs)
 
+    def _repr_simple_(self) -> str:
+        """Returns a simple __repr__.
+
+        Used by `LightCurveCollection`.
+        """
+        result = f"<{self.__class__.__name__}"
+        if "LABEL" in self.meta:
+            result += f" LABEL=\"{self.meta.get('LABEL')}\""
+        for kw in ["QUARTER", "CAMPAIGN", "SECTOR", "AUTHOR"]:
+            if kw in self.meta:
+                result += f" {kw}={self.meta.get(kw)}"
+        result += ">"
+        return result
+
     def _base_repr_(self, html=False, descr_vals=None, **kwargs):
         """Defines the description shown by `__repr__` and `_html_repr_`."""
         if descr_vals is None:
             descr_vals = [self.__class__.__name__]
             if self.masked:
                 descr_vals.append("masked=True")
-            if hasattr(self, "targetid"):
-                descr_vals.append(f"targetid={self.targetid}")
             descr_vals.append("length={}".format(len(self)))
+            if "LABEL" in self.meta:
+                descr_vals.append(f"LABEL=\"{self.meta.get('LABEL')}\"")
+            for kw in ["QUARTER", "CAMPAIGN", "SECTOR", "AUTHOR"]:
+                if kw in self.meta:
+                    descr_vals.append(f"{kw}={self.meta.get(kw)}")
         return super()._base_repr_(html=html, descr_vals=descr_vals, **kwargs)
 
     # Define `time`, `flux`, `flux_err` as class attributes to enable IDE

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1116,7 +1116,8 @@ def test_bin_issue705():
         lc.bin(binsize=15)
 
 
-@pytest.mark.remote_data
+#@pytest.mark.remote_data
+@pytest.mark.skip  # At time of writing, the SkyBot API yields too many intermittent HTTP Errors
 def test_SSOs():
     # TESS test
     lc = TessTargetPixelFile(asteroid_TPF).to_lightcurve(aperture_mask="all")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -72,11 +72,11 @@ def test_search_targetpixelfile():
     tic = "TIC 273985862"  # Has been observed in multiple sectors including 1
     assert len(search_targetpixelfile(tic, mission="TESS").table) > 1
     assert (
-        len(search_targetpixelfile(tic, mission="TESS", sector=1, radius=100).table)
+        len(search_targetpixelfile(tic, author="SPOC", sector=1, radius=100).table)
         == 2
     )
-    search_targetpixelfile(tic, mission="TESS", sector=1).download()
-    assert len(search_targetpixelfile("pi Mensae", sector=1).table) == 1
+    search_targetpixelfile(tic, author="SPOC", sector=1).download()
+    assert len(search_targetpixelfile("pi Mensae", sector=1, author="SPOC").table) == 1
     # Issue #445: indexing with -1 should return the last index of the search result
     assert len(search_targetpixelfile("pi Men")[-1]) == 1
 

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -738,7 +738,8 @@ def test_aperture_photometry_nan():
     assert np.isnan(lc.flux_err[2])
 
 
-@pytest.mark.remote_data
+#@pytest.mark.remote_data
+@pytest.mark.skip  # At time of writing, the SkyBot API yields too many intermittent HTTP Errors
 def test_SSOs():
     # TESS test
     tpf = TessTargetPixelFile(asteroid_TPF)


### PR DESCRIPTION
The current version of the `LightCurveCollection` object dates from the time when we only supported Kepler products.  This is problematic in the TESS era for two reasons:
* the `__repr__()` method groups targets by target id without representing any notion that it is now very common for unique targets to have multiple light curves from different missions, pipelines, and cadence modes.
* likewise, the `plot()` method does not visually distinguish light curves with identical target id's.

This PR addresses these shortcomings in the following way:

### Old behavior

<img width="823" alt="Screen Shot 2021-03-18 at 10 52 58 PM" src="https://user-images.githubusercontent.com/817669/111737410-cfc2d680-883c-11eb-9eec-05fce5904b9d.png">

### New behavior

<img width="812" alt="Screen Shot 2021-03-18 at 10 53 38 PM" src="https://user-images.githubusercontent.com/817669/111737427-d6e9e480-883c-11eb-9ab4-f742e1401c42.png">

