### PR TITLE
query split campaigns separately

### DIFF
--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -927,13 +927,14 @@ def _search_products(
     # passed a radius value), because strict target name search does not apply.
     if filetype.lower() == "ffi" and radius is None:
         radius = 0.0001 * u.arcsec
+    # No campaign should be given otherwise split K2 campaigns will be filtered out
     observations = _query_mast(
         target,
         radius=radius,
         project=mission,
         provenance_name=provenance_name,
         exptime=exptime,
-        sequence_number=campaign or sector,
+        sequence_number=sector,
         **extra_query_criteria,
     )
     log.debug(
@@ -1212,6 +1213,13 @@ def _filter_products(
     if "kepler" in provenance_lower and campaign is None and sector is None:
         mask |= _mask_kepler_products(products, quarter=quarter, month=month)
 
+    # K2 data needs a special filter for split campaigns
+    mask &= ~np.array(
+        [prov.lower() == "k2" for prov in products["provenance_name"]]
+    )
+    if "k2" in provenance_lower and quarter is None and sector is None:
+        mask |= _mask_k2_products(products, campaign=campaign)
+
     # HLSP products need to be filtered by extension
     if filetype.lower() == "lightcurve":
         mask &= np.array(
@@ -1304,6 +1312,22 @@ def _mask_kepler_products(products, quarter=None, month=None):
 
     return mask
 
+def _mask_k2_products(products, campaign=None):
+    """Returns a mask flagging the K2 products that match the criteria."""
+    mask = np.array([proj.lower() == 'k2' for proj in products['provenance_name']])
+    if mask.sum() == 0:
+        return mask
+
+    # Identify campaign by the description.
+    if campaign is not None:
+        campaign_mask = np.zeros(len(products), dtype=bool)
+        for c in np.atleast_1d(campaign):
+            campaign_mask |= np.array(['c{:02d}'.format(c) in desc.lower().replace('-', '') or
+                                       'c{:03d}'.format(c) in desc.lower().replace('-', '')
+                                       for desc in products['description']])
+        mask &= campaign_mask
+
+    return mask
 
 def _mask_by_exptime(products, exptime):
     """Helper function to filter by exposure time."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -88,6 +88,7 @@ def test_search_split_campaigns():
     K2 Campaigns 9, 10, and 11 were split into two halves for various technical
     reasons (C91=C9a, C92=C9b, C101=C10a, C102=C10b, C111=C11a, C112=C11b).
     We expect most targets from those campaigns to return two TPFs.
+    But split campaigns should be queried separately too.
     """
     campaigns = [9, 10, 11]
     ids = ["EPIC 228162462", "EPIC 228726301", "EPIC 202975993"]
@@ -95,6 +96,12 @@ def test_search_split_campaigns():
         search = search_targetpixelfile(idx, campaign=c, cadence="long").table
         assert len(search) == 2
 
+    campaigns = [[91, 92], [101, 102], [111, 112]]
+    ids = ["EPIC 228162462", "EPIC 228726301", "EPIC 202975993"]
+    for subc, idx in zip(campaigns, ids):
+        for c in subc:
+            search = search_targetpixelfile(idx, campaign=c, cadence="long").table
+            assert len(search) == 1
 
 @pytest.mark.remote_data
 def test_search_lightcurve(caplog):


### PR DESCRIPTION
Hi, 
I opened this PR to solve the issue of querying split campaigns, which was originally reported in [105](https://github.com/lightkurve/lightkurve/issues/105) and [139](https://github.com/lightkurve/lightkurve/issues/139),  and has been resolved in `Lightkurve 1.x`. Now, in version 2.x, it has reappeared. However, due to certain technical problems ([see K2 release notes](https://keplergo.github.io/KeplerScienceWebsite/k2-data-release-notes.html)) it is useful to let the user query the split campaigns separately as well.