### PR TITLE
Prevent `LightCurve.append()` from crashing in the presence of incompatible column types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.0.9 (unreleased)
+==================
+
+- Fixed a bug in ``LightCurve.append()`` which caused the method to crash
+  if the light curves contained incompatible column types. [#1015]
+
+
 2.0.8 (2021-03-30)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lightkurve"
-version = "2.0.8"
+version = "2.0.9dev"
 description = "A friendly package for Kepler & TESS time series analysis in Python."
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>"]

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='lightkurve',
-    version='2.0.8',
+    version='2.0.9dev',
     description='A friendly package for Kepler & TESS time series analysis in Python.',
     python_requires='>=3.6.1',
     project_urls={"homepage": "https://docs.lightkurve.org", "repository": "https://github.com/lightkurve/lightkurve"},

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -667,8 +667,10 @@ class LightCurve(QTimeSeries):
             )
         if not hasattr(others, "__iter__"):
             others = (others,)
-        # Need `join_type='inner'` until AstroPy supports masked Quantities
-        return vstack((self, *others), join_type="inner", metadata_conflicts="silent")
+
+        # Re-use LightCurveCollection.stitch() to avoid code duplication
+        from .collections import LightCurveCollection  # avoid circular import
+        return LightCurveCollection((self, *others)).stitch(corrector_func=None)
 
     def flatten(
         self,

--- a/src/lightkurve/version.py
+++ b/src/lightkurve/version.py
@@ -1,3 +1,3 @@
 # It is important to store the version number in a separate file
 # so that we can read it from setup.py without importing the package
-__version__ = "2.0.8"
+__version__ = "2.0.9dev"

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -357,8 +357,10 @@ def test_accessor_k2_campaign():
 
 
 def test_unmergeable_columns():
-    """Regression test for #954."""
+    """Regression test for #954 and #1015."""
     lc1 = LightCurve(data={'time': [1,2,3], 'x': [1,2,3]})
     lc2 = LightCurve(data={'time': [1,2,3], 'x': [1,2,3]*u.electron/u.second})
     with pytest.warns(LightkurveWarning, match="column types are incompatible"):
         LightCurveCollection([lc1, lc2]).stitch()
+    with pytest.warns(LightkurveWarning, match="column types are incompatible"):
+        lc1.append(lc2)


### PR DESCRIPTION
This PR intends to fix #1015.