### PR TITLE
Add four new convenience methods to LightCurve and TargetPixelFile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 2.0.9 (unreleased)
 ==================
 
+- Added the ``head()``, ``tail()``, and ``truncate()`` convenience methods
+  to the ``LightCurve`` class.
+
+- Modified ``TargetPixelFile.to_lightcurve()`` to accept "sff", "cbv", and "pld"
+  as options for the ``method`` keyword argument.
+
 - Fixed a bug in ``LightCurve.append()`` which caused the method to crash
   if the light curves contained incompatible column types. [#1015]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 ==================
 
 - Added the ``head()``, ``tail()``, and ``truncate()`` convenience methods
-  to the ``LightCurve`` class.
+  to the ``LightCurve`` class. [#1017]
 
 - Modified ``TargetPixelFile.to_lightcurve()`` to accept "sff", "cbv", and "pld"
-  as options for the ``method`` keyword argument.
+  as options for the ``method`` keyword argument. [#1017]
 
 - Fixed a bug in ``LightCurve.append()`` which caused the method to crash
   if the light curves contained incompatible column types. [#1015]

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1539,3 +1539,15 @@ def test_string_column_with_unit():
     # string-typed columns with a unit set were making `_convert_col_for_table` crash
     col = Column(data=["a", "b", "c"], unit='unitless')
     LightCurve(data={'time': [1, 2, 3], 'x': col})
+
+
+def test_head_tail_truncate():
+    """Simple test for the `head()`, `tail()`, and `truncate()` methods."""
+    lc = LightCurve({'time': [1, 2, 3, 4, 5], 'flux':[1, 2, 3, 4, 5]})
+    assert lc.head(1).flux == 1
+    assert lc.head(n=1).flux == 1
+    assert lc.tail(1).flux == 5
+    assert lc.tail(n=1).flux == 5
+    assert all(lc.truncate(2, 4).flux == [2, 3, 4])
+    assert lc.truncate(before=2).head(1).flux == 2
+    assert lc.truncate(after=3).tail(1).flux == 3


### PR DESCRIPTION
To make Lightkurve v2 more fun to use, this PR proposes to add four new convenience methods:
* Modified `TargetPixelFile.to_lightcurve()` to accept `method="sff"`, `method="cbv"`, and `method="pld"`.
* Added `LightCurve.trucate(before, after)`
* Added `LightCurve.head(n)`
* Added `LightCurve.tail(n)`

The motivation for these changes is that I am creating a video which demonstrates how Trappist-1b can be (re-)discovered using a single line of Python, which requires these modifications:
```python
lk.search_targetpixelfile("Trappist-1")[1] \
    .download() \
    .to_lightcurve(method="pld") \
    .flatten() \
    .remove_outliers() \
    .fold(period=1.511) \
    .bin(0.001) \
    .truncate(-0.5, -0.25) \
    .scatter()
```