### PR TITLE
Delineate sections of split K2 campaigns in SearchResult

### DIFF
--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -980,7 +980,7 @@ def _search_products(
             # listed separately in the table with suffixes "-1" and "-2"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
                 for half,letter in zip([1,2],['a','b']):
-                    if f"c{tmp_seqno}{half}" in result["obs_id"][idx]:
+                    if f"c{tmp_seqno}{half}" in result["productFilename"][idx]:
                         obs_seqno = f"{int(tmp_seqno):02d}{letter}"
             result["mission"][idx] = "{} {} {}".format(
                 obs_project, obs_prefix.get(obs_project, ""), obs_seqno

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -979,10 +979,9 @@ def _search_products(
             # K2 campaigns 9, 10, and 11 were split into two halfs, which are
             # listed separately in the table with suffixes "-1" and "-2"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
-                obs_camp = result["sequence_number"][idx]
                 for half in [1,2]:
-                    if f"c{obs_camp}{half}" in result["obs_id"][idx]:
-                        obs_seqno = f"{int(obs_camp):02d}-{half}"
+                    if f"c{tmp_seqno}{half}" in result["obs_id"][idx]:
+                        obs_seqno = f"{int(tmp_seqno):02d}-{half}"
             result["mission"][idx] = "{} {} {}".format(
                 obs_project, obs_prefix.get(obs_project, ""), obs_seqno
             )

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -977,7 +977,7 @@ def _search_products(
                 except IndexError:
                     obs_seqno = ""
             # K2 campaigns 9, 10, and 11 were split into two sections, which are
-            # listed separately in the table with suffixes "-1" and "-2"
+            # listed separately in the table with suffixes "a" and "b"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
                 for half,letter in zip([1,2],['a','b']):
                     if f"c{tmp_seqno}{half}" in result["productFilename"][idx]:

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -976,7 +976,7 @@ def _search_products(
                     obs_seqno = f"{int(tmp_seqno):02d}"
                 except IndexError:
                     obs_seqno = ""
-            # K2 campaigns 9, 10, and 11 were split into two halfs, which are
+            # K2 campaigns 9, 10, and 11 were split into two sections, which are
             # listed separately in the table with suffixes "-1" and "-2"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
                 for half in [1,2]:

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -979,9 +979,9 @@ def _search_products(
             # K2 campaigns 9, 10, and 11 were split into two sections, which are
             # listed separately in the table with suffixes "-1" and "-2"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
-                for half in [1,2]:
+                for half,letter in zip([1,2],['a','b']):
                     if f"c{tmp_seqno}{half}" in result["obs_id"][idx]:
-                        obs_seqno = f"{int(tmp_seqno):02d}-{half}"
+                        obs_seqno = f"{int(tmp_seqno):02d}{letter}"
             result["mission"][idx] = "{} {} {}".format(
                 obs_project, obs_prefix.get(obs_project, ""), obs_seqno
             )

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -976,6 +976,13 @@ def _search_products(
                     obs_seqno = f"{int(tmp_seqno):02d}"
                 except IndexError:
                     obs_seqno = ""
+            # K2 campaigns 9, 10, and 11 were split into two halfs, which are
+            # listed separately in the table with suffixes "-1" and "-2"
+            if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
+                obs_camp = result["sequence_number"][idx]
+                for half in [1,2]:
+                    if f"c{obs_camp}{half}" in result["obs_id"][idx]:
+                        obs_seqno = f"{int(obs_camp):02d}-{half}"
             result["mission"][idx] = "{} {} {}".format(
                 obs_project, obs_prefix.get(obs_project, ""), obs_seqno
             )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -498,3 +498,20 @@ def test_spoc_ffi_lightcurve():
     assert search.exptime[0] == 30 * u.minute  # Sector 26 had 30-minute FFIs
     lc = search.download()
     all(lc.flux == lc.pdcsap_flux)
+
+
+@pytest.mark.remote_data
+def test_split_k2_campaigns():
+    """Do split K2 campaign sections appear separately in search results?"""
+    # Campaign 9
+    search_c09 = search_targetpixelfile("EPIC 228162462", cadence="long", campaign=9)
+    assert search_c09.table["mission"][0] == "K2 Campaign 09a"
+    assert search_c09.table["mission"][1] == "K2 Campaign 09b"
+    # Campaign 10
+    search_c10 = search_targetpixelfile("EPIC 228725972", cadence="long", campaign=10)
+    assert search_c10.table["mission"][0] == "K2 Campaign 10a"
+    assert search_c10.table["mission"][1] == "K2 Campaign 10b"
+    # Campaign 11
+    search_c11 = search_targetpixelfile("EPIC 203830112", cadence="long", campaign=11)
+    assert search_c11.table["mission"][0] == "K2 Campaign 11a"
+    assert search_c11.table["mission"][1] == "K2 Campaign 11b"


### PR DESCRIPTION
In response to #1010, I've added code to list the different segments of split campaigns separately with clear labels in the search result. (PR opened separately because this is a much simpler proposed change.) 

This approach requires no additional queries, and uses the `obs_id` value to label campaigns. It doesn't allow you to specifically search for half of a campaign, but it does disambiguate the search result. I think this strikes a balance between maintaining the fast query speed (important for large samples of data) and keeping it intuitive to users.

Here it is in action for campaigns 9 and 11:

<img width="1218" alt="Screen Shot 2021-03-31 at 2 52 49 PM" src="https://user-images.githubusercontent.com/17130840/113228534-c9ffc480-9230-11eb-9139-84c77f8b65e4.png">

Because they're always listed in order, you can index the `SearchResult` to get the desired section in an automated way, e.g. you could use

```python
lk.search_targetpixelfile('EPIC 228162462', cadence='long', campaign=9)[0]
``` 
if you just want `9a` (FWIW that's true of the current behavior as well, it's just not as clear). 

The major issue with this change is that the labels for split campaign 10 on MAST are not consistent with the [K2 data release notes](https://keplergo.github.io/KeplerScienceWebsite/k2-data-release-notes.html) or campaigns 9 and 11. The DR notes say for campaign 10
> The two segments are identified in the archive products as c101 and c102, respectively.

However, for the c10 targets I checked, both segments are listed as `{id}-c10_lc` instead of `{id}-c101_lc` and `{id}-c102_lc` as they are for 9 and 11. 

I'll keep investigating if there's a simple way to check this for c10, but for now feel free to provide any feedback @barentsen and @astrobatty.