### PR TITLE
Fix math involving a NumPy float and a LightCurve object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Modified the search functions to ensure the two parts of K2 Campaigns
   9, 10, and 11 are more clearly marked. [#1018]
 
+- Fixed a bug in ``LightCurve`` which caused left-hand side multiplication
+  with NumPy floats and AstroPy Quantity objects to fail. [#925]
 
 
 2.0.9 (2021-03-31)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -195,6 +195,9 @@ class LightCurve(QTimeSeries):
     # initial construction of the object using `_new_attributes_relax`.
     _new_attributes_relax = True
 
+    # cf. issue #925
+    __array_priority__ = 100_000
+
     def __init__(self, data=None, *args, time=None, flux=None, flux_err=None, **kwargs):
         # Delay checking for required columns until the end
         self._required_columns_relax = True

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -134,6 +134,17 @@ def test_math_operators_on_units():
     assert lc_div.flux_err.unit == 1 / u.pixel
 
 
+def test_math_regression_925():
+    """Regression test for #925: left hand side multiplication with a np.float failed."""
+    lc = LightCurve(time=[1, 2, 3], flux=[1, 1, 1], flux_err=[1, 1, 1])
+    for three in [3, 3.0, np.float64(3), u.Quantity(3.)]:
+        # left hand side multiplication with a numpy float failed in the past, cf. #925
+        assert all((three * lc).flux == 3)
+        assert all((lc * three).flux == 3)
+        assert all((three + lc).flux == 4)
+        assert all((lc + three).flux == 4)
+
+
 @pytest.mark.remote_data
 @pytest.mark.parametrize("path, mission", [(TABBY_Q8, "Kepler"), (K2_C08, "K2")])
 def test_KeplerLightCurveFile(path, mission):


### PR DESCRIPTION
This PR fixes #925 and adds a regression test for the issue.