### PR TITLE
bugfix tpf.interact(ylim_func) when users select custom aperture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
 - Fixed a bug which caused the ``column`` parameter to be ignored in
   ``TargetPixelFile.animate()``.
 
+- Fixed a bug in ``TargetPixelFile.interact()`` when ``ylim_func`` is specified and
+  users tap to select custom apertures. [#1033]
+
 
 2.0.9 (2021-03-31)
 ==================
@@ -229,7 +232,7 @@ lightkurve.search
   MAST by default, including community-contributed light curves. [#933]
 
 - Modified the search functions to show the author and exposure time of each
-  data product in the search results table. [#831]  
+  data product in the search results table. [#831]
 
 - Added support for reading in High Level Science Product light curves, including
   TESS-SPOC, QLP, TASOC, K2SFF, EVEREST, PATHOS. [#739, #913, #935, #939]

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -784,7 +784,7 @@ def show_interact_widget(
                 if ylim_func is None:
                     ylims = get_lightcurve_y_limits(lc_source)
                 else:
-                    ylims = ylim_func(lc_new)
+                    ylims = _to_unitless(ylim_func(lc_new))
                 fig_lc.y_range.start = ylims[0]
                 fig_lc.y_range.end = ylims[1]
             else:


### PR DESCRIPTION
Fix #1033 

The fix is essentially an extension of PR #876 

No unit test is added, as it is hard to test logic during bokeh interaction (user tapping pixels in thie case).
