### PR TITLE
remove unused doc build dependency file

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-sphinx
-sphinx-automodapi
-sphinxcontrib-rawfiles
-amunra-sphinx-theme
-nbsphinx
-graphviz
-ghp-import
-numpydoc
-pandocfilters


### PR DESCRIPTION
Remove the now unused `doc/requirments.txt`
- the doc build dependency is now in `extras_require` of setup.py
