### PR TITLE
Fix lc.bin() missing original meta

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1382,9 +1382,7 @@ class LightCurve(QTimeSeries):
             ts.remove_column(colname)
             ts.add_column(tmpcol, name=colname, index=idx)
 
-        binned_lc = self.__class__(ts)
-        binned_lc.meta.update(self.meta)
-        return binned_lc
+        return self.__class__(ts, meta=self.meta)
 
     def estimate_cdpp(
         self, transit_duration=13, savgol_window=101, savgol_polyorder=2, sigma=5.0

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1382,7 +1382,9 @@ class LightCurve(QTimeSeries):
             ts.remove_column(colname)
             ts.add_column(tmpcol, name=colname, index=idx)
 
-        return self.__class__(ts)
+        binned_lc = self.__class__(ts)
+        binned_lc.meta.update(self.meta)
+        return binned_lc
 
     def estimate_cdpp(
         self, transit_duration=13, savgol_window=101, savgol_polyorder=2, sigma=5.0

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -482,7 +482,6 @@ def test_cdpp_tabby():
     assert np.abs(lc2.estimate_cdpp().value - lc.cdpp6_0) < 30
 
 
-# TEMPORARILY SKIPPED, cf. https://github.com/lightkurve/lightkurve/issues/663
 def test_bin():
     """Does binning work?"""
     with warnings.catch_warnings():  # binsize is deprecated
@@ -605,7 +604,6 @@ def test_bins_kwarg():
     #   - Bins = 310.0
 
 
-# TEMPORARILY SKIPPED, cf. https://github.com/lightkurve/lightkurve/issues/663
 def test_bin_quality():
     """Binning must also revise the quality and centroid columns."""
     lc = KeplerLightCurve(
@@ -1129,7 +1127,6 @@ def test_river():
         plt.close()
 
 
-# TEMPORARILY SKIPPED, cf. https://github.com/lightkurve/lightkurve/issues/663
 def test_bin_issue705():
     """Regression test for #705: binning failed."""
     lc = TessLightCurve(time=np.arange(50), flux=np.ones(50), quality=np.zeros(50))

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -519,6 +519,17 @@ def test_bin():
         assert np.round(lc.bin(2000).flux_err[0], 2) == 0.01
 
 
+def test_bin_meta():
+    """Ensure .bin() result carries original meta. See #1040 """
+    lc = LightCurve(
+        time=np.arange(10), flux=2 * np.ones(10), flux_err=2 ** 0.5 * np.ones(10)
+    )
+    lc.meta['CREATOR'] = 'lk unit test'
+    lc.meta['SECTOR'] = 99
+    binned_lc = lc.bin(time_bin_size=5)
+    assert binned_lc.meta == lc.meta
+
+
 def test_bin_folded():
     # bin folded light curves issue #927
     lc = LightCurve(


### PR DESCRIPTION
Close #1040

- The issue also has an open ended suggestion that some bin parameters / stats be stored in binned lc. 
If there is a consensus and easy to fix, I can add it to this PR
- The PR also removed outdated comments regarding temporarily skipped bin tests (no longer the case)

