### PR TITLE
Bugfix lc.meta assignment bogus Warning and outdated API doc links

### DIFF
--- a/docs/source/tutorials/1-getting-started/what-are-targetpixelfile-objects.ipynb
+++ b/docs/source/tutorials/1-getting-started/what-are-targetpixelfile-objects.ipynb
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can find the full list of properties in the [API documentation](https://docs.lightkurve.org/api/lightkurve.targetpixelfile.KeplerTargetPixelFile.html#lightkurve.targetpixelfile.KeplerTargetPixelFile) on this object."
+    "You can find the full list of properties in the [API documentation](https://docs.lightkurve.org/reference/api/lightkurve.targetpixelfile.KeplerTargetPixelFile.html#lightkurve.targetpixelfile.KeplerTargetPixelFile) on this object."
    ]
   },
   {

--- a/docs/source/tutorials/2-creating-light-curves/2-1-combining-multiple-quarters.ipynb
+++ b/docs/source/tutorials/2-creating-light-curves/2-1-combining-multiple-quarters.ipynb
@@ -311,7 +311,7 @@
     "id": "vf6NDWeqk-4g"
    },
    "source": [
-    "Let's first have a look at how these observations differ from one another. We can plot the simple aperture photometry (SAP) flux of all of the observations in the [`LightCurveCollection`](https://docs.lightkurve.org/api/lightkurve.collections.LightCurveCollection.html#lightkurve.collections.LightCurveCollection) to see how they compare."
+    "Let's first have a look at how these observations differ from one another. We can plot the simple aperture photometry (SAP) flux of all of the observations in the [`LightCurveCollection`](https://docs.lightkurve.org/reference/api/lightkurve.collections.LightCurveCollection.html#lightkurve.collections.LightCurveCollection) to see how they compare."
    ]
   },
   {

--- a/docs/source/tutorials/2-creating-light-curves/2-2-kepler-noise-2-spurious-signals-and-time-sampling-effects.ipynb
+++ b/docs/source/tutorials/2-creating-light-curves/2-2-kepler-noise-2-spurious-signals-and-time-sampling-effects.ipynb
@@ -263,7 +263,7 @@
     "\n",
     "Like *Kepler*, the *K2* mission used guide stars to assist with pointing as part of the FGS. Where *Kepler* used 40 guide stars throughout the whole mission, in *K2* it was harder to find suitable guide stars in *K2*'s visually crowded fields along the ecliptic plane, and so four stars were used in each campaign. This predictably reduced pointing stability, as each guide star in *K2* contributed more to the overall pointing.\n",
     "\n",
-    "The majority of *K2* guide stars were stable. However, one of the Campaign 6 guide stars was an eclipsing binary with a period of 0.6046 days. By [folding](https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html#lightkurve.lightcurve.LightCurve.fold) an affected light curve on this period, we can see the impact of the eclipsing binary on an otherwise non-variable target.\n",
+    "The majority of *K2* guide stars were stable. However, one of the Campaign 6 guide stars was an eclipsing binary with a period of 0.6046 days. By [folding](https://docs.lightkurve.org/reference/api/lightkurve.lightcurve.LightCurve.html#lightkurve.lightcurve.LightCurve.fold) an affected light curve on this period, we can see the impact of the eclipsing binary on an otherwise non-variable target.\n",
     "\n",
     "The example below is from the [*K2* Data Release Notes 35](https://archive.stsci.edu/missions/k2/doc/drn/KSCI-19156-001_K2-DRN35_C6.pdf) on the reprocessing of Campaign 6:"
    ]

--- a/docs/source/tutorials/3-science-examples/asteroseismology-estimating-mass-and-radius.ipynb
+++ b/docs/source/tutorials/3-science-examples/asteroseismology-estimating-mass-and-radius.ipynb
@@ -125,7 +125,7 @@
     "id": "83w84X7O-cFt"
    },
    "source": [
-    "In one of the companion tutorials, we already identified the location of the modes of oscillation, so we'll zoom in on that region right away when creating the periodogram. We also set the [`normalization='psd'`](https://docs.lightkurve.org/api/lightkurve.periodogram.LombScarglePeriodogram.html#lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve) keyword argument, to match the common conventions in asteroseismology of solar-like oscillators."
+    "In one of the companion tutorials, we already identified the location of the modes of oscillation, so we'll zoom in on that region right away when creating the periodogram. We also set the [`normalization='psd'`](https://docs.lightkurve.org/reference/api/lightkurve.periodogram.LombScarglePeriodogram.html#lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve) keyword argument, to match the common conventions in asteroseismology of solar-like oscillators."
    ]
   },
   {

--- a/docs/source/tutorials/3-science-examples/periodograms-measuring-a-rotation-period.ipynb
+++ b/docs/source/tutorials/3-science-examples/periodograms-measuring-a-rotation-period.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "We're going to explore a star named KIC 2157356, which is part of the cohort of rotating stars that were studied by *Kepler* and analyzed in a research paper by [McQuillan et al. (2014)](https://arxiv.org/abs/1402.5694).\n",
     "\n",
-    "Because rotation variability tends to happen on relatively long time scales (for instance, the Sun rotates every 25 days), we will start by downloading three ~90-day long quarters of *Kepler* data and then combine them using Lightkurve's [`stitch()`](https://docs.lightkurve.org/api/lightkurve.collections.LightCurveCollection.html#lightkurve.collections.LightCurveCollection.stitch) feature."
+    "Because rotation variability tends to happen on relatively long time scales (for instance, the Sun rotates every 25 days), we will start by downloading three ~90-day long quarters of *Kepler* data and then combine them using Lightkurve's [`stitch()`](https://docs.lightkurve.org/reference/api/lightkurve.collections.LightCurveCollection.html#lightkurve.collections.LightCurveCollection.stitch) feature."
    ]
   },
   {

--- a/docs/source/tutorials/3-science-examples/periodograms-verifying-the-location-of-a-signal.ipynb
+++ b/docs/source/tutorials/3-science-examples/periodograms-verifying-the-location-of-a-signal.ipynb
@@ -449,7 +449,7 @@
    "source": [
     "In this case, we can clearly see an eclipse to the left of our target. The eclipsing binary is outside of the pipeline aperture, but the signal is strong enough to have contaminated it. And sure enough, if we check on the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=K00311.01&type=KEPLER_CANDIDATE), KOI 311 was designated a false positive in the first data release it was included in.\n",
     "\n",
-    "We can double-check this by using Lightkurve's [cone search](https://docs.lightkurve.org/api/lightkurve.search.search_lightcurvefile.html#lightkurve.search.search_lightcurvefile) to look for the eclipsing binary in question. So long as there's a light curve for this contaminant — and we can reasonably expect one, for such a star — we'll be able to find it with Lightkurve's search function.\n",
+    "We can double-check this by using Lightkurve's [cone search](https://docs.lightkurve.org/reference/api/lightkurve.search.search_lightcurvefile.html#lightkurve.search.search_lightcurvefile) to look for the eclipsing binary in question. So long as there's a light curve for this contaminant — and we can reasonably expect one, for such a star — we'll be able to find it with Lightkurve's search function.\n",
     "\n",
     "(As an aside, if you run this notebook yourself, you can use the [interact_sky()](https://docs.lightkurve.org/reference/api/lightkurve.KeplerTargetPixelFile.interact_sky.html?highlight=interact_sky#lightkurve.KeplerTargetPixelFile.interact_sky) function, which returns an interactive TPF widget with targets labelled by _Gaia_ ID. This includes many targets which were not collected by _Kepler_ or _K2_.)\n",
     "\n",

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -362,6 +362,7 @@ class LightCurve(QTimeSeries):
                 name not in self.__dict__
                 and not name.startswith("_")
                 and not self._new_attributes_relax
+                and name != 'meta'
             ):
                 warnings.warn(
                     (

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -368,7 +368,7 @@ class LightCurve(QTimeSeries):
                     (
                         "Lightkurve doesn't allow columns or meta values to be created via a new attribute name."
                         "A new attribute is created. It will not be carried over when the object is copied."
-                        " - see https://docs.lightkurve.org/api/lightkurve.lightcurve.LightCurve.html"
+                        " - see https://docs.lightkurve.org/reference/api/lightkurve.LightCurve.html"
                     ),
                     UserWarning,
                     stacklevel=2,

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1362,6 +1362,30 @@ def test_attr_access_meta():
     assert lc.keycase == "value lower"  # the meta entry with exact case is retrieved
 
 
+@pytest.mark.parametrize(
+    "lc",
+    [
+        LightCurve(time=[1, 2, 3], flux=[4, 5, 6], meta={'SECTOR': 5}),
+        LightCurve(time=[1, 2, 3], flux=[4, 5, 6]),
+    ],
+)
+def test_meta_assignment(lc):
+    """Test edge cases in trying to assign meta (#1046)"""
+
+    # ensure lc.meta assignment does not emit any warnings.
+    meta_new = {'TSTART': 123456789.0}
+    with pytest.warns(None) as record:
+        lc.meta = meta_new
+
+    if (len(record) > 0):
+        pytest.fail(f"{len(record)} unexpected warning: {record[0]}")
+
+    # for the case existing meta is not empty
+    # ensure the assignment overwrites it
+    # (rather than just copying the values over to the existing one)
+    assert lc.meta == meta_new
+
+
 def test_attr_access_others():
     """Test accessing attributes, misc. boundary cases"""
     u_e_s = u.electron / u.second


### PR DESCRIPTION
Closes #1046

Additional, outdated API links in various tutorials have been fixed too.

(API doc URLs were changed from 
`https://docs.lightkurve.org/api/...` to `https://docs.lightkurve.org/reference/api/...`

