### PR TITLE
Include source in apidoc output

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.mathjax',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
     'nbsphinx',
     'numpydoc',
     'sphinxcontrib.rawfiles']


### PR DESCRIPTION
api doc output is tweaked to that it includes sources, similar to what astropy and various python library do.

Changes:
![image](https://user-images.githubusercontent.com/250644/117044872-bfb76700-acc3-11eb-827e-bd3137b2a5f6.png)

Click source:

![image](https://user-images.githubusercontent.com/250644/117044934-ce058300-acc3-11eb-9890-b293ca2d2ffb.png)
