### PR TITLE
Add a conda environment.yml file for standardizing a quickstart dev env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,40 @@
+name: lightkurve_env
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.7
+  - numpy
+  - scipy
+  - matplotlib
+  - astropy>=4.1
+  - astroquery>=0.3.10
+  - beautifulsoup4
+  - tqdm
+  - pandas
+  - bokeh
+  - jupyter
+  - oktopus
+  - ipython
+  - seaborn
+  - scikit-learn
+  - requests
+  - pytest
+  - sphinx # for documentation and testing
+  - nbsphinx # for documentation and testing
+  - numpydoc # for documentation and testing
+  - sphinx-automodapi # for documentation and testing
+  - black
+  - isort
+  - tox
+  - uncertainties
+  - mypy
+  - pip
+  - pip:
+      #- sphinxcontrib-rawfiles
+      #- twine
+      #- pydata-sphinx-theme
+      #- pytest-remotedata
+      #- pytest-doctestplus
+      #- pytest-cov
+      - fbpca


### PR DESCRIPTION
In [this comment](https://github.com/lightkurve/lightkurve/issues/268#issuecomment-443364489) from 2018, I thought it'd be convenient to provide a quickstart developer environment to get students or developers started on a common, standardized, sandboxed python environment.  I still think that's a good idea!  So here is the start of a pull request for such an `environment.yml` file.  

This approach has some drawbacks.  First there are new cool ways to install Python dependencies, including poetry, etc.  I am not as familiar with these!  Second, we'd have to support this environment file and constantly keep it up-to-date with whatever new versions of dependencies we hinge upon.  That sounds like a nightmare.  So definitely some drawbacks.  But the plus side is that it serves as a quick go-to for many who want to try out a project without disturbing their existing python installs.

The location in the root of the repo need not endure.  We could put it as a gist or as a documentation resource for example.  The root of the repo is nice because someone new to the project who is familiar with conda envs can start that-much-more-easily.  But the root of the repo is already cluttered, so either way is fine.