### PR TITLE
Fix test_search_tesscut error

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -147,7 +147,7 @@ def test_search_tesscut():
     assert len(search_tesscut("pi Mensae", sector=1).table) == 1
     assert len(search_tesscut("pi Mensae").table) > 1
     # Cutout by TIC ID
-    assert len(search_tesscut("TIC 206669860", sector=2).table) == 1
+    assert len(search_tesscut("TIC 206669860", sector=28).table) == 1
     # Cutout by RA, dec string
     search_string = search_tesscut("30.578761, -83.210593")
     # Cutout by SkyCoord


### PR DESCRIPTION
It should fix the persistent remote-data test failure in CI.

Somehow the expected TESSCut product "TIC 206669860", sector=2 is no longer there. There is one from sector 28. Changed the test code to use the one that exists.

BTW, is that something that should happen (a product seems to be removed from TESSCut service) at all on TESSCut side?