### PR TITLE
Fix tesscut dowload phantom error with downlooad_dir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+# temp directory generated in test
+#  (that should have been cleaned up automatically in nomral test run)
+temp_lk_cache_4test_*
 
 # Translations
 *.mo

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@
 - Fixed a bug in ``TargetPixelFile.interact()`` when ``ylim_func`` is specified and
   users tap to select custom apertures. [#1033]
 
+- Fixed a bug in ``search_tesscut().download()`` when ``download_dir`` is specified.
+  [#1063]
+
 
 2.0.9 (2021-03-31)
 ==================

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -531,7 +531,7 @@ class SearchResult(object):
             cutout_path = TesscutClass().download_cutouts(
                 coords, size=cutout_size, sector=sector, path=tesscut_dir
             )
-            path = os.path.join(download_dir, cutout_path[0][0])
+            path = cutout_path[0][0]  # the cutoutpath already contains testcut_dir
             log.debug("Finished downloading.")
         return path
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -194,6 +194,13 @@ def test_search_tesscut_download(caplog):
         log.setLevel("DEBUG")
         tpf_cached = search_string[0].download(cutout_size=(3, 5))
         assert "Cached file found." in caplog.text
+        # test #1063 - ensure when download_dir is specified, there is no error
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory(dir=".", prefix="temp_lk_cache_4test_") as download_dir:
+            # ensure relative path works, the bug in #1063
+            tpf_w_download_dir = search_string[0].download(cutout_size=(3, 5), download_dir=download_dir)
+            assert tpf_w_download_dir.flux[0].shape == (3, 5)
+            tpf_w_download_dir = None  # remove the tpf reference so that the underlying file can be deleted on Windows
     except HTTPError as exc:
         # TESSCut will occasionally return a "504 Gateway Timeout error" when
         # it is overloaded.  We don't want this to trigger a test failure.


### PR DESCRIPTION
Closes #1063

The old code for generating the path
```python
 os.path.join(download_dir, cutout_path[0][0])
```
would append an addtional download_dir.

It works in typical case, because in typical case the download dir is an absolute path, e.g. `/usr/lk/.lightkurve-cache`. The os path join's behavior is such that it will detect that the path is already part of the argument, and won't join it again. 

In other words, the `join()` function is smart enough to hide the bug in the case where the path is absolute.