### PR TITLE
Mark remote data for applicable tests

### DIFF
--- a/tests/prf/test_prfmodel.py
+++ b/tests/prf/test_prfmodel.py
@@ -12,6 +12,7 @@ from lightkurve.prf import KeplerPRF, SimpleKeplerPRF
 from lightkurve.targetpixelfile import KeplerTargetPixelFile
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_prf_normalization():
     """Does the PRF model integrate to the requested flux across the focal plane?"""
     for channel in [1, 20, 40, 60, 84]:
@@ -26,6 +27,7 @@ def test_prf_normalization():
                 assert np.isclose(prf_sum, flux, rtol=0.1)
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_simple_kepler_prf():
     """Ensures that concentric PRFs have the same values."""
     prf_1 = SimpleKeplerPRF(channel=16, shape=[20, 20], column=0, row=0)
@@ -54,6 +56,7 @@ def test_simple_kepler_prf_interpolation_consistency():
     np.isclose(np.sum(np.abs(sprf_data - cal_prf_subsampled_normalized)), 0)
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_get_model_prf():
     tpf_fn = get_pkg_data_filename("../../tests/data/test-tpf-star.fits")
     tpf = KeplerTargetPixelFile(tpf_fn)
@@ -70,6 +73,7 @@ def test_get_model_prf():
     assert prf.row == prf_from_tpf.row
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_keplerprf_gradient_against_simplekeplerprf():
     """is the gradient of KeplerPRF consistent with
     the gradient of SimpleKeplerPRF?
@@ -82,6 +86,7 @@ def test_keplerprf_gradient_against_simplekeplerprf():
     assert_allclose(prf_grad[:-3], simple_prf.gradient(**params))
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 @pytest.mark.parametrize(
     "param_to_test",
     [

--- a/tests/prf/test_tpfmodel.py
+++ b/tests/prf/test_tpfmodel.py
@@ -50,12 +50,14 @@ def test_backgroundprior():
     assert not np.isfinite(bp(flux + 0.1))
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_tpf_model_simple():
     prf = SimpleKeplerPRF(channel=16, shape=[10, 10], column=15, row=15)
     model = TPFModel(prfmodel=prf)
     assert model.prfmodel.channel == 16
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_tpf_model():
     col, row, flux, bgflux = 1, 2, 3, 4
     shape = (7, 8)
@@ -136,6 +138,7 @@ def test_tpf_model_fitting():
     phot.run([tpf[1].data])
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_empty_model():
     """Can we fit the background flux in a model without stars?"""
     shape = (4, 3)
@@ -147,6 +150,7 @@ def test_empty_model():
     assert np.isclose(results.background.flux, bgflux, rtol=1e-2)
 
 
+@pytest.mark.remote_data  # PRF relies on calibration files on stsci.edu
 def test_model_with_one_star():
     """Can we fit the background flux in a model with one star?"""
     channel = 42

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -59,6 +59,7 @@ def test_graceful_exit_outside_notebook():
     assert result is None
 
 
+@pytest.mark.remote_data  # due to test (TABBY_TPF is remote)
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_custom_aperture_mask():
     """Can we provide a custom lightcurve to show?"""
@@ -77,6 +78,7 @@ def test_custom_aperture_mask():
         tpf.interact(aperture_mask=mask)
 
 
+@pytest.mark.remote_data  # due to test (TABBY_TPF is remote)
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_custom_exported_filename():
     """Can we provide a custom lightcurve to show?"""
@@ -98,6 +100,7 @@ def test_custom_exported_filename():
         tpf[mask].interact()
 
 
+@pytest.mark.remote_data  # due to test (TABBY_TPF is remote)
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_transform_and_ylim_funcs():
     """Test the transform_func and ylim_func"""

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -999,6 +999,7 @@ def test_targetid():
     assert lc.targetid == 20
 
 
+@pytest.mark.remote_data  # due to test (K2_C08 is remote)
 def test_regression_346():
     """Regression test for https://github.com/lightkurve/lightkurve/issues/346"""
     # This previously triggered an IndexError:

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -602,6 +602,7 @@ def test_interact_sky():
         tpf.interact_sky()
 
 
+@pytest.mark.remote_data  # get_model / get_prf_model relies on calibration files on stsci.edu
 def test_get_models():
     """Can we obtain PRF and TPF models?"""
     tpf = KeplerTargetPixelFile(filename_tpf_all_zeros, quality_bitmask=None)


### PR DESCRIPTION
Closes #1062 

Ready, pending discussion on exactly what we should do:
1. The PR currently will make all PRF / TPF Model tests run only on remote-data, currently linux 3.8 in the CI. I suspect we still want the logic underlying PRF / TPF models be tested in a variety of OS/Python version. Thoughts?

2. Outside of tests involving PRF / TPF models, there are 4 tests marked as remote-data. I think most, if not all, can be converted to using local data.
  i. 3 tests in `test_interact.py`: they all rely on the remote Kepler `TABBY_TPF` file. We could replace it with a local test FIS file with 1st cadence only. If there is concern that 1st cadence only is not realistic enough, we could use a local FITS file , say, 1 day worth of cadence.
  ii. `test_lightcurve.py::test_regression_346()`: it relies on a remote `K2_C08` lc file. The test seems to need test files with specific characteristics. So a simple trim to first cadence would not do.

3. I tried to tweak the CI so that we have a test config that simulates environments without network, so that any future tests missing `remote-data` mark would be exposed right away during CI tests. The tweak, which involves `pytest-socket` plugin, unfortunately doesn't fully  work so I backed it out. It is blocked by https://github.com/miketheman/pytest-socket/issues/65.


