### PR TITLE
Add a `select_flux()` method to the LightCurve class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@
 - Fixed a bug in ``LightCurveCollection`` and ``TargetPixelFileCollection``, where
   indexing by slice, e.g., ``lc_collection[0:2]``, incorrectly returns a ``list`` [#1077]
 
+- Added the ``LightCurve.select_flux()`` method to make it easier to use a different
+  column to populate the ``flux`` and ``flux_err`` columns. [#1076]
+
 
 2.0.9 (2021-03-31)
 ==================

--- a/docs/source/reference/lightcurve.rst
+++ b/docs/source/reference/lightcurve.rst
@@ -83,7 +83,7 @@ The following methods all return a new `LightCurve` object.
   LightCurve.normalize
   LightCurve.remove_nans
   LightCurve.remove_outliers
-  LightCurve.set_flux
+  LightCurve.select_flux
   LightCurve.tail
   LightCurve.truncate
 

--- a/docs/source/reference/lightcurve.rst
+++ b/docs/source/reference/lightcurve.rst
@@ -83,6 +83,7 @@ The following methods all return a new `LightCurve` object.
   LightCurve.normalize
   LightCurve.remove_nans
   LightCurve.remove_outliers
+  LightCurve.set_flux
   LightCurve.tail
   LightCurve.truncate
 

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -115,5 +115,6 @@ def read_generic_lightcurve(
     tab.meta["RA"] = hdulist[0].header.get("RA_OBJ")
     tab.meta["DEC"] = hdulist[0].header.get("DEC_OBJ")
     tab.meta["FILENAME"] = filename
+    tab.meta["FLUX_ORIGIN"] = flux_column
 
     return LightCurve(time=time, data=tab)

--- a/tests/io/test_cdips.py
+++ b/tests/io/test_cdips.py
@@ -34,6 +34,7 @@ def test_read_cdips():
     for ext in exts:
         lc = read_cdips_lightcurve(url, flux_column=ext)
         assert type(lc).__name__ == "TessLightCurve"
+        assert lc.meta["FLUX_ORIGIN"] == ext.lower()
         # Are `time` and `flux` consistent with the FITS file?
         assert_array_equal(f[1].data['TMID_BJD'][lc.meta['QUALITY_MASK']],
                            lc.time.value)

--- a/tests/io/test_pathos.py
+++ b/tests/io/test_pathos.py
@@ -33,6 +33,7 @@ def test_read_pathos():
     for ext in exts:
         lc = read_pathos_lightcurve(url, flux_column=ext)
         assert type(lc).__name__ == "TessLightCurve"
+        assert lc.meta["FLUX_ORIGIN"] == ext.lower()
         # Are `time` and `flux` consistent with the FITS file?
         assert_array_equal(f[1].data["TIME"][lc.meta["QUALITY_MASK"]], lc.time.value)
         assert_array_equal(f[1].data[ext][lc.meta["QUALITY_MASK"]], lc.flux.value)

--- a/tests/io/test_tasoc.py
+++ b/tests/io/test_tasoc.py
@@ -27,10 +27,8 @@ def test_read_tasoc():
 
     lc = read_tasoc_lightcurve(url, flux_column="FLUX_RAW")
 
-    flux_lc = lc.flux.value
-
-    # print(flux_lc, fluxes)
-    assert np.sum(fluxes) == np.sum(flux_lc)
+    assert lc.meta["FLUX_ORIGIN"] == "flux_raw"
+    assert_array_equal(fluxes, lc.flux.value)
 
 
 @pytest.mark.remote_data

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -162,6 +162,7 @@ def test_KeplerLightCurveFile(path, mission):
     assert lc.time.format == "bkjd"
     assert lc.time.scale == "tdb"
     assert lc.flux.unit == u.electron / u.second
+    assert lc.meta["FLUX_ORIGIN"] == "sap_flux"
 
     # Does the data match what one would obtain using pyfits.open?
     hdu = pyfits.open(path)
@@ -191,6 +192,7 @@ def test_TessLightCurveFile(quality_bitmask):
     assert lc.ccd == hdu[0].header["CCD"]
     assert lc.ra == hdu[0].header["RA_OBJ"]
     assert lc.dec == hdu[0].header["DEC_OBJ"]
+    assert lc.meta["FLUX_ORIGIN"] == "sap_flux"
 
     assert_array_equal(lc.time[0:10].value, hdu[1].data["TIME"][0:10])
     assert_array_equal(lc.flux[0:10].value, hdu[1].data["SAP_FLUX"][0:10])

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1589,3 +1589,23 @@ def test_head_tail_truncate():
     assert all(lc.truncate(2, 4).flux == [2, 3, 4])
     assert lc.truncate(before=2).head(1).flux == 2
     assert lc.truncate(after=3).tail(1).flux == 3
+
+
+def test_set_flux():
+    """Simple test for the `LightCurve.set_flux()` method."""
+    lc = LightCurve(data={'time': [1,2,3],
+                          'newflux': [4, 5, 6],
+                          'newflux_err': [7, 8, 9]})
+    # Can we set flux to newflux?
+    assert all(lc.set_flux("newflux").flux == lc.newflux)
+    # Did `set_flux()` return a copy rather than operating in place?
+    assert not all(lc.flux == lc.newflux)
+    # Does `set_flux()` set the error column by default?
+    assert all(lc.set_flux("newflux").flux_err == lc.newflux_err)
+    # Can a different error column be specified?
+    assert all(lc.set_flux("newflux", flux_err_column="newflux").flux_err == lc.newflux)
+    # Do invalid column names raise a ValueError?
+    with pytest.raises(ValueError):
+        lc.set_flux("doesnotexist")
+    with pytest.raises(ValueError):
+        lc.set_flux("newflux", "doesnotexist")

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1591,21 +1591,22 @@ def test_head_tail_truncate():
     assert lc.truncate(after=3).tail(1).flux == 3
 
 
-def test_set_flux():
-    """Simple test for the `LightCurve.set_flux()` method."""
+def test_select_flux():
+    """Simple test for the `LightCurve.select_flux()` method."""
     lc = LightCurve(data={'time': [1,2,3],
                           'newflux': [4, 5, 6],
                           'newflux_err': [7, 8, 9]})
     # Can we set flux to newflux?
-    assert all(lc.set_flux("newflux").flux == lc.newflux)
-    # Did `set_flux()` return a copy rather than operating in place?
+    assert all(lc.select_flux("newflux").flux == lc.newflux)
+    assert lc.select_flux("newflux").meta["FLUX_ORIGIN"] == "newflux"
+    # Did `select_flux()` return a copy rather than operating in place?
     assert not all(lc.flux == lc.newflux)
-    # Does `set_flux()` set the error column by default?
-    assert all(lc.set_flux("newflux").flux_err == lc.newflux_err)
+    # Does `select_flux()` set the error column by default?
+    assert all(lc.select_flux("newflux").flux_err == lc.newflux_err)
     # Can a different error column be specified?
-    assert all(lc.set_flux("newflux", flux_err_column="newflux").flux_err == lc.newflux)
+    assert all(lc.select_flux("newflux", flux_err_column="newflux").flux_err == lc.newflux)
     # Do invalid column names raise a ValueError?
     with pytest.raises(ValueError):
-        lc.set_flux("doesnotexist")
+        lc.select_flux("doesnotexist")
     with pytest.raises(ValueError):
-        lc.set_flux("newflux", "doesnotexist")
+        lc.select_flux("newflux", "doesnotexist")


### PR DESCRIPTION
This PR intends to address #1072 by adding a `set_flux` method to the `LightCurve` class.

This method enables users to assign a different column to act as the main `flux` (and `flux_err`) column, which is what most `LightCurve` methods operate on by default.

For example, the syntax for assigning the values of the `sap_flux` column to the main `flux` column will now be:

```python
lc = lc.set_flux(flux_column="sap_flux")
```

Optionally, the error column can be specified, though it already defaults to `f"{flux_column}_err"` (if available) for convenience, so specifying it is not actually necessary in this example:

```python
lc = lc.set_flux(flux_column="sap_flux", flux_err_column="sap_flux_err")
```

The main reason for adding `set_flux` is that it remove the need for every LightCurve method to accept and support a `flux_column` parameter. For example, a periodogram can now be created from `sap_flux` data as follows:

```python
import lightkurve as lk
lc = lk.search_lightcurve("Pi Men", sector=1, author="SPOC").download()
lc.set_flux("sap_flux").to_periodogram("lombscargle").plot()
```

Does anyone have questions/thoughts/concerns?