### PR TITLE
Use SAP_FLUX as the default flux for MIT QLP light curves

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@
 - Added the ``LightCurve.select_flux()`` method to make it easier to use a different
   column to populate the ``flux`` and ``flux_err`` columns. [#1076]
 
+- Modified the MIT Quicklook Pipeline (QLP) light curve file reader to use the "SAP_FLUX"
+  column as the default flux column. [#1083]
+
 
 2.0.9 (2021-03-31)
 ==================

--- a/src/lightkurve/io/qlp.py
+++ b/src/lightkurve/io/qlp.py
@@ -9,15 +9,22 @@ from ..utils import TessQualityFlags
 from .generic import read_generic_lightcurve
 
 
-def read_qlp_lightcurve(filename, flux_column="kspsap_flux", quality_bitmask="default"):
-    """Returns a `TessLightCurve`.
+def read_qlp_lightcurve(filename, flux_column="sap_flux", flux_err_column="kspsap_flux_err", quality_bitmask="default"):
+    """Returns a `TessLightCurve` object given a light curve file from the MIT Quicklook Pipeline (QLP).
+
+    By default, QLP's `sap_flux` column is used to populate the `flux` values,
+    and 'kspsap_flux_err' is used to populate `flux_err`. For a discussion
+    related to this choice, see https://github.com/lightkurve/lightkurve/issues/1083
 
     Parameters
     ----------
     filename : str
         Local path or remote url of a QLP light curve FITS file.
-    flux_column : 'pdcsap_flux' or 'sap_flux'
+    flux_column : 'sap_flux', 'kspsap_flux', 'kspsap_flux_sml', 'kspsap_flux_lag', or 'sap_bkg'
         Which column in the FITS file contains the preferred flux data?
+        By default the "Simple Aperture Photometry" flux (sap_flux) is used.
+    flux_err_column: 'kspsap_flux_err', or 'sap_bkg_err'
+      Which column in the FITS file contains the preferred flux_err data?
     quality_bitmask : str or int
         Bitmask (integer) which identifies the quality flag bitmask that should
         be used to mask out bad cadences. If a string is passed, it has the
@@ -33,7 +40,7 @@ def read_qlp_lightcurve(filename, flux_column="kspsap_flux", quality_bitmask="de
 
         See the :class:`TessQualityFlags` class for details on the bitmasks.
     """
-    lc = read_generic_lightcurve(filename, flux_column=flux_column, time_format="btjd")
+    lc = read_generic_lightcurve(filename, flux_column=flux_column, flux_err_column=flux_err_column, time_format="btjd")
 
     # Filter out poor-quality data
     # NOTE: Unfortunately Astropy Table masking does not yet work for columns

--- a/tests/io/test_qlp.py
+++ b/tests/io/test_qlp.py
@@ -1,0 +1,34 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from lightkurve import search_lightcurve
+from lightkurve.io.qlp import read_qlp_lightcurve
+from lightkurve.io.detect import detect_filetype
+
+
+@pytest.mark.remote_data
+def test_qlp():
+    """Can we read in QLP light curves?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/qlp/s0011/0000/0002/7755/4109/hlsp_qlp_tess_ffi_s0011-0000000277554109_tess_v01_llc.fits"    
+    with fits.open(url, mode="readonly") as hdulist:
+        # Can we auto-detect a QLP file?
+        assert detect_filetype(hdulist) == "QLP"
+        # Are the correct fluxes read in?
+        lc = read_qlp_lightcurve(url, quality_bitmask=0)
+        assert lc.meta["FLUX_ORIGIN"] == "sap_flux"
+        assert_array_equal(lc.flux.value, hdulist[1].data["SAP_FLUX"])
+
+
+@pytest.mark.remote_data
+def test_search_qlp():
+    """Can we search and download QLP light curves from MAST?"""
+    search = search_lightcurve("TIC 277554109", author="QLP", sector=11)
+    assert len(search) == 1
+    assert search.table["author"][0] == "QLP"
+    lc = search.download()
+    assert type(lc).__name__ == "TessLightCurve"
+    assert lc.sector == 11
+    assert lc.author == "QLP"


### PR DESCRIPTION
This PR intends to resolve #1083.