### PR TITLE
fix lc.bin() excessive memory usage in some cases

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data, 3.9]
+        name: [3.6, 3.7, 3.8-remote-data, 3.8-memtest, 3.9]
         include:
           - name: 3.6
             python-version: 3.6

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -31,6 +31,9 @@ jobs:
           - name: 3.8-remote-data
             python-version: 3.8
             pytest-command: poetry run pytest --remote-data --doctest-modules
+          - name: 3.8-memtest
+            python-version: 3.8
+            pytest-command: poetry run pytest -m memtest
           - name: 3.9
             python-version: 3.9
             pytest-command: poetry run pytest

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -33,7 +33,7 @@ jobs:
             pytest-command: poetry run pytest --remote-data --doctest-modules
           - name: 3.8-memtest
             python-version: 3.8
-            pytest-command: poetry run pytest -m memtest
+            pytest-command: poetry run pytest -m memtest --remote-data
           - name: 3.9
             python-version: 3.9
             pytest-command: poetry run pytest

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1386,13 +1386,13 @@ class LightCurve(QTimeSeries):
         if time_bin_size is None:
             if bins is not None:
                 i = len(self.time) - np.searchsorted(
-                    self.time, time_bin_start - 1 * u.ns
+                    self.time.value, time_bin_start.value - 1e-10
                 )
                 time_bin_size = (
                     (self.time[-1] - time_bin_start) * i / ((i - 1) * bins)
                 ).to(u.day)
             elif binsize is not None:
-                i = np.searchsorted(self.time, time_bin_start - 1 * u.ns)
+                i = np.searchsorted(self.time.value, time_bin_start.value - 1e-10)
                 time_bin_size = (self.time[i + binsize] - self.time[i]).to(u.day)
             else:
                 time_bin_size = 0.5 * u.day

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,13 @@ def pytest_runtest_setup(item):
 
     matplotlib.use("Agg")
 
+# Add a marker @pytest.mark.memtest
+# - used to mark tests that stress memory, typically done by limiting the memory Python can use
+# - thus they should be run in isolation.
+#
+# - skipped by default
+# - tests marked as such can be run by "-m memtest" option
+
 
 def pytest_configure(config):
     config.addinivalue_line(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+import pytest
+
+
 def pytest_runtest_setup(item):
-    """Our tests will often run in headless virtual environments. For this
+    r"""Our tests will often run in headless virtual environments. For this
     reason, we enforce the use of matplotlib's robust Agg backend, because it
     does not require a graphical display.
 
@@ -10,3 +13,21 @@ def pytest_runtest_setup(item):
     import matplotlib
 
     matplotlib.use("Agg")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "memtest: mark memory usage tests that need to be run in isolation"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    keywordexpr = config.option.keyword
+    markexpr = config.option.markexpr
+    if keywordexpr or markexpr:
+        return  # let pytest handle this
+
+    skip_memtest = pytest.mark.skip(reason='memtest skipped, need -m memtest option to run')
+    for item in items:
+        if 'memtest' in item.keywords:
+            item.add_marker(skip_memtest)

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -634,20 +634,24 @@ def duplicate_and_stitch(lc, num_copies):
     return LightCurveCollection(lcc).stitch()
 
 
-lc_for_mem_test = duplicate_and_stitch(read(TESS_SIM), 10)
 
 @pytest.mark.memtest
 @pytest.mark.skipif(bad_resource_module_imports, reason="Requires resource module, only available for Unix")
+@pytest.mark.remote_data
 @pytest.mark.parametrize(
-    "lc, dict_of_bin_args",
+    "dict_of_bin_args",
     [  # variants for lc.bin() call, they all result in roughly the same number of bins.
-        (lc_for_mem_test, dict(bins=10000)),
-        (lc_for_mem_test, dict(binsize=10)),
-        (lc_for_mem_test, dict(time_bin_size=20 * u.min)),
+        dict(bins=10000),
+        dict(binsize=10),
+        dict(time_bin_size=20 * u.min),
     ]
 )
-def test_bin_memory_usage(lc, dict_of_bin_args):
+def test_bin_memory_usage(dict_of_bin_args):
     """Ensure lc.bin() does not use excessive memory (#1092)"""
+
+    # create a large lightcurve that could stress memory
+    lc = duplicate_and_stitch(read(TESS_SIM), 10)
+
     import resource
 
     # empirically, need about 1.1Gb just to open and stitch the lc

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -613,6 +613,58 @@ def test_bin_quality():
     assert_allclose(binned_lc.centroid_row, [2./3, 2])  # Expect mean
 
 
+# BEGIN codes for lc.bin memory usage test
+#
+
+bad_resource_module_imports = False
+try:
+    import resource  # supported on Unix only
+except ImportError:
+    bad_resource_module_imports = True
+
+
+def duplicate_and_stitch(lc, num_copies):
+    """Helper to create a large LC by duplicating and stitching the supplied one"""
+    duration = lc.time.max() - lc.time.min()
+    lcc = [lc]
+    for i in range(1, num_copies):
+        lc_copy = lc.copy()
+        lc_copy.time = lc_copy.time + (duration + 1 * u.day) * i
+        lcc.append(lc_copy)
+    return LightCurveCollection(lcc).stitch()
+
+
+lc_for_mem_test = duplicate_and_stitch(read(TESS_SIM), 10)
+
+@pytest.mark.memtest
+@pytest.mark.skipif(bad_resource_module_imports, reason="Requires resource module, only available for Unix")
+@pytest.mark.parametrize(
+    "lc, dict_of_bin_args",
+    [  # variants for lc.bin() call, they all result in roughly the same number of bins.
+        (lc_for_mem_test, dict(bins=10000)),
+        (lc_for_mem_test, dict(binsize=10)),
+        (lc_for_mem_test, dict(time_bin_size=20 * u.min)),
+    ]
+)
+def test_bin_memory_usage(lc, dict_of_bin_args):
+    """Ensure lc.bin() does not use excessive memory (#1092)"""
+    import resource
+
+    # empirically, need about 1.1Gb just to open and stitch the lc
+    # (with ipython kernel)
+    # if we hit excessive memory usage like those in #1092,
+    # the system can easily need another 1+ Gb.
+    memory_limit = 1.5 * 1024 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
+
+    # Ensure it does not result in  Out of Memory Error
+    with warnings.catch_warnings():  # lc.bin(binsize=n) is  is deprecated
+        warnings.simplefilter("ignore", LightkurveDeprecationWarning)
+        lc_b = lc.bin(**dict_of_bin_args)
+
+#
+# END codes for lc.bin memory usage test
+
 def test_normalize():
     """Does the `LightCurve.normalize()` method normalize the flux?"""
     lc = LightCurve(

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -658,7 +658,7 @@ def test_bin_memory_usage(dict_of_bin_args):
     # (with ipython kernel)
     # if we hit excessive memory usage like those in #1092,
     # the system can easily need another 1+ Gb.
-    memory_limit = 1.5 * 1024 * 1024 * 1024
+    memory_limit = int(1.5 * 1024 * 1024 * 1024)
     resource.setrlimit(resource.RLIMIT_AS, (memory_limit, memory_limit))
 
     # Ensure it does not result in  Out of Memory Error


### PR DESCRIPTION
Closes #1092 

- Fixed by avoiding the astropy bug 
  - The alternative, raising minimum astropy to 4.2, would require us to drop Python 3.6 support
- A test is added. It is run in isolation in a new CI check `3.8-memtest` (on Linux)
