### PR TITLE
Fix apidoc tpf.to_lightcurve()

### DIFF
--- a/docs/source/reference/correctors.rst
+++ b/docs/source/reference/correctors.rst
@@ -105,3 +105,5 @@ A DesignMatrix supports the following operations:
   :toctree: api/
 
   corrector.Corrector
+  corrector.Corrector.correct
+  corrector.Corrector.diagnose

--- a/docs/source/reference/targetpixelfile.rst
+++ b/docs/source/reference/targetpixelfile.rst
@@ -43,6 +43,7 @@ Constructor
    KeplerTargetPixelFile.to_lightcurve
    KeplerTargetPixelFile.extract_aperture_photometry
    KeplerTargetPixelFile.extract_prf_photometry
+   KeplerTargetPixelFile.get_model
    KeplerTargetPixelFile.create_threshold_mask
    KeplerTargetPixelFile.estimate_background
    KeplerTargetPixelFile.estimate_centroids

--- a/docs/source/reference/targetpixelfile.rst
+++ b/docs/source/reference/targetpixelfile.rst
@@ -41,6 +41,8 @@ Constructor
    KeplerTargetPixelFile.wcs
    KeplerTargetPixelFile.get_coordinates
    KeplerTargetPixelFile.to_lightcurve
+   KeplerTargetPixelFile.extract_aperture_photometry
+   KeplerTargetPixelFile.extract_prf_photometry
    KeplerTargetPixelFile.create_threshold_mask
    KeplerTargetPixelFile.estimate_background
    KeplerTargetPixelFile.estimate_centroids

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2362,16 +2362,18 @@ class LightCurve(QTimeSeries):
         Parameters
         ----------
         methods : string
-            Currently, only "sff" is supported.  This will return a
-            `SFFCorrector` class instance.
+            Currently, "sff" and "cbv" are supported.  This will return a
+            `~correctors.SFFCorrector` and `~correctors.CBVCorrector`
+            class instance respectively.
          **kwargs : dict
             Extra keyword arguments to be passed to the corrector class.
 
         Returns
         -------
-        correcter : `lightkurve.Correcter`
-            Instance of a Corrector class, which typically provides `correct()`
-            and `diagnose()` methods.
+        correcter : `~correctors.corrector.Corrector`
+            Instance of a Corrector class, which typically provides
+            `~correctors.corrector.Corrector.correct()`
+            and `~correctors.corrector.Corrector.diagnose()` methods.
         """
         if method == "pld":
             raise ValueError(

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -540,17 +540,25 @@ class TargetPixelFile(object):
     def to_lightcurve(self, method="sap", corrector=None, **kwargs):
         """Performs photometry on the pixel data and returns a LightCurve object.
 
-        See the docstring of `aperture_photometry()` for valid
-        arguments if the method is 'aperture'.  Otherwise, see the docstring
-        of `prf_photometry()` for valid arguments if the method is 'prf'.
+        The valid keyword arguments depends on the method chosen:
+
+        - 'sap' or 'aperture': see the docstring of `extract_aperture_photometry()`
+        - 'prf': see the docstring of `extract_prf_photometry()`
+        - 'pld': see the docstring of `to_corrector()`
+
+        For methods 'sff' and 'cbv', they are syntactic shortcuts of:
+
+        - creating a lightcurve using 'sap' method,
+        - corrects the created lightcurve using `LightCurve.to_corrector()`
+          of the respective method.
 
         Parameters
         ----------
         method : 'aperture', 'prf', 'sap', 'sff', 'cbv', 'pld'.
-            Photometry method to use.
+            Photometry method to use. 'aperture' is an alias of 'sap'.
         **kwargs : dict
-            Extra arguments to be passed to the `aperture_photometry` or the
-            `prf_photometry` method of this class.
+            Extra arguments to be passed to the `extract_aperture_photometry()`, the
+            `extract_prf_photometry()`, or the `to_corrector()` method of this class.
 
         Returns
         -------

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1370,21 +1370,21 @@ class TargetPixelFile(object):
         )
 
     def to_corrector(self, method="pld", **kwargs):
-        """Returns a `Corrector` instance to remove systematics.
+        """Returns a `~correctors.corrector.Corrector` instance to remove systematics.
 
         Parameters
         ----------
         methods : string
             Currently, only "pld" is supported.  This will return a
-            `PLDCorrector` class instance.
+            `~correctors.PLDCorrector` class instance.
         **kwargs : dict
             Extra keyword arguments to be passed on to the corrector class.
 
         Returns
         -------
-        correcter : `lightkurve.Correcter`
-            Instance of a Corrector class, which typically provides `correct()`
-            and `diagnose()` methods.
+        correcter : `~correctors.corrector.Corrector`
+            Instance of a Corrector class, which typically provides `~correctors.PLDCorrector.correct()`
+            and `~correctors.PLDCorrector.diagnose()` methods.
         """
         allowed_methods = ["pld"]
         if method == "sff":
@@ -2150,7 +2150,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
             at each cadence. Defaults to 'sum'.
         centroid_method : str, 'moments' or 'quadratic'
             For the details on this arguments, please refer to the documentation
-            for `TargetPixelFile.estimate_centroids`.
+            for `estimate_centroids()`.
 
         Returns
         -------
@@ -2288,8 +2288,8 @@ class KeplerTargetPixelFile(TargetPixelFile):
             If `True`, fitting cadences will be distributed across multiple
             cores using Python's `multiprocessing` module.
         **kwargs : dict
-            Keywords to be passed to `tpf.get_model()` to create the
-            `TPFModel` object that will be fit.
+            Keywords to be passed to `get_model()` to create the
+            `~prf.TPFModel` object that will be fit.
 
         Returns
         -------
@@ -2809,7 +2809,7 @@ class TessTargetPixelFile(TargetPixelFile):
             at each cadence. Defaults to 'sum'.
         centroid_method : str, 'moments' or 'quadratic'
             For the details on this arguments, please refer to the documentation
-            for `TargetPixelFile.estimate_centroids`.
+            for `estimate_centroids()`.
 
         Returns
         -------


### PR DESCRIPTION
The existing [apidoc of `tpf.to_lightcurve()`](https://docs.lightkurve.org/reference/api/lightkurve.KeplerTargetPixelFile.to_lightcurve.html):
- contains broken links to apeture/prf photometry functions
- does not include information of recently added methods: `sff, cbv, pld`

This PR:
- fixes `to_lightcurve()` apidoc. 
- also fixes the broken link in the referenced functions:`extract_aperture_photometry()`, `extract_prf_photometry()`, `to_corrector()`, and `LightCurve.to_corrector()`.
- Caveat: `to_corrector()` references `prf.TPFModel`. The entire `prf` module is not exposed in apidoc. This PR does not address it.

The existing doc:
![image](https://user-images.githubusercontent.com/250644/124643578-18cb8480-de46-11eb-8932-3b59f1566746.png)

Update:
![image](https://user-images.githubusercontent.com/250644/124643877-78299480-de46-11eb-9d85-15a86c09f388.png)
