### PR TITLE
Centroid estimates are off by 0.5 pixels in column and row position

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
   does not have the target's proper motion / coordinate; or it is from
   `tpf.cutout()` call. [#1088]
 
+- Fixed a bug in ``TargetPixelFile.estimate_centroids`` which caused the column
+  and row coordinates reported to be off by 0.5.
+
 
 2.0.10 (2021-06-04)
 ===================

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -810,7 +810,7 @@ class TargetPixelFile(object):
         """Compute the "center of mass" of the light based on the 2D moments;
         this is a helper method for `estimate_centroids()`."""
         aperture_mask = self._parse_aperture_mask(aperture_mask)
-        yy, xx = np.indices(self.shape[1:]) + 0.5
+        yy, xx = np.indices(self.shape[1:])
         yy = self.row + yy
         xx = self.column + xx
         total_flux = np.nansum(self.flux[:, aperture_mask], axis=1)
@@ -834,10 +834,8 @@ class TargetPixelFile(object):
             col, row = centroid_quadratic(self.flux[idx], mask=aperture_mask)
             col_centr.append(col)
             row_centr.append(row)
-        # Finally, we add .5 to the result bellow because the convention is that
-        # pixels are centered at .5, 1.5, 2.5, ...
-        col_centr = np.asfarray(col_centr) + self.column + 0.5
-        row_centr = np.asfarray(row_centr) + self.row + 0.5
+        col_centr = np.asfarray(col_centr) + self.column
+        row_centr = np.asfarray(row_centr) + self.row
         col_centr = Quantity(col_centr, unit="pixel")
         row_centr = Quantity(row_centr, unit="pixel")
         return col_centr, row_centr

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -202,14 +202,11 @@ def test_tpf_ones(centroid_method):
     for tpf in tpfs:
         lc = tpf.to_lightcurve(aperture_mask="all", centroid_method=centroid_method)
         assert np.all(lc.flux.value == 1)
-        assert np.all(
-            (lc.centroid_col.value < tpf.column + tpf.shape[1]).all()
-            * (lc.centroid_col.value > tpf.column).all()
-        )
-        assert np.all(
-            (lc.centroid_row.value < tpf.row + tpf.shape[2]).all()
-            * (lc.centroid_row.value > tpf.row).all()
-        )
+        # The test TPF file contains 3x3 pixels with a single bright pixel in the center pixel.
+        # Because pixel coordinates refer to the center of a pixel (cf. #755),
+        # we expect the centroid to be exactly one larger than the corner coordinates.
+        assert np.all(lc.centroid_row.value == tpf.row + 1)
+        assert np.all(lc.centroid_col.value == tpf.column + 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Until ~one year ago, Lightkurve followed the convention that pixel coordinates refer to the corner of a pixel.  This was incorrect, because the Kepler/TESS pipeline products adopt the convention that pixel coordinates refer to the middle of a pixel (cf. #755).  For example, (column, row) = (10.0, 20.0) refers to the middle of a pixel rather than its lower left corner.

Over in #755, we previously updated Lightkurve's plotting features to follow the correct convention, but we forgot to update Lightkurve's centroid estimation feature, which was also affected by the incorrect convention.

As a result, the centroid positions estimated by `TargetPixelFile.estimate_centroids()` have been off by exactly 0.5 pixels in both the row and column positions (see example screenshots below). 

The PR fixes this bug and introduces a regression test.


## Old behavior (incorrect)
<img width="633" alt="Screen Shot 2021-07-09 at 1 41 05 PM" src="https://user-images.githubusercontent.com/817669/125133844-538a2280-e0bb-11eb-91a3-bcd17e8d0368.png">

## New behavior (correct)
<img width="642" alt="Screen Shot 2021-07-09 at 1 33 51 PM" src="https://user-images.githubusercontent.com/817669/125133924-67ce1f80-e0bb-11eb-8e59-3c71fb01c02b.png">
