### PR TITLE
Improve the implementation of the BKJD and BTJD time formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 - Fixed a bug in ``TargetPixelFile.estimate_centroids`` which caused the column
   and row coordinates reported to be off by 0.5. [#1103]
 
+- Fixed the BKJD and BTJD AstroPy time formats to use the Barycentric Dynamical
+  Time (TDB) scale by default.
+
+
 
 2.0.10 (2021-06-04)
 ===================

--- a/src/lightkurve/time.py
+++ b/src/lightkurve/time.py
@@ -1,51 +1,46 @@
-"""Adds the BKJD and BTJD time format for use by Astropy's `Time` object."""
-from astropy.time.formats import TimeNumeric, day_frac
+"""Adds the BKJD and BTJD time format for use by Astropy's `Time` object.
+
+Caution: AstroPy time objects make a distinction between a time's format
+(e.g. ISO, JD, MJD) and its scale (e.g. UTC, TDB).  This can be confusing
+because the acronym "BTJD" refers both to a format (TJD) and to a scale (TDB).
+
+Note: the classes below derive from an AstroPy meta class which will automatically
+register the formats for use in AstroPy Time objects.
+"""
+from astropy.time.formats import TimeFromEpoch
 
 
-class TimeBKJD(TimeNumeric):
+class TimeBKJD(TimeFromEpoch):
     """
-    Barycentric Kepler Julian Date time format.
-    This represents the number of days since January 1, 2009 12:00:00 UTC.
-    BKJD is the format in which times are recorded in Kepler data products.
-    See Section 2.3.2 in the Kepler Archive Manual for details.
+    Barycentric Kepler Julian Date (BKJD): days since JD 2454833.0.
+
+    For example, 0 in BTJD is noon on January 1, 2009.
+
+    BKJD is the format in which times are recorded in data products from
+    NASA's Kepler Space Telescope, where it is always given in the
+    Barycentric Dynamical Time (TDB) scale by convention.
     """
-
-    name = "bkjd"
-    BKJDREF = 2454833  # Barycentric Kepler Julian Date offset
-
-    def set_jds(self, val1, val2):
-        self._check_scale(self._scale)  # Validate scale.
-        jd1, jd2 = day_frac(val1, val2)
-        jd1 += self.BKJDREF
-        self.jd1, self.jd2 = day_frac(jd1, jd2)
-
-    def to_value(self, **kwargs):
-        jd1 = self.jd1 - self.BKJDREF
-        jd2 = self.jd2
-        return super().to_value(jd1=jd1, jd2=jd2, **kwargs)
-
-    value = property(to_value)
+    name = 'bkjd'
+    unit = 1.0
+    epoch_val = 2454833
+    epoch_val2 = None
+    epoch_scale = 'tdb'
+    epoch_format = 'jd'
 
 
-class TimeBTJD(TimeNumeric):
+class TimeBTJD(TimeFromEpoch):
     """
-    Barycentric TESS Julian Date time format.
-    This represents the number of days since JD 2457000.0.
-    BTJD is the format in which times are recorded in TESS data products.
+    Barycentric TESS Julian Date (BTJD): days since JD 2457000.0.
+
+    For example, 0 in BTJD is noon on December 8, 2014.
+
+    BTJD is the format in which times are recorded in data products from
+    NASA's Transiting Exoplanet Survey Satellite (TESS), where it is
+    always given in the Barycentric Dynamical Time (TDB) scale by convention.
     """
-
-    name = "btjd"
-    BTJDREF = 2457000  # Barycentric TESS Julian Date offset
-
-    def set_jds(self, val1, val2):
-        self._check_scale(self._scale)  # Validate scale.
-        jd1, jd2 = day_frac(val1, val2)
-        jd1 += self.BTJDREF
-        self.jd1, self.jd2 = day_frac(jd1, jd2)
-
-    def to_value(self, **kwargs):
-        jd1 = self.jd1 - self.BTJDREF
-        jd2 = self.jd2
-        return super().to_value(jd1=jd1, jd2=jd2, **kwargs)
-
-    value = property(to_value)
+    name = 'btjd'
+    unit = 1.0
+    epoch_val = 2457000
+    epoch_val2 = None
+    epoch_scale = 'tdb'
+    epoch_format = 'jd'

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,30 @@
+from astropy.time import Time
+import numpy as np
+
+
+def test_bkjd():
+    """Tests for the Barycentric Kepler Julian Date (BKJD) time format."""
+    # Sanity checks
+    t0 = Time(0, format="bkjd")
+    assert t0.format == "bkjd"
+    assert t0.scale == "tdb"
+    assert t0.iso == "2009-01-01 12:00:00.000"
+
+
+def test_btjd():
+    """Tests for the Barycentric TESS Julian Date (BTJD) time format."""
+    # Sanity checks
+    t0 = Time(0, format="btjd")
+    assert t0.format == "btjd"
+    assert t0.scale == "tdb"
+    assert t0.iso == "2014-12-08 12:00:00.000"
+
+    # The test values below correspond to the header keywords (TSTART, TSTOP, DATE-OBS, DATE-END)
+    # found in s3://stpubdata/tess/public/ffi/s0031/2020/296/4-3/tess2020296001912-s0031-4-3-0198-s_ffic.fits
+    tstart, tstop = 2144.513656838462, 2144.520601048349
+    date_obs, date_end = '2020-10-22 00:18:30.767', '2020-10-22 00:28:30.747'
+    assert np.isclose(Time(date_obs).btjd, tstart, rtol=1e-10)
+    assert np.isclose(Time(date_end).btjd, tstop, rtol=1e-10)
+    assert np.isclose(Time(date_end).btjd, Time(date_end).tdb.btjd, rtol=1e-10)
+    assert Time(tstart, format="btjd").utc.iso[:22] == date_obs[:22]
+    assert Time(tstop, format="btjd").utc.iso[:22] == date_end[:22]


### PR DESCRIPTION
This PR addresses #1024 by revising the implementation of the `TimeBKJD` and `TimeBTJD` AstroPy time formats to utilize the `TimeFromEpoch` base time format available in AstroPy.

The benefits of this change are two-fold:
1. It simplifies the implementation.
2. It ensures that times use the Barycentric Dynamical Time (TDB) scale by default, because the `TimeFromEpoch` base class includes logic to ensure values are in the time scale of the epoch.

This PR also adds improved unit tests for verification.

We may eventually wish to add these time formats to AstroPy, but for the time being, Lightkurve provides a good testing ground.