### PR TITLE
Show the dependencies used during test

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,15 @@
+import lightkurve as lk
+import numpy as np
+import astropy
+import scipy
+import astroquery
+
+def test_show_environment(capsys):
+    """Show the environment the test suite is running. """
+    with capsys.disabled():
+        print("Dependencies used: ")
+        print("lightkurve", lk.__version__)
+        print("astropy", astropy.__version__)
+        print("numpy", np.__version__)
+        print("scipy", scipy.__version__)
+        print("astroquery", astroquery.__version__)


### PR DESCRIPTION
At times I wanted to know the versions of some dependent packages used during CI tests.

The "install dependencies" in CI output often does not have the information (possibly due to some form of caching), e.g., I cannot find astropy in https://github.com/lightkurve/lightkurve/runs/3176571199?check_suite_focus=true#step:4:1

As a workaround, this PR adds a dummy test that prints out the version of the main dependent packages

![image](https://user-images.githubusercontent.com/250644/127694964-448cdb40-2493-44b0-9668-d98fff3be2e6.png)

