### PR TITLE
Customize search result display with astropy-based configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.3.0 (unreleased)
+==================
+
+- Allow users to include more columns in ``SearchResult`` display via a new
+  ``SearchResult.display_extra_columns`` attribute, with defaults set by an
+  Astropy-based configuration system. [#1134]
+
+
+
 2.2.1 (2022-05-26)
 ==================
 - Fixed a bug in ``LightCurve.flatten()`` which caused the flux unit of

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1,0 +1,25 @@
+.. _api.config:
+
+=============
+Configuration
+=============
+.. currentmodule:: lightkurve
+
+
+``Lightkurve`` uses ``Astropy``'s configuration system for configurable parameters.
+
+Users can set their defaults in their configuration file, defaulted at ``$HOME/.lightkurve/config/lightkurve.cfg``.
+
+Furthermore, they can also change the values at runtime via `lightkurve.conf` object.
+
+The remaining specifics can be found in `Astropy documentation <https://docs.astropy.org/en/stable/config/index.html>`_.
+
+
+Access configuration values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+  :toctree: api/
+
+  conf
+  config.get_config_dir

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -18,8 +18,9 @@ methods.
    periodogram
    seismology
    correctors
+   config
    misc
-   
+
 
 If you are looking for a specific class or function not listed here, try consulting the API index or search page:
 

--- a/docs/source/reference/search.rst
+++ b/docs/source/reference/search.rst
@@ -56,6 +56,17 @@ For example, a search result can be filtered by exposure time using
   SearchResult.table
 
 
+Customizing search results display
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Users can optionally include a list of extra columns in the default display of `SearchResult` objects.
+
+.. autosummary::
+  :toctree: api/
+
+  SearchResult.display_extra_columns
+
+
 Data products collection
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -52,6 +52,11 @@ from . import config as _config
 class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `lightkurve`.
+
+    Refer to `astropy.config.ConfigNamespace` for API details.
+
+    Refer to `Astropy documentation <https://docs.astropy.org/en/stable/config/index.html#accessing-values>`_
+    for usage.
     """
     # Note: when using list or string_list datatype,
     # the behavior of astropy's parsing of the config file value:

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -53,11 +53,12 @@ class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `lightkurve`.
     """
-    # OPEN: when using list or string_list datatype
-    # astropy's parsing of the config file value is somewhat unexpected,
+    # Note: when using list or string_list datatype,
+    # the behavior of astropy's parsing of the config file value:
     # - it does not accept python list literal
     # - it accepts a comma-separated list of string
     #   - for a single value, it needs to be ended with a comma
+    # see: https://configobj.readthedocs.io/en/latest/configobj.html#the-config-file-format
     search_result_display_extra_columns = _config.ConfigItem(
         [],
         "List of extra columns to be included when displaying a SearchResult object.",

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -46,6 +46,29 @@ import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 
+from astropy import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `lightkurve`.
+    """
+    # OPEN: when using list or string_list datatype
+    # astropy's parsing of the config file value is somewhat unexpected,
+    # - it does not accept python list literal
+    # - it accepts a comma-separated list of string
+    #   - for a single value, it needs to be ended with a comma
+    search_result_display_extra_columns = _config.ConfigItem(
+        [],
+        "List of extra columns to be included when displaying a SearchResult object.",
+        cfgtype="string_list",
+        module="lightkurve.search"
+    )
+
+
+conf = Conf()
+
+
 from .version import __version__
 from . import units  # enable ppt and ppm as units
 from .time import *

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -46,7 +46,7 @@ import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler())
 
-from astropy import config as _config
+from . import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -1,0 +1,32 @@
+import astropy.config as astropyconfig
+
+
+ROOTNAME = 'lightkurve'
+
+
+class ConfigNamespace(astropyconfig.ConfigNamespace):
+    rootname = ROOTNAME
+
+
+class ConfigItem(astropyconfig.ConfigItem):
+    rootname = ROOTNAME
+
+
+def get_config_dir():
+    """
+    Determines the package configuration directory name and creates the
+    directory if it doesn't exist.
+
+    This directory is typically ``$HOME/.lightkurve/config``, but if the
+    XDG_CONFIG_HOME environment variable is set and the
+    ``$XDG_CONFIG_HOME/lightkurve`` directory exists, it will be that directory.
+    If neither exists, the former will be created and symlinked to the latter.
+
+    Returns
+    -------
+    configdir : str
+        The absolute path to the configuration directory.
+
+    """
+    return astropyconfig.get_config_dir(ROOTNAME)
+

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -134,6 +134,8 @@ class SearchResult(object):
         columns = REPR_COLUMNS_BASE
         if self.display_extra_columns is not None:
             columns = REPR_COLUMNS_BASE + self.display_extra_columns
+        # search_tesscut() has fewer columns, ensure we don't try to display columns that do not exist
+        columns = [c for c in columns if c in self.table.colnames]
 
         self.table["#"] = [idx for idx in range(len(self.table))]
         out += "\n\n" + "\n".join(self.table[columns].pformat(max_width=300, html=html))
@@ -143,7 +145,11 @@ class SearchResult(object):
                 out = out.replace(f">{author}<", f"><a href='{url}'>{author}</a><")
             # special HTML formating for TESS proposal_id
             tess_table = self.table[self.table["project"] == "TESS"]
-            for p_ids in np.unique(tess_table["proposal_id"]):
+            if "proposal_id" in tess_table.colnames:
+                proposal_id_col = np.unique(tess_table["proposal_id"])
+            else:
+                proposal_id_col = []
+            for p_ids in proposal_id_col:
                 # for CDIPS products, proposal_id is a np MaskedConstant, not a string
                 if p_ids == "N/A" or (not isinstance(p_ids, str)):
                     continue

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -81,6 +81,30 @@ class SearchResult(object):
     table = None
     """`~astropy.table.Table` containing the full search results returned by the MAST API."""
 
+    display_extra_columns = []
+    """A list of extra columns to be included in the default display of the search result.
+    It can be configured in a few different ways.
+
+    For example, to include ``proposal_id`` in the default display, users can set it:
+
+    1. in the user's ``lightkurve.cfg`` file::
+
+        [search]
+        # The extra comma at the end is needed for a single extra column
+        search_result_display_extra_columns = proposal_id,
+
+    2. at run time::
+
+        import lightkurve as lk
+        lk.conf.search_result_display_extra_columns = ['proposal_id']
+
+    3. for a specific `SearchResult` object instance::
+
+        result.display_extra_columns = ['proposal_id']
+
+    See configuration for more information.
+    """
+
     def __init__(self, table=None):
         if table is None:
             self.table = Table()

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -102,7 +102,7 @@ class SearchResult(object):
 
         result.display_extra_columns = ['proposal_id']
 
-    See configuration for more information.
+    See :ref:`configuration <api.config>` for more information.
     """
 
     def __init__(self, table=None):

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -20,6 +20,7 @@ from .targetpixelfile import TargetPixelFile
 from .collections import TargetPixelFileCollection, LightCurveCollection
 from .utils import suppress_stdout, LightkurveWarning, LightkurveDeprecationWarning
 from .io import read
+from . import conf
 from . import PACKAGEDIR
 
 log = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class SearchResult(object):
             if len(table) > 0:
                 self._add_columns()
                 self._sort_table()
-        self.display_extra_columns = None
+        self.display_extra_columns = conf.search_result_display_extra_columns
 
     def _sort_table(self):
         """Sort the table of search results by distance, author, and filename.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import pytest
 
 
@@ -38,3 +41,9 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if 'memtest' in item.keywords:
             item.add_marker(skip_memtest)
+
+# Make sure we use temporary directories for the config
+# so that the tests are insensitive to local configuration.
+
+os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('lightkurve_config')
+os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'lightkurve'))

--- a/tests/data/lightkurve_sr_cols_added.cfg
+++ b/tests/data/lightkurve_sr_cols_added.cfg
@@ -1,0 +1,5 @@
+[search]
+
+## List of extra columns to be included when displaying a SearchResult object.
+search_result_display_extra_columns = proposal_id,
+

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,24 @@
+from astropy.utils.data import get_pkg_data_filename
+
+from pathlib import Path
+import shutil
+
+import lightkurve as lk
+
+def test_read_conf_from_file():
+    """Sanity test to ensure lightkurve per-user config is in the expected location."""
+
+    # assert the default config
+    assert [] == lk.conf.search_result_display_extra_columns
+    # Use a custom config file, and assert the changes are read.
+    try:
+        cfg_dest_path = Path(lk.config.get_config_dir(), 'lightkurve.cfg')
+        cfg_src_path = get_pkg_data_filename("data/lightkurve_sr_cols_added.cfg")
+        shutil.copy(cfg_src_path, cfg_dest_path)
+        lk.conf.reload()
+        assert ['proposal_id'] == lk.conf.search_result_display_extra_columns
+    finally:
+        # cleanup: remvoe the custom config file and its effect
+        cfg_dest_path.unlink()
+        lk.conf.reload()
+

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -12,13 +12,22 @@ def test_read_conf_from_file():
     assert [] == lk.conf.search_result_display_extra_columns
     # Use a custom config file, and assert the changes are read.
     try:
-        cfg_dest_path = Path(lk.config.get_config_dir(), 'lightkurve.cfg')
-        cfg_src_path = get_pkg_data_filename("data/lightkurve_sr_cols_added.cfg")
-        shutil.copy(cfg_src_path, cfg_dest_path)
-        lk.conf.reload()
+        use_custom_config_file("data/lightkurve_sr_cols_added.cfg")
         assert ['proposal_id'] == lk.conf.search_result_display_extra_columns
     finally:
         # cleanup: remvoe the custom config file and its effect
-        cfg_dest_path.unlink()
-        lk.conf.reload()
+        remove_custom_config()
 
+
+def use_custom_config_file(cfg_filepath):
+    """Copy the config file in the given path (in tests) to the default lightkurve config file """
+    cfg_dest_path = Path(lk.config.get_config_dir(), 'lightkurve.cfg')
+    cfg_src_path = get_pkg_data_filename(cfg_filepath)
+    shutil.copy(cfg_src_path, cfg_dest_path)
+    lk.conf.reload()
+
+
+def remove_custom_config():
+    cfg_dest_path = Path(lk.config.get_config_dir(), 'lightkurve.cfg')
+    cfg_dest_path.unlink()
+    lk.conf.reload()


### PR DESCRIPTION
Close #1060.

The PR lets users optionally add extra columns to be displayed for `SearchResult` object, using astropy-style configuration that can serve as the basis of how configuration option for other features are done.

E.g., users can add `proposal_id` column. The display will then be:

![image](https://user-images.githubusercontent.com/250644/128792590-18756d65-ceed-401b-b666-8fe0ba5a15f0.png)

The PR also contains tweaks specific to TESS `proposal_ids`, so that in Jupyter/HTML display, it is formatted nicely similar to how the `author` is displayed.

---

Open issues that require discussion:
1. the location of config file. In the current PR, it is `~/.astropy/config/lightkurve.cfg` , mainly for expediency. Should it be `~/.lightkurve/lightkurve.cfg` instead?
2. the format in specifying list of columns. The current astropy config behavior in specifying a list of values is a bit weird. Eg., if I want to add a single `proposal_id` column to display, the line required is a bit unintuitive. 
```
# Notice the extra comma needed at the end.
search_result_display_extra_columns = proposal_id,
```
The issue is tracked in https://github.com/astropy/astropy/issues/12033 (update: it's the expected behavior)


If the open issues are resolved, documentation and tests will still be needed for the PR.

### Tasks
- [x] SearchResult customization with astropy-based config
- [x] Move per-user config file to `~/.lightcurve` directory
- [x] Ensure unit tests have isolated config environment
- [x] Test for SearchResult customization
- [x] Documentation 
  - [x] Configuration in general
  - [x] SearchResult customization in specific. 
- [ ] Support `create_config_file()` (create a file with defaults) : I'm stuck, as I keep getting empty file created. It's a very nice to have, but probably not a showstopper.

---
Changelog snippet:

```rst
- Allow users to include more columns in ``SearchResult`` display via a new 
  ``SearchResult.display_extra_columns`` attribute and associated Astropy-based
  configuration system. [#1134]
```