### PR TITLE
LightCurve.create_transit_mask: allow transit_time to be a Quantity object (fixes #1141)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@
   Dynamical Time (TDB) scale by default. [#1112]
 
 - Modified ``LightCurve.create_transit_mask()`` to accept AstroPy ``Quantity``
-  objects for the ``period`` and ``duration`` parameters. [#1119]
+  objects for ``period``, ``transit_time``, and ``duration``. [#1119, #1141]
 
 - Modified ``CBVCorrector`` to issue a warning message of the CBVs are
   poorly aligned to the input light curve. [#1113]

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2625,8 +2625,13 @@ class LightCurve(QTimeSeries):
             >>> lc.create_transit_mask(transit_time=[2., 3.], period=[2., 10.], duration=[0.1, 0.1])
             array([False,  True,  True,  True, False])
         """
+        # Convert Quantity objects to floats in units "day"
         period = _to_unitless_day(period)
         duration = _to_unitless_day(duration)
+
+        # If ``transit_time`` is a ``Quantity```, attempt converting it to a ``Time`` object
+        if isinstance(transit_time, Quantity):
+            transit_time = Time(transit_time, format=self.time.format, scale=self.time.scale)
 
         # Ensure all parameters are 1D-arrays
         period = np.atleast_1d(period)

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1694,3 +1694,11 @@ def test_select_flux():
         lc.select_flux("doesnotexist")
     with pytest.raises(ValueError):
         lc.select_flux("newflux", "doesnotexist")
+
+
+def test_transit_mask_with_quantities():
+    """Regression test for #1141."""
+    lc = LightCurve(time=range(10), flux=range(10))
+    mask_quantity = lc.create_transit_mask(period=2.9*u.day, transit_time=1*u.day, duration=1*u.day)
+    mask_no_quantity = lc.create_transit_mask(period=2.9, transit_time=1, duration=1)
+    assert all(mask_quantity == mask_no_quantity)


### PR DESCRIPTION
This PR addresses #1141 by allowing a `Quantity` object to be passed as the value for `transit_time` in `LightCurve.create_transit_mask()`.