### PR TITLE
Duplicate

### DIFF
--- a/src/lightkurve/correctors/__init__.py
+++ b/src/lightkurve/correctors/__init__.py
@@ -18,3 +18,4 @@ from .pldcorrector import *
 from .sffcorrector import *
 from .cbvcorrector import *
 from .regressioncorrector import *
+from .tic82corrector import *

--- a/src/lightkurve/correctors/tic82corrector.py
+++ b/src/lightkurve/correctors/tic82corrector.py
@@ -1,0 +1,170 @@
+"""Defines TIC82Corrector
+"""
+import logging
+import warnings
+
+import numpy as np
+import matplotlib
+import lightkurve as lk
+
+from .corrector import Corrector
+
+from ..lightcurve import LightCurve, MPLSTYLE
+
+__all__ = ['TIC82Corrector']
+
+log = logging.getLogger(__name__)
+
+
+class TIC82Corrector(Corrector):
+    """The TIC input catalog is a list of ~1.7X10^9 sources on the sky and is used to provide stellar 
+    parameters for evaluation. The catalogue is designed to include stars much fainter than likely TESS targets. 
+    The catalog is therefore vast and as such certain spurious entries can occur, which must be considered.
+ 
+    To ensure completeness and reliability the TIC is maintained and updated with new information from 
+    astronomical surveys. TIC-7 was based on 2MASS data and was updated with information from Gaia DS2 to form 
+    TIC-8.  
+ 
+    Upon the incorporation of this new data several problems were found with a small number of objects (<1%). 
+    Several Gaia objects were not found in the 2MASS data, and other objects once thought to be individual stars 
+    are actually multiple objects.  
+ 
+    To resolve these issues all Gaia objects not found in 2MASS, or earlier versions of the TIC, were given new 
+    TIC-IDs. The more problematic objects were identified, and their nature documented under an assigned 
+    “Disposition”column in the catalogue. The kinds of problematic objects are defined below:
+
+    - Artifacts: These are spurious sources from 2MASS generally caused by diffraction spikes around bright stars. 
+	- For newly flagged ARTIFACT sources, target pixel files are produced, but no light curves or data 
+          validation pipeline products.
+	- Beware! The search for artifacts around target stars was limited to stars brighter than 13 Tmag.
+ 
+    - Join: Two TIC objects of near-equal brightness are in fact the same one real star. They originate from 
+      slight mismatches between different catalogs, usually a 2MASS star that failed to be matched with its 
+      respective Gaia DR2 entry.
+	- The 2MASS object retains its TIC-ID for backward compatibility.
+	- The stellar parameters of the 2MASS TIC-ID are updated to the improved Gaia-derived values (unless it is 
+          from a specially curated list, in which case these values are used).
+	- The Gaia TIC-ID is given the “Disposition” argument of DUPLICATE, indicating it is not a real star.
+	- If using Lightkurve the SPOC flux of your 2MASS TIC object will be wrong before Sector 38. For data 
+          before sector 38 you can adjust the SAP flux using the parent Tmag, as provided on MAST, and the SPLIT 
+          mag in the object header. This correction however is only an approximation. 
+	- Note that such objects are not labeled as JOIN in the disposition column on MAST.
+ 
+    - Split: A bright 2MASS object that is not real, but the combination (sum of flux) of two or more fainter 
+      objects, which have been found by Gaia. 
+	- The 2MASS object remains in the TIC with the original TIC-ID
+		- The magnitudes and stellar parameters are updated with those of the brightest real object 
+                  identified by Gaia.
+		- The star is marked as SPLIT in the “Disposition” column.
+		- The 2MASS JHK magnitude will be incorrect.
+	- Two or more new sources (the real sources) are added to the TIC with new TIC IDs. 
+		- In these cases, the new TIC objects will be marked as DUPLICATES and have the TIC ID of the
+                  original object in the “duplicate_id” column.
+	- There is no way to tell what TESS signal came from a given star in the unresolved system.
+	- Note that the old 2MASS magnitude isn’t available in TIC v8.2, as such the user will have to obtain 
+          the magnitude from the meta data, and then use a sum of all mags to correct the flux for all sectors 
+          before 38.
+
+    In this notebook we will fix the flux for any object identified as a split or join.
+    Exaples
+    ------
+    You will first need to run your obect of interest through SearchDuplicate and from that you will get a table
+    which will identify the kind of issue you are working with.
+
+    >>> import lightkurve as lk
+    >>> table = lk.SearchDuplicate(tic=1716106609)
+    >>> SPLIT_LK = lk.search_lightcurve("TIC 1716106609", mission="TESS")
+    >>> corrected_split_lc = lk.TIC82Corrector(table, SPLIT_LK)"""
+    
+    def __init__(self, table, lc):
+        self.table = table
+        self.ids = table['ID']
+        self.ra = table['ra']
+        self.dec = table['dec']
+        self.mag = table['Tmag']
+        self.disp = table['disposition']
+        self.dupid = table['duplicate_id']
+        self.lc = lc
+        self.lc.mag = lc.meta['TESSMAG']
+        self.lc.flux = lc.sap_flux
+        self.lc.flux_err = lc.sap_flux_err
+        self.lc.time = lc.time
+        
+    def correct(self):
+
+        #From the table obtained via SearchDuplicate determine what kind of object you have
+        if 'SPLIT' in self.disp:
+            #This means the object is a split and so will need to be corrected
+            
+            dp = np.where(self.disp=="DUPLICATE")
+            sp = np.where(self.disp=="SPLIT")
+
+            t = np.arange(0,len(self.disp),1,dtype=int)
+            fp = np.delete(t,[sp[0],dp[0]])
+
+            #Get the duplicate mag
+            mag_dup = self.mag[dp]
+
+            #Get the mag of the faint sources - there might be multiple
+            mag_faint= self.mag[fp]
+
+            #Convert things to flux
+            Fs = 10**(4-0.4*self.lc.mag) #The split
+            Fd = 10**(4-0.4*mag_dup) #The duplicate
+
+            Ff = []
+            for b in range(len(mag_faint)):
+                Ff.append(10**(4-0.4*mag_faint[b])) #The faint
+
+            #Sum up flux values of all except split
+            sumfaint = sum(Ff)
+            comb_flux = sumfaint + Fd
+
+            #Calculate the flux ratio
+            ratio = Fd/comb_flux
+
+            flux_new = self.lc.flux.value * ratio
+            flux_err_new =  self.lc.flux_err.value * ratio
+
+            #Make a copy of the original so we can make sure units are correct
+            corrected_lc = self.lc.copy()
+            corrected_lc.sap_flux = flux_new
+            corrected_lc.sap_flux_err = flux_err_new
+
+            return corrected_lc
+
+        elif 'DUPLICATE' in self.disp:
+
+            dp = np.where(self.disp=="DUPLICATE")
+            
+            #Get the duplicate mag
+            mag_Gaia = self.mag[dp]
+
+            #Get the mag of the 2mass sources
+            mag_2mass = self.lc.mag
+           
+            #Convert things to flux
+            F2m = 10**(4-0.4*self.lc.mag)
+            FGi = 10**(4-0.4*mag_Gaia)
+
+            #Sum up flux values of all except split
+            comb_flux = F2m + FGi
+
+            #Calculate the flux ratio
+            ratio = F2m/comb_flux
+
+            flux_new = self.lc.flux.value * ratio
+            flux_err_new =  self.lc.flux_err.value * ratio
+
+            #Make a copy of the original so we can make sure units are correct
+            corrected_lc = self.lc.copy()
+            corrected_lc.sap_flux = flux_new
+            corrected_lc.sap_flux_err = flux_err_new
+        
+            return corrected_lc
+            
+
+    def diagnose(self):
+        return None
+
+    

--- a/src/lightkurve/searchduplicate.py
+++ b/src/lightkurve/searchduplicate.py
@@ -1,0 +1,57 @@
+"""Defines tools to see if your object of interest is an ARTIFACT, SPLIT, or JOIN"""
+from __future__ import division
+import os
+import glob
+import logging
+import re
+import warnings
+
+import numpy as np
+from astropy.table import join, Table, Row
+from astropy.coordinates import SkyCoord
+from astropy.io import ascii
+from astropy import units as u
+from astropy.utils import deprecated
+from astropy.time import Time
+from astroquery.mast import Catalogs
+
+log = logging.getLogger(__name__)
+
+__all__ = ["SearchDuplicate"]
+
+
+def SearchDuplicate(name=None, ra=None, dec=None, tic=None):
+    """Here the user can input the name, TIC-ID, or RA and Dec of an object and query MAST to 
+    determine if it part of the <1% which have been been affected by the update of the TIC to
+    version 8.2. In this version the Gaia catalog was used instead of the 2MASS. This has led 
+    to the discovery that some stars are actually artificats, some have duplicate entries and 
+    are in fact one star, and some were actually made up of multiple stars.
+    See https://outerspace.stsci.edu/display/TESS/TIC+v8+and+CTL+v8.xx+Data+Release+Notes
+    for more details on this issue 
+
+    If an object has been affected by the TIC update then this code will inform the user what
+    kind of issue it has via displaying the MAST "disposition" column. 
+
+    Input needed from a user will be the object of interest name, TIC-ID, or co-ordinates.
+
+    ----------
+    Example
+    >>> import lightkurve as lk
+    >>> lk.SearchDuplicate(tic=1716106614)
+    
+    """
+    if name!=None:
+        catalog_data = Catalogs.query_object(name, radius=0.001, catalog="TIC", version=8.2)
+        output = catalog_data["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+
+    if ra and dec !=None:
+        cords = str(ra)+" "+str(dec)
+        catalog_data = Catalogs.query_object(cords, radius=0.001, catalog="TIC", version=8.2)
+        output = catalog_data["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+
+    if tic !=None:
+        tname ="TIC "+str(tic)
+        catalog_data = Catalogs.query_object(tname, radius=0.001, catalog="TIC", version=8.2)
+        output = catalog_data["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+
+    return output

--- a/tests/correctors/test_tic82corrector.py
+++ b/tests/correctors/test_tic82corrector.py
@@ -1,0 +1,116 @@
+"""Unit tests for the `TIC82Corrector` class."""
+import pytest
+import warnings
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+from astroquery.mast import Catalogs
+
+import lightkurve as lk
+from lightkurve.correctors import TIC82Corrector
+
+def test_TIC82Corrector_priors():
+    """This test will check that correction to the SAP flux is being calculated
+    corectly
+    """
+
+    #Example of a join
+    catalog_data = Catalogs.query_object("TIC 408200371", radius=0.001, catalog="TIC", version=8.2)
+    table_join = catalog_data["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+    #This table should contain information for two objects
+
+    #For their object of interest they will need to download the light curve
+    #You might have more than one sector and so will have to do each one at a time
+    lcf = lk.search_lightcurve('TIC 408200371', mission='TESS', author="SPOC", sector=14).download()
+
+    #Get the mag of your object from the lcf
+    mag_obj = lcf.meta['TESSMAG']
+     
+    #Get the mag of the duplicate
+    pos = np.where(table_join['disposition']=="DUPLICATE")
+    mag_dup = table_join['Tmag'][pos]
+
+    #Calculate the fluxes
+    F2m = 10**(4-0.4*mag_obj)
+    FGi = 10**(4-0.4*mag_dup)
+
+    assert_almost_equal(F2m,2.5562305448313114)
+    assert_almost_equal(FGi,2.4139040312021063)
+
+    #Sum up flux values of all except split
+    comb_flux = F2m + FGi
+    assert_almost_equal(comb_flux,4.970134576033418)
+
+    #Calculate the flux ratio
+    ratio = F2m/comb_flux
+    assert_almost_equal(ratio,0.514318175036499)
+
+    flux_new = lcf.sap_flux.value * ratio
+    flux_err_new =  lcf.sap_flux_err.value * ratio
+    check1 = flux_new[1]
+
+    assert_almost_equal(int(check1),15910)
+
+    #Now lets use the actual corrector
+    join = TIC82Corrector(table_join, lcf)
+    corrected_lc = join.correct()
+
+    check2 = corrected_lc.sap_flux.value[1]
+
+    assert_almost_equal(int(check2),int(check1))
+     
+
+    #Example of a SPLIT
+    catalog_data2 = Catalogs.query_object("TIC 158324245", radius=0.001, catalog="TIC", version=8.2)
+    table_split = catalog_data2["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+    #This table should contain information for three objects
+
+    #For their object of interest they will need to download the light curve
+    #You might have more than one sector and so will have to do each one at a time
+    lcf_split = lk.search_lightcurve('TIC 158324245', mission='TESS', author="SPOC", sector=26).download()
+    print(lcf_split.sap_flux.value[0])
+    
+    #Get the mag of your object from the lcf
+    mag_obj_split = lcf_split.meta['TESSMAG']
+    #Get position of the SPLIT in the array
+    pos_split = np.where(table_split['disposition']=="SPLIT")
+    
+    #Get the mag of the duplicate
+    pos_dup = np.where(table_split['disposition']=="DUPLICATE")
+    mag_dup2 = table_split['Tmag'][pos_dup]
+    
+    
+    #Get the location of the faint objects in the array
+    t = np.arange(0,len(table_split['disposition']),1,dtype=int)
+    pos_faint = np.delete(t,[pos_split[0],pos_dup[0]])
+    mag_faint = table_split['Tmag'][pos_faint]
+
+    #Calculate the fluxes
+    Fs = 10**(4-0.4*mag_obj_split)
+    Fd = 10**(4-0.4*mag_dup2)
+    Ff = 10**(4-0.4*mag_faint)
+
+    assert_almost_equal(np.round(Fs,3),np.round(1.490046576557392,3))
+    assert_almost_equal(np.round(Fd,3),np.round(0.8086486316572605,3))
+    assert_almost_equal(np.round(Ff,3),np.round(0.6396170440617517,3))
+    
+    #Sum up flux values of all except split
+    comb_flux2 = Fd + Ff
+
+    #Calculate the flux ratio
+    ratio2 = Fd/comb_flux2
+    
+    flux_new2 = lcf_split.sap_flux.value * ratio2
+    flux_err_new2 =  lcf_split.sap_flux_err.value * ratio2
+    check3 = flux_new2[1]
+
+    assert_almost_equal(int(check3),int(11819.829))
+    
+    #Now lets use the actual corrector
+    split = TIC82Corrector(table_split, lcf_split)
+    corrected_lc2 = split.correct()
+    check4 = corrected_lc2.sap_flux.value[1]
+
+    assert_almost_equal(int(check4),int(check3))
+     

--- a/tests/test_searchduplicate.py
+++ b/tests/test_searchduplicate.py
@@ -1,0 +1,39 @@
+"""Test features of lightkurve that interact with the data archive at MAST.
+
+Note: if you have the `pytest-remotedata` package installed, then tests flagged
+with the `@pytest.mark.remote_data` decorator below will only run if the
+`--remote-data` argument is passed to py.test.  This allows tests to pass
+if no internet connection is available.
+"""
+import os
+import pytest
+
+from numpy.testing import assert_almost_equal, assert_array_equal
+import tempfile
+from requests import HTTPError
+from astroquery.mast import Catalogs
+
+from lightkurve.utils import LightkurveWarning, LightkurveError
+from lightkurve import SearchDuplicate
+
+
+@pytest.mark.remote_data
+def test_SearchDuplicate():
+    """ TIC 158324245 was classified as a SPLIT in TIC v8.2
+    This means that it itself is not a real star, but composed of several other stars
+    The brightest real star is called the DUPLICATE and replaces the MAST paramters of 
+    the original. 
+
+    There is then an additional faint star. 
+    This procedure should return the ID's of all associated stars. 
+    """
+    catalog_data = Catalogs.query_object("TIC 158324245", radius=0.001, catalog="TIC", version=8.2)
+    table = catalog_data["ID", "ra", "dec", "Tmag", "disposition", "duplicate_id"]
+
+    assert table['ID'][0] == '158324245'
+    assert table['ID'][1] == '1717079071'
+    assert table['ID'][2] == '1717079066'
+
+    assert table['disposition'][0] == 'SPLIT'
+    assert table['disposition'][1] == 'DUPLICATE'
+    


### PR DESCRIPTION
This code helps the user to identify the duplicate and split stars which are a result of the TIC 8.2 version update. This issue was caused by updating the catalog from 2MASS to Gaia. 

searchduplicate creates a table that indicates if the object of interest is part of the <1% of stars affected by the update and also lists the kind of issue present.

Then TIC82Correct adjusts the SAP flux for the affected object - correcting it and making it more comparable to that in later sectors. 
The user will have to correct the SAP flux for background and noise still and replace the PLDSAP flux.
