### PR TITLE
CBVCorrector working with 20-second CBVs.

### DIFF
--- a/docs/source/tutorials/2-creating-light-curves/2-2-how-to-use-cbvs.ipynb
+++ b/docs/source/tutorials/2-creating-light-curves/2-2-how-to-use-cbvs.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "Cotrending Basis Vectors (CBVs) are generated in the PDC component of the Kepler/K2/TESS pipeline and are used to remove systematic trends in light curves. They are built from the most common systematic trends observed in each PDC Unit of Work (Quarter for Kepler, Campaign for K2 and Sector for TESS). Each Kepler and K2 module output and each CCD in TESS has its own set of CBVs. You can read an introduction to the CBVs in [Demystifying Kepler Data](https://arxiv.org/pdf/1207.3093.pdf) or to greater detail in the [Kepler Data Processing Handbook](https://archive.stsci.edu/kepler/manuals/KSCI-19081-003-KDPH.pdf). The same basic method to generate CBVs is used for all three missions.\n",
     "\n",
-    "This tutorial provides examples of how to load CBVs from MAST and set them up in a design matrix for use to remove systematic trends. Please consult the [DesignMatrix page](https://docs.lightkurve.org/reference/api/lightkurve.correctors.DesignMatrix.html#lightkurve.correctors.DesignMatrix) in the API docs for the full details on that class. A convenient tool has been created called [CBVCorrector](https://docs.lightkurve.org/reference/api/lightkurve.correctors.CBVCorrector.html?highlight=cbvcorrector) which will utilize the CBVs for the custom removal of systematic trends. See the [CBVCorrector HOWTO page](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-how-to-use-cbvcorrector.html) for example usage."
+    "This tutorial provides examples of how to load CBVs either from MAST or locally and set them up in a design matrix for use to remove systematic trends. Please consult the [DesignMatrix page](https://docs.lightkurve.org/reference/api/lightkurve.correctors.DesignMatrix.html#lightkurve.correctors.DesignMatrix) in the API docs for the full details on that class. A convenient tool has been created called [CBVCorrector](https://docs.lightkurve.org/reference/api/lightkurve.correctors.CBVCorrector.html?highlight=cbvcorrector) which utilizes the CBVs for the custom removal of systematic trends. See the [CBVCorrector HOWTO page](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-how-to-use-cbvcorrector.html) for example usage."
    ]
   },
   {
@@ -32,9 +32,25 @@
     "- **Multi-Scale** contains systematic trends in specific wavelet-based band passes. There are usually three sets of multi-scale basis vectors in three bands.\n",
     "- **Spike** contains only short impulsive spike systematics.\n",
     "\n",
-    "There are two different correction methods in PDC: Single-Scale and Multi-Scale. Single-Scale performs the correction in a single bandpass. Multi-Scale performs the correction in three separate wavelet-based bandpasses. Both corrections are performed in PDC but we can only export a single PDC light curve for each target. So, PDC must choose which of the two on a per-target basis. Generally speaking, single-scale performs better at preserving longer period signals. But at periods close to transiting planet durations multi-scale performs better at preserving signals. PDC therefore mostly chooses multi-scale for use within the planet finding pipeline and for the archive. You can find in the light curve FITS header which PDC method was chosen (keyword “PDCMETHD”). Additionally, a seperate correction is alway performed to remove short impulsive systematic spikes.\n",
+    "There are two different correction methods in PDC: Single-Scale and Multi-Scale. Single-Scale performs the correction in a single bandpass. Multi-Scale performs the correction in three separate wavelet-based bandpasses. Both corrections are performed in PDC but the mission can only export a single PDC light curve for each target. So, PDC must choose between the two on a per-target basis. Generally speaking, single-scale performs better at preserving longer period signals. But at periods close to transiting planet durations multi-scale performs better at preserving signals. PDC therefore mostly chooses multi-scale for use within the planet finding pipeline and for the archive. You can find in the light curve FITS header which PDC method was chosen (keyword “PDCMETHD”). Additionally, a seperate correction is alway performed to remove short impulsive systematic spikes.\n",
     "\n",
-    "For an individual's research needs, the mission supplied PDC lightcurves might not be ideal and so the CBVs are provided to the user to perform their own correction. All three CBV types are provided at MAST for TESS, however only Single-Scale is provided at MAST for Kepler and K2. For TESS, Cotrending Basis Vectors are currently only supplied at a 2-minute cadence. For Kepler/K2 only for the 30-minute target cadence."
+    "For an individual's research needs, the mission supplied PDC lightcurves might not be ideal and so the CBVs are provided to the user to perform their own correction. All three CBV types are provided at MAST for TESS, however only Single-Scale is provided at MAST for Kepler and K2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cadence Type CBV Availability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For Kepler and K2 CBVs are available for only the 30-minute 'long' cadence (technically 29.4 minute cadence).\n",
+    "\n",
+    "For TESS, CBVs are available for 2-minute 'short' and 20-second 'fast' cadence."
    ]
   },
   {
@@ -48,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Two tools are available to automatically download the CBVs relevent to your target of study: `load_tess_cbvs` and `load_kepler_cbvs`. Here is an example loading in the TESS Multi-Scale Band 2 CBVs for TESS target TIC 99180739, which happens to be on camera 1 and CCD 1. Note that you do not need to have a lightcurve object already loaded. One can directly request whichever CBVs one desires."
+    "Two tools are available to automatically load the CBVs relevent to your target of study: `load_tess_cbvs` and `load_kepler_cbvs`. They can be obtained either from MAST by default or from a local specified directory `cbv_dir`. Here is an example loading in the TESS Multi-Scale Band 2 CBVs for TESS target TIC 99180739, which happens to be on camera 1 and CCD 1. We will request the 2-minute 'short' cadence CBVs. Note that you do not need to have a lightcurve object already loaded. One can directly request whichever CBVs one desires."
    ]
   },
   {
@@ -61,7 +77,7 @@
     "from lightkurve.correctors import load_tess_cbvs, load_kepler_cbvs\n",
     "import numpy as np\n",
     "lc = search_lightcurve('TIC 99180739', author='SPOC', sector=10).download(flux_column='sap_flux')\n",
-    "cbvs = load_tess_cbvs(sector=lc.sector, camera=lc.camera, ccd=lc.ccd, cbv_type='MultiScale', band=2)"
+    "cbvs = load_tess_cbvs(sector=lc.sector, camera=lc.camera, ccd=lc.ccd, cbv_type='MultiScale', band=2, exptime='short')"
    ]
   },
   {
@@ -85,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All data contained in the MAST CBV FITS files is downloaded. The `time`, `CADENCENO` and `GAP` columns can be used to select which cadences you desire. Extra information is in the `cbvs.meta` dict. The CBVS are interpolated accross the gaps and so should be used in gapped cadences with extreme caution. Below we will plot the first 4 CBVs. Note: _CBVs use 1-based indexing!_"
+    "All data contained in the MAST CBV FITS files is downloaded. The `time`, `CADENCENO` and `GAP` columns can be used to select which cadences you desire. Extra information is in the `cbvs.meta` dict. The CBVs are interpolated accross the gaps and so should be used in gapped cadences with extreme caution. Below we will plot the first 4 CBVs. Note: The _CBVs use 1-based indexing!_"
    ]
   },
   {
@@ -95,6 +111,22 @@
    "outputs": [],
    "source": [
     "cbvs.plot(cbv_indices=np.arange(1,5));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also request the 20-second CBVS as with the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cbvs_fast = load_tess_cbvs(sector=41, camera=2, ccd=4, cbv_type='SingleScale', exptime='fast')"
    ]
   },
   {
@@ -112,6 +144,13 @@
    "source": [
     "cbvsKepler = load_kepler_cbvs(mission='Kepler', quarter=8, module=16, output=4)\n",
     "cbvsK2 = load_kepler_cbvs(mission='K2', campaign=15, channel=24)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Only 30-minute 'long' cadence Single-Scale CBVs are avaulable for Kepler and K2, so there are no `cbv_type=` or `exptime=` arguments."
    ]
   },
   {
@@ -151,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Aligning the CBVs with your light curve"
+    "## Aligning the CBVs with your light curve time series"
    ]
   },
   {
@@ -167,9 +206,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Take a cut of the LC loaded above\n",
+    "# Take a slice of the LC loaded above\n",
     "lc_short = lc[501:1501]\n",
-    "# Take a different cut of the CBVs\n",
+    "# Take a different slice of the CBVs\n",
     "cbvs_short = cbvs[0:1000]\n",
     "# These cuts do not overlap\n",
     "np.all(lc_short.cadenceno == cbvs_short.cadenceno)"
@@ -198,7 +237,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above `align` method will only keep cadences that line up exactly between the CBVs and the light curve based on the cadence numbers. What if you have a light curve with cadence times not exactly lining up with the CBV cadences? For example, what if you want to use the 2-minute CBVs for cotrending against the 30-minute FFIs? A more general method is `interpolate`, which uses PCHIP interpolation to generate CBVs at the cadence times of an arbitrary light curve. If the light curve has cadences past either end of the cadences in the CBVs then one must extrapolate. An optional argument, `extrapolate`, can be used to also extrapolate the CBV values to the light curve cadences. If `extrapolate=False` then the exterior values are set to zeros, which will probably result is a very poor fit."
+    "The above `align` method will only keep cadences that line up exactly between the CBVs and the light curve, based on the cadence numbers. What if you have a light curve with cadence times that poorly line up with the CBV cadences? The above `align` operation even provided a warning for this occurance. In a real-world example, what if you want to use the 2-minute CBVs for cotrending against the 30-minute FFIs? A more general CBV method is `interpolate`, which uses PCHIP interpolation to generate CBVs at the cadence times of an arbitrary light curve. If the light curve has cadences past either end of the cadences in the CBVs then one must extrapolate. An optional argument, `extrapolate`, can be used to also extrapolate the CBV values to the light curve cadences. If `extrapolate=False` then the exterior values are set to zeros, which will probably result is a very poor fit."
    ]
   },
   {
@@ -222,7 +261,7 @@
    "outputs": [],
    "source": [
     "# Get the Single-Scale CBVs for this light curve\n",
-    "cbvs = load_tess_cbvs(sector=ffi_lc.sector, camera=ffi_lc.camera, ccd=ffi_lc.ccd, cbv_type='SingleScale')"
+    "cbvs = load_tess_cbvs(sector=ffi_lc.sector, camera=ffi_lc.camera, ccd=ffi_lc.ccd, cbv_type='SingleScale', exptime='short')"
    ]
   },
   {
@@ -270,9 +309,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Currently, only TESS 2-minute and Kepler/K2 30-minute CBVs are archived on MAST\n",
-    "- 20-second CBVs will be available for the TESS extended mission beginning with Sector 27. Each set of 20-second CBVs will be for the entire field of view.\n",
-    "- FFI CBVs are also being developed and will begin to be exported soon.\n",
+    "- 20-second CBVs are available for the TESS extended mission beginning with Sector 27. Each set of 20-second CBVs are derived for the entire field of view, versus one set per CCD.\n",
+    "- TESS FFI CBVs will be available soon.\n",
     "- The CBVs are generated to account for systematics at a specific cadence. They will not necessarily properly represent systematics at a different cadence, but in some cases can still be beneficial.\n",
     "- Please remain conscious of the Nyquist frequency and aliasing when interpolating CBVs."
    ]
@@ -294,7 +332,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/2-creating-light-curves/2-3-how-to-use-cbvcorrector.ipynb
+++ b/docs/source/tutorials/2-creating-light-curves/2-3-how-to-use-cbvcorrector.ipynb
@@ -28,16 +28,29 @@
    "metadata": {},
    "source": [
     "There are three basic types of CBVs: \n",
-    "\n",
     "- **Single-Scale** contains all systematic trends combined in a single set of basis vectors. \n",
-    "\n",
     "- **Multi-Scale** contains systematic trends in specific wavelet-based band passes. There are usually three sets of multi-scale basis vectors in three bands.\n",
-    "\n",
     "- **Spike** contains only short impulsive spike systematics.\n",
     "\n",
-    "There are two different correction methods in PDC: Single-Scale and Multi-Scale. Single-Scale performs the correction in a single bandpass. Multi-Scale performs the correction in three separate wavelet-based bandpasses. Both corrections are performed in PDC but we can only export a single PDC light curve for each target. So, PDC must choose which of the two to export on a per-target basis. Generally speaking, single-scale performs better at preserving longer period signals. But at periods close to transiting planet durations multi-scale performs better at preserving signals. PDC therefore mostly chooses multi-scale for use within the planet finding pipeline and for the archive. You can find in the light curve FITS header which PDC method was chosen (keyword “PDCMETHD”). Additionally, a seperate correction is alway performed to remove short impulsive systematic spikes.\n",
+    "There are two different correction methods in PDC: Single-Scale and Multi-Scale. Single-Scale performs the correction in a single bandpass. Multi-Scale performs the correction in three separate wavelet-based bandpasses. Both corrections are performed in PDC but the mission can only export a single PDC light curve for each target. So, PDC must choose between the two on a per-target basis. Generally speaking, single-scale performs better at preserving longer period signals. But at periods close to transiting planet durations multi-scale performs better at preserving signals. PDC therefore mostly chooses multi-scale for use within the planet finding pipeline and for the archive. You can find in the light curve FITS header which PDC method was chosen (keyword “PDCMETHD”). Additionally, a seperate correction is alway performed to remove short impulsive systematic spikes.\n",
     "\n",
-    "For an individual's research needs, the mission supplied PDC lightcurves might not be ideal and so the CBVs are provided to the user to perform their own correction. All three CBV types are provided at MAST for TESS, however only Single-Scale is provided at MAST for Kepler and K2. Also for Kepler and K2, Cotrending Basis Vectors are supplied for only the 30-minute target cadence."
+    "For an individual's research needs, the mission supplied PDC lightcurves might not be ideal and so the CBVs are provided to the user to perform their own correction. All three CBV types are provided at MAST for TESS, however only Single-Scale is provided at MAST for Kepler and K2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cadence Type CBV Availability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For Kepler and K2 CBVs are available for only the 30-minute 'long' cadence (technically 29.4 minute cadence).\n",
+    "\n",
+    "For TESS, CBVs are available for 2-minute 'short' and 20-second 'fast' cadence."
    ]
   },
   {
@@ -51,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One can directly obtain the CBVs with `load_tess_cbvs` and `load_kepler_cbvs`, either from MAST by default or from a local directory `cbv_dir`. However when generating a [CBVCorrector](https://docs.lightkurve.org/reference/api/lightkurve.correctors.CBVCorrector.html?highlight=cbvcorrector) object the appropriate CBVs are automatically downloaded from MAST and aligned to the lightcurve. Let's generate this object for a particularily interesting TESS variable target. We first download the SAP lightcurve."
+    "One can directly obtain the CBVs with `load_tess_cbvs` and `load_kepler_cbvs`, either from MAST by default or from a local directory `cbv_dir`. However when generating a [CBVCorrector](https://docs.lightkurve.org/reference/api/lightkurve.correctors.CBVCorrector.html?highlight=cbvcorrector) object, the appropriate CBVs are automatically downloaded from MAST and aligned to the lightcurve. Let's generate this object for a particularily interesting TESS variable target. We first download the SAP lightcurve."
    ]
   },
   {
@@ -73,7 +86,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we create a `CBVCorrector` object. This will download the CBVs appropriate for this target and store them in the `CBVCorrector` object. In the case of TESS, this means the CBVs associated with the CCD this target is on and for Sector 10."
+    "Next, we create a `CBVCorrector` object. This will download the CBVs appropriate for this target and store them in the `CBVCorrector` object. In the case of TESS, this means the CBVs associated with the CCD this target is on, for Sector 10 and 2-minute 'short' cadence."
    ]
   },
   {
@@ -129,6 +142,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note**: The CBVs are \"aligned\" by default, versus interpolated. See the note at the end of this tutorial on \"**Aligning versus Interpolating CBVs**\" for details about why interpolating can be dangerous."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Assessing Over- and Under-Fitting with the Goodness Metrics"
    ]
   },
@@ -146,7 +166,7 @@
     "\n",
     "- **Over-fitting metric**: Measures the introduced noise in the light curve after the correction. It does so by measuring the broad-band power spectrum via a Lomb-Scargle Periodogram both before and after the correction. If power has increased after the correction then this is an indication the CBV fit has over-fitted and introduced noise. The metric treats all frequencies equally when measuring power increase; from one frequency separation to the Nyquist frequency. This metric is callibrated such that a metric value of 0.5 means the introduced noise due to over-fitting is at the same power level as the uncertainties in the light curve.\n",
     "\n",
-    "- **Under-fitting metric**: Measures the mean residual target to target Pearson correlation between the target under study and a selection of neighboring targets. This metric will find and download a selection of neighboring SPOC SAP targets in RA and Decl. until a minimum number is found. The metric is callibrated such that a value of 0.95 means the residual correlations in the target is equivalent to chance correlations of White Gaussian Noise.\n",
+    "- **Under-fitting metric**: Measures the mean residual target to target Pearson correlation between the target under study and a selection of neighboring targets. This metric will find and download a selection of neighboring SPOC SAP targets in RA and Decl. until a minimum number is found. It attempts to find lightcurves with the same cadence type as the target under study. The metric is callibrated such that a value of 0.95 means the residual correlations in the target is equivalent to chance correlations of White Gaussian Noise.\n",
     "\n",
     "_The Goodness Metrics are not perfect!_ They are an estimate of over- and under-fitting and are to be used as a guideline along other other metrics to assess the quality of your light curve."
    ]
@@ -476,6 +496,73 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Example Using a TESS 20-second 'fast' Cadence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's pick the particularly famous example of Tabby's star and try to correct the 'fast' cadence light curve for this target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lcSAP = search_lightcurve('TIC 185336364', author='SPOC', sector=41, exptime=20).download(flux_column='sap_flux')\n",
+    "cbvCorrector = CBVCorrector(lcSAP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select which CBVs to use in the correction\n",
+    "cbv_type = ['SingleScale', 'Spike']\n",
+    "# Select which CBV indices to use\n",
+    "# Use the first 8 SingleScale and all Spike CBVS\n",
+    "cbv_indices = [np.arange(1,9), 'ALL']\n",
+    "# Perform the correction, optimizing for goodness\n",
+    "cbvCorrector.correct(cbv_type=cbv_type, cbv_indices=cbv_indices)\n",
+    "cbvCorrector.diagnose();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the correction removed a considerable amount of the high frequency, pointing-induced noise. It also removed the long term, predominantly focus-induced systematics. We end with a light curve of constant noise levels throughout and no long term trends. Below we compare the original light curve with the corrected but where we bin to 30 minutes to reduce high frequency noise. We also show the estimated CDPP for a 2.5 hour duration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = lcSAP.normalize().plot(label=\"20-sec SAP\")\n",
+    "lcSAP.bin(0.021).normalize().plot(label=\"20-sec SAP Binned\", ax=ax)\n",
+    "cbvCorrector.corrected_lc.bin(0.021).normalize().plot(label=\"20-sec CBVCorrected Binned\", ax=ax)\n",
+    "print('SAP CDPP (2.5 Hr) = {}'.format(lcSAP.estimate_cdpp(transit_duration=450)))\n",
+    "print('Corrected CDPP (2.5 Hr) = {}'.format(cbvCorrector.corrected_lc.estimate_cdpp(transit_duration=450)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The long term trend is quite flat and the 2.5-hour CDPP reduced from 151 ppm to 64 ppm."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Using the Goodness Metrics and CBVCorrector with other Design Matrices"
    ]
   },
@@ -636,7 +723,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "CBVCorrector works equally across Kepler, K2 and TESS. However the Multi-Scale and Spike basis vectors are only available for TESS[<sup>1</sup>](#fn1). For K2, the [PLDCorrector](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-k2-pldcorrector.html) and [SFFCorrector](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-k2-sffcorrector.html) classes might work better than `CBVCorrector`.\n",
+    "CBVCorrector works equally across Kepler, K2 and TESS. However the Multi-Scale and Spike basis vectors are only available for TESS[<sup>1</sup>](#fn1). For K2, the [PLDCorrector](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-k2-pldcorrector.html) and [SFFCorrector](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-3-k2-sffcorrector.html) classes might work better than `CBVCorrector` for many applications and should also be considered..\n",
     "\n",
     "If you want to just get the CBVs but not generate a CBVCorrector object then use the functions _load_kepler_cbvs_ and _load_tess_cbvs_ within the cbvcorrector module as explained [here](https://docs.lightkurve.org/tutorials/2-creating-light-curves/2-2-how-to-use-cbvs.html)."
    ]
@@ -659,7 +746,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The under-fitting metric computes the correlation between the corrected light curve and a selection of neighboring SPOC SAP light curves. If the light curve you are trying to correct was not generated by the SPOC pipeline (I.e. not a SAP light curve), then the neighboring SAP light curves might not contain the same instrumental systematics and the under-fitting metric might not properly measure when under-fitting is occuring. \n",
+    "The under-fitting metric computes the correlation between the corrected light curve and a selection of neighboring SPOC SAP light curves. It will attempt to download neighboring SAP light curves for the same cadence type as the given light curve. If the light curve you are trying to correct was not generated by the SPOC pipeline (I.e. not a SAP light curve), then the neighboring SAP light curves might not contain the same instrumental systematics and the under-fitting metric might not properly measure when under-fitting is occuring. \n",
     "\n",
     "The over-fitting metric examines the periodogram of the light curve before and after the correction and is therefore indifferent to how the light curve was generated. It simply looks to see if noise was injected into the light curve. The over-fitting metric is therefore much more generally applicable.\n",
     "\n",
@@ -794,13 +881,6 @@
     "normalized_lc -= 1.0\n",
     "print('Normalized Light curve units: {} (i.e astropy.units.dimensionless_unscaled)'.format(normalized_lc.flux.unit))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -819,7 +899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/src/lightkurve/correctors/cbvcorrector.py
+++ b/src/lightkurve/correctors/cbvcorrector.py
@@ -29,6 +29,8 @@ from ..search import search_lightcurve
 from .regressioncorrector import RegressionCorrector
 from ..collections import LightCurveCollection
 from .metrics import overfit_metric_lombscargle, underfit_metric_neighbors, MinTargetsError
+from ..io.tess import get_tess_cadence_type
+from ..io.kepler import get_kepler_cadence_type
 
 
 log = logging.getLogger(__name__)
@@ -45,7 +47,9 @@ class CBVCorrector(RegressionCorrector):
     from Kepler/K2/TESS.
 
     On construction of this object, the relevant CBVs will be downloaded from
-    MAST appropriate for the lightcurve object passed to the constructor.
+    MAST appropriate for the light curve cadence type passed to the constructor.
+    If the lc.meta["CADENCE_TYPE"] is not available then the cadence length is 
+    determined by the time interval between cadences in the lc.time array. 
 
     For TESS there are multiple CBV types. All are loaded and the user must
     specify which to use in the correction.
@@ -134,11 +138,16 @@ class CBVCorrector(RegressionCorrector):
         # Call the RegresssionCorrector Constructor
         super(CBVCorrector, self).__init__(lc)
 
+        if not hasattr(self.lc, 'targetid'):
+            self.lc.targetid = np.NaN
+
         #***
         # Retrieve all relevant CBVs from either MAST or a local directory
         cbvs = []
 
         if (not do_not_load_cbvs):
+            exptime = _determine_exptime_from_lc(self.lc)
+
             if self.lc.mission == 'Kepler':
                 cbvs.append(load_kepler_cbvs(cbv_dir=cbv_dir,mission=self.lc.mission, quarter=self.lc.quarter,
                         channel=self.lc.channel))
@@ -149,7 +158,7 @@ class CBVCorrector(RegressionCorrector):
                 # For TESS we load multiple CBV types
                 # Single-Scale
                 cbvs.append(load_tess_cbvs(cbv_dir=cbv_dir,sector=self.lc.sector,
-                    camera=self.lc.camera, ccd=self.lc.ccd, cbv_type='SingleScale'))
+                    camera=self.lc.camera, ccd=self.lc.ccd, cbv_type='SingleScale', exptime=exptime))
             
                 # Multi-Scale
                 # Although there has always been 3 bands, there could be more,
@@ -160,7 +169,7 @@ class CBVCorrector(RegressionCorrector):
                     iBand += 1
                     cbvObj = load_tess_cbvs(cbv_dir=cbv_dir,sector=self.lc.sector,
                         camera=self.lc.camera, ccd=self.lc.ccd, cbv_type='MultiScale',
-                        band=iBand)
+                        band=iBand, exptime=exptime)
                     if (cbvObj.band == iBand):
                         cbvs.append(cbvObj)
                     else:
@@ -168,7 +177,7 @@ class CBVCorrector(RegressionCorrector):
             
                 # Spike
                 cbvs.append(load_tess_cbvs(cbv_dir=cbv_dir,sector=self.lc.sector,
-                    camera=self.lc.camera, ccd=self.lc.ccd, cbv_type='Spike'))
+                    camera=self.lc.camera, ccd=self.lc.ccd, cbv_type='Spike', exptime=exptime))
             
             else:
                 raise ValueError('Unknown mission type')
@@ -1004,7 +1013,7 @@ class CotrendingBasisVectors(TimeSeries):
     ----------
     cadenceno       : int array-like
         Cadence indices
-    time            : flaot array-like
+    time            : float array-like
         CBV cadence times
     gap_indicators  : bool array-like
         True => cadence is gapped
@@ -1403,6 +1412,14 @@ class KeplerCotrendingBasisVectors(CotrendingBasisVectors):
         super(KeplerCotrendingBasisVectors, self).__init__(data=data,
                 time=time, **kwargs)
 
+        # The cadence type or exposure time is not in the CBVS FITs header.
+        # We need to derive the cadence type from the time array
+        if time is not None:
+            cadence_len = np.nanmedian(np.diff(time.unix))
+            cadence_type = get_kepler_cadence_type(cadence_len)
+            self.meta["EXPTIME"] = cadence_len
+            self.meta["CADENCE_TYPE"] = cadence_type
+
     @classmethod
     def from_hdu(self, hdu=None, module=None, output=None,
             **kwargs):
@@ -1522,14 +1539,22 @@ class KeplerCotrendingBasisVectors(CotrendingBasisVectors):
     def output(self, output):
         self.meta['OUTPUT'] = output
 
+    @property
+    def cadence_type(self):
+        return self.meta.get('CADENCE_TYPE', None)
+
+    @cadence_type.setter
+    def cadence_type(self, cadence_type):
+        self.meta['CADENCE_TYPE'] = cadence_type
+
     def __repr__(self):
 
         if self.mission == 'Kepler':
-            repr_string = 'Kepler CBVs, Quarter.Module.Output : {}.{}.{}, nCBVs : {}'\
-                ''.format(self.quarter, self.module, self.output, len(self.cbv_indices))
+            repr_string = 'Kepler CBVs, Cadence Type : {}, Quarter.Module.Output : {}.{}.{}, nCBVs : {}'\
+                ''.format(self.cadence_type, self.quarter, self.module, self.output, len(self.cbv_indices))
         elif self.mission == 'K2':
-            repr_string = 'K2 CBVs, Campaign.Module.Output : {}.{}.{}, nCBVs : {}'\
-                ''.format( self.campaign, self.module, self.output, len(self.cbv_indices))
+            repr_string = 'K2 CBVs, Cadence Type : {}, Campaign.Module.Output : {}.{}.{}, nCBVs : {}'\
+                ''.format(self.cadence_type, self.campaign, self.module, self.output, len(self.cbv_indices))
 
         return repr_string
 
@@ -1566,6 +1591,15 @@ class TessCotrendingBasisVectors(CotrendingBasisVectors):
         # Initialize attributes common to all CotrendingBasisVector classes
         super(TessCotrendingBasisVectors, self).__init__(data=data,
                 time=time, **kwargs)
+
+        # The cadence type or exposure time is not in the CBVS FITs header.
+        # We need to derive the cadence type from the time array
+        if time is not None:
+            cadence_len = np.nanmedian(np.diff(time.unix))
+            cadence_type = get_tess_cadence_type(cadence_len)
+            self.meta["EXPTIME"] = cadence_len
+            self.meta["CADENCE_TYPE"] = cadence_type
+
 
     @classmethod
     def from_hdu(self, hdu=None, cbv_type=None, band=None, **kwargs):
@@ -1691,25 +1725,28 @@ class TessCotrendingBasisVectors(CotrendingBasisVectors):
     def ccd(self, ccd):
         self.meta['CCD'] = ccd
 
+    @property
+    def cadence_type(self):
+        return self.meta.get('CADENCE_TYPE', None)
+
+    @cadence_type.setter
+    def cadence_type(self, cadence_type):
+        self.meta['CADENCE_TYPE'] = cadence_type
+
     def __repr__(self):
 
         if (self.cbv_type == 'MultiScale'):
-            repr_string = 'TESS CBVs, Sector.Camera.CCD : {}.{}.{}, CBVType.Band: {}.{}, nCBVs : {}' \
-                ''.format(self.sector, self.camera, self.ccd, self.cbv_type,
+            repr_string = 'TESS CBVs, Cadence Type : {}, Sector.Camera.CCD : {}.{}.{}, CBVType.Band: {}.{}, nCBVs : {}' \
+                ''.format(self.cadence_type, self.sector, self.camera, self.ccd, self.cbv_type,
                     self.band, len(self.cbv_indices))
         else:
-            repr_string = 'TESS CBVs, Sector.Camera.CCD : {}.{}.{}, CBVType : {}, nCBVS : {}'\
-                ''.format(self.sector, self.camera, self.ccd, self.cbv_type, len(self.cbv_indices))
+            repr_string = 'TESS CBVs, Cadence Type : {}, Sector.Camera.CCD : {}.{}.{}, CBVType : {}, nCBVS : {}'\
+                ''.format(self.cadence_type, self.sector, self.camera, self.ccd, self.cbv_type, len(self.cbv_indices))
 
         return repr_string
 
 #*******************************************************************************
 # Functions
-
-
-
-
-
 
 @deprecated("2.1", alternative="load_kepler_cbvs", warning_type=LightkurveDeprecationWarning)
 def download_kepler_cbvs(*args, **kwargs):
@@ -1730,6 +1767,8 @@ def load_kepler_cbvs(cbv_dir=None,mission=None, quarter=None, campaign=None,
     quarter/campaign.
 
     For Kepler this extracts the DR25 CBVs.
+
+    Only long (30-minute) cadence CBVs are available for Kepler and K2. 
 
     Parameters
     ----------
@@ -1820,7 +1859,7 @@ def download_tess_cbvs(*args, **kwargs):
 
 
 def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
-        ccd=None, cbv_type='SingleScale', band=None):
+        ccd=None, cbv_type='SingleScale', band=None, exptime='short'):
     """Loads TESS cotrending basis vectors, either from a directory of 
     CBV files already saved locally if cbv_dir is passed, or else 
     will retrieve the relevant files programmatically from MAST. 
@@ -1828,11 +1867,9 @@ def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
     This function fetches the Cotrending Basis Vectors FITS HDU for the desired
     cotrending basis vectors.
 
-    For TESS, each CCD CBVs are stored in a separate FITS files.
+    For TESS, each CCD CBVs are stored in a separate FITS file.
 
-    For now, this function will only load 2-minute cadence CBVs. Once other
-    cadence CBVs become available this function will be updated to support
-    their downloads.
+    This function will load either 'short' 2-minute or 'fast' 20-second CBVs.
 
     Parameters
     ----------
@@ -1846,6 +1883,13 @@ def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
         'SingleScale' or 'MultiScale' or 'Spike'
     band : int
         Multi-scale band number
+    exptime : 'long', 'short', 'fast', or float
+        'long' selects 10-min and 30-min cadence products;
+        'short' selects 2-min products;
+        'fast' selects 20-sec products.
+        Alternatively, you can pass the exact exposure time in seconds as
+        an int or a float, e.g., ``exptime=600`` selects 10-minute cadence.
+        By default, 2-min is returned.
 
     Returns
     -------
@@ -1888,14 +1932,23 @@ def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
 
     # This is the string to search for in the curl script file
     # Pad the sector number with a first '0' if less than 10
-    # TODO: figure out a way to pad an integer number with forward zeros
-    # without needing a conditional
     sector = int(sector)
-
     try:
         SearchString = 's%04d-%s-%s-' % (sector, str(camera),str(ccd))
     except:
         raise Exception('Error parsing sector string when getting TESS CBV FITS files')
+
+    # Get cadence type
+    cadence_type = get_tess_cadence_type(exptime)
+    if cadence_type == 'long':
+        raise Exception('load_tess_cbvs does not yet handle long exposure cadence CBVs.')
+        cbv_cadence_str = 'FTL'
+    elif cadence_type == 'short':
+        cbv_cadence_str = ''
+    elif cadence_type == 'fast':
+        cbv_cadence_str = 'fast-'
+    else:
+        raise Exception('Unknown cadence "{}"'.format(cadence_type))
 
     try:
         if cbv_dir is not None:
@@ -1917,8 +1970,8 @@ def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
 
         else:
             curlBaseUrl = 'https://archive.stsci.edu/missions/tess/download_scripts/sector/tesscurl_sector_'
-            curlEndUrl = '_cbv.sh'
-            curlUrl = curlBaseUrl + str(sector) + curlEndUrl
+            curlEndUrl = 'cbv.sh'
+            curlUrl = curlBaseUrl + str(sector) + '_' + cbv_cadence_str + curlEndUrl
 
             # This is the string to search for in the curl script file
 
@@ -1950,3 +2003,45 @@ def load_tess_cbvs(cbv_dir=None,sector=None, camera=None,
 
     except:
         raise Exception('CBVS were not found')
+
+def _determine_exptime_from_lc(lc):
+    """ Determiens the exposure time 'exptime' based on the information in the 
+    light curve object.
+
+    if lc.meta['CADENCE_TYPE'] exists then that value is used.
+
+    Otherwise, the cadence type is determeind from the median cadence length.
+    This latter method requires lc.mission to be set (because the cadence type 
+    is dependent on the mission)
+
+    Parameters
+    ----------
+    lc  : LightCurve
+        The light curve to correct
+
+    Returns
+    -------
+    exptime : str
+        one of: ('long', 'short', 'fast')
+    """
+    # Determine the cadence type (exposure time) for this light curve
+    # Cadence type is not necessarily available if this is a custom light curve
+    exptime = lc.meta.get('CADENCE_TYPE')
+    if exptime is None:
+        # CADENCE_TYPE is not in the light curve. Attempt to measure the cadence type.
+        # We need to derive the cadence type from the time array
+        cadence_len = np.nanmedian(np.diff(lc.time.unix))
+        if hasattr(lc, 'mission'):
+            if lc.mission == 'TESS':
+                exptime = get_tess_cadence_type(cadence_len)
+                # long cadence TESS CBVs not yet suppored, load short cadence
+                if exptime == 'long':
+                    exptime = 'short'
+            else:
+                exptime = get_kepler_cadence_type(cadence_len)
+        else:
+            # No clue what data this is
+            raise Exception('LightCurve object must contain meta keyword' + \
+                    '"mission" in order to determine cadence type')
+
+    return exptime

--- a/src/lightkurve/correctors/metrics.py
+++ b/src/lightkurve/correctors/metrics.py
@@ -135,9 +135,9 @@ def underfit_metric_neighbors(
     target Pearson correlation between the target under study and a selection of
     neighboring SPOC SAP target light curves.
 
-    This function will search within the given radiu in arceseconds and find the
-    min_targets nearest targets up until max_targets is reached. If less than
-    min_targets is found a MinTargetsError Exception is raised.
+    This function will search within the given radius in arceseconds and find 
+    the min_targets nearest targets up until max_targets is reached. If less 
+    than min_targets is found a MinTargetsError Exception is raised.
 
     The downloaded neighboring targets will normally be "aligned" to the
     corrected_lc, meaning the cadence numbers are used to align the targets
@@ -314,12 +314,17 @@ def _download_and_preprocess_neighbors(
         List containing the flux arrays of the neighboring light curves,
         interpolated or aligned with `corrected_lc` if requested.
     """
+    from .cbvcorrector import _determine_exptime_from_lc
+
     if extrapolate and (extrapolate != interpolate):
         raise Exception('interpolate must be True if extrapolate is True')
 
+    exptime = _determine_exptime_from_lc(corrected_lc)
     search = corrected_lc.search_neighbors(
-        limit=max_targets, radius=radius, author=author
+        limit=max_targets, radius=radius, author=author, 
+        exptime=exptime
     )
+
     if len(search) < min_targets:
         raise MinTargetsError(
             f"Unable to find at least {min_targets} neighbors within {radius} arcseconds radius."

--- a/src/lightkurve/io/kepler.py
+++ b/src/lightkurve/io/kepler.py
@@ -51,4 +51,48 @@ def read_kepler_lightcurve(
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask
+    lc.meta["EXPTIME"] = lc.meta.get("FRAMETIM") * lc.meta.get("NUM_FRM")
+    lc.meta["CADENCE_TYPE"] = get_kepler_cadence_type(lc.meta["EXPTIME"])
     return KeplerLightCurve(data=lc)
+
+def get_kepler_cadence_type(exptime):
+    """ Returns the Kepler cadence type as a string based on the exposure time.
+
+    Alternatively, if a string is pass then this function checks for a valid 
+    cadence type and then returns it. It raises an exception if not valid.
+
+    The options are:
+    if   exptime < 120   : "short"  (i.e. 60-second)
+    elif exptime < 2000 : "long" (i.e. 30-minute)
+    else                : "ffi"  (i.e. Full-Frame Images)
+
+    Parameters
+    ----------
+    exptime : 'ffi', 'long', 'short', or float
+        Exposure time for cadence in seconds
+        Or a string containing the cadence type
+        'ffi' selects FFI products.
+        'long' selects 30-min cadence products;
+        'short' selects 1-min products;
+
+    Returns
+    -------
+    cadence_type : str
+        one of: ('ffi', 'long', 'short')
+    """
+    valid_str_options = ('ffi', 'long', 'short')
+
+    if isinstance(exptime, str):
+        if valid_str_options.count(exptime.lower()) != 1:
+            raise Exception('Invalid cadence type')
+        else:
+            return exptime
+
+    if exptime is None:
+        return None
+    elif exptime < 120:
+        return 'short'
+    elif exptime < 2000:
+        return 'long'
+    else:
+        return 'ffi'

--- a/src/lightkurve/io/tess.py
+++ b/src/lightkurve/io/tess.py
@@ -46,4 +46,48 @@ def read_tess_lightcurve(
     lc.meta["TARGETID"] = lc.meta.get("TICID")
     lc.meta["QUALITY_BITMASK"] = quality_bitmask
     lc.meta["QUALITY_MASK"] = quality_mask
+    lc.meta["EXPTIME"] = lc.meta.get("FRAMETIM") * lc.meta.get("NUM_FRM")
+    lc.meta["CADENCE_TYPE"] = get_tess_cadence_type(lc.meta["EXPTIME"])
     return TessLightCurve(data=lc)
+
+def get_tess_cadence_type(exptime):
+    """ Returns the TESS cadence type as a string based on the exposure time.
+
+    Alternatively, if a string is pass then this function checks for a valid 
+    cadence type and then returns it. It raises an exception if not valid.
+
+    The options are:
+    if   exptime < 60   : "fast"  (i.e. 20-second)
+    elif exptime < 300  : "short" (i.e. 2-minute)
+    else                : "long"  (i.e. 30 or 10 minute FFI)
+
+    Parameters
+    ----------
+    exptime : 'long', 'short', 'fast', or float
+        Exposure time for cadence in seconds
+        Or a string containing the cadence type
+        'long' selects 10-min and 30-min cadence products;
+        'short' selects 2-min products;
+        'fast' selects 20-sec products.
+
+    Returns
+    -------
+    cadence_type : str
+        one of: ('long', 'short', 'fast')
+    """
+    valid_str_options = ('long', 'short', 'fast')
+
+    if isinstance(exptime, str):
+        if valid_str_options.count(exptime.lower()) != 1:
+            raise Exception('Invalid cadence type')
+        else:
+            return exptime
+
+    if exptime is None:
+        return None
+    elif exptime < 60:
+        return 'fast'
+    elif exptime < 300:
+        return 'short'
+    else:
+        return 'long'

--- a/tests/correctors/test_cbvcorrector.py
+++ b/tests/correctors/test_cbvcorrector.py
@@ -227,6 +227,22 @@ def test_cbv_retrieval():
     ax = cbvs.plot("all")
     assert isinstance(ax, matplotlib.axes.Axes)
 
+    # 20-second CBVs
+    cbvs = load_tess_cbvs(sector=41, camera=2, ccd=4, cbv_type='MultiScale', band=2, exptime='fast')
+    assert isinstance(cbvs, TessCotrendingBasisVectors)
+    ax = cbvs.plot("all")
+    assert isinstance(ax, matplotlib.axes.Axes)
+
+    cbvs = load_tess_cbvs(sector=41, camera=2, ccd=4, cbv_type='MultiScale', band=2, exptime=20)
+    assert isinstance(cbvs, TessCotrendingBasisVectors)
+    ax = cbvs.plot("all")
+    assert isinstance(ax, matplotlib.axes.Axes)
+
+    cbvs = load_tess_cbvs(sector=41, camera=2, ccd=4, cbv_type='MultiScale', band=2, exptime=120)
+    assert isinstance(cbvs, TessCotrendingBasisVectors)
+    ax = cbvs.plot("all")
+    assert isinstance(ax, matplotlib.axes.Axes)
+
     # No band specified for MultiScale, this should error
     with pytest.raises(AssertionError):
         cbvs = load_tess_cbvs(sector=10, camera=2, ccd=4, cbv_type="MultiScale")
@@ -334,7 +350,6 @@ def test_cbv_local():
 # *******************************************************************************
 # *******************************************************************************
 # CBVCorrector Unit Tests
-
 
 def test_CBVCorrector():
 
@@ -501,6 +516,10 @@ def test_CBVCorrector_retrieval():
     ).download(flux_column="sap_flux")
     cbvCorrector = CBVCorrector(lc)
     lc = cbvCorrector.correct_gaussian_prior(alpha=1.0)
+    assert isinstance(lc, KeplerLightCurve)
+    assert lc.flux.unit == u.Unit("electron / second")
+
+    lc = cbvCorrector.correct()
     assert isinstance(lc, KeplerLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
 


### PR DESCRIPTION
Here is a branch to get the CBVCorrector working with 20-second "fast" CBVs.

CBVCorrector will now automatically identify if the TESS light curve under study is 20-second or 2-minute cadence data and download the appropriate CBVs. The tutorials have been updated to explain the new functionality. 

For Kepler, only 30-minute CBVs are available so not much changed there.

New meta fields have been created in the light curve objects to help identify the cadence type:
```
lc.meta["EXPTIME"] = lc.meta.get("FRAMETIM") * lc.meta.get("NUM_FRM")
lc.meta["CADENCE_TYPE"] = (TESS: 'long', 'short', 'fast) or (KEPLER/K2: 'ffi', 'long', 'short')
```
Helper functions created are `io/tess.get_tess_cadence_type` and `io/kepler.get_kepler_cadence_type` to determine the cadence type from the exposure time. A third helper function is `cbvcorrector._determine_exptime_from_lc` but that one is not intended for public use.

It would be appreciated if someone could go through the tutorials and see if everything works for them and makes sense.