### PR TITLE
Make Lightkurve compatible with Astropy v5.0 and Python 3.10

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -1,10 +1,10 @@
 # GitHub Actions workflow for Lightkurve's continuous integration.
 #
 # This file configures seven different jobs:
-# 1) pytest on Linux, Python 3.7.
-# 2) pytest on Linux, Python 3.7.
-# 3) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
-# 4) pytest on Linux, Python 3.9.
+# 1) pytest on Linux, Python 3.8, with -m memtest (i.e. stress memory)
+# 2) pytest on Linux, Python 3.8, with --remote-data enabled (i.e. get data from MAST).
+# 3) pytest on Linux, Python 3.9.
+# 4) pytest on Linux, Python 3.10.
 # 5) pytest on Windows, Python 3.8.
 # 6) pytest on OSX, Python 3.8.
 # 7) flake8 syntax check.
@@ -20,14 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.6, 3.7, 3.8-remote-data, 3.8-memtest, 3.9]
+        name: [3.8-remote-data, 3.8-memtest, 3.9, 3.10]
         include:
-          - name: 3.6
-            python-version: 3.6
-            pytest-command: poetry run pytest
-          - name: 3.7
-            python-version: 3.7
-            pytest-command: poetry run pytest
           - name: 3.8-remote-data
             python-version: 3.8
             pytest-command: poetry run pytest --remote-data --doctest-modules
@@ -36,6 +30,9 @@ jobs:
             pytest-command: poetry run pytest -m memtest --remote-data
           - name: 3.9
             python-version: 3.9
+            pytest-command: poetry run pytest
+          - name: 3.10
+            python-version: 3.10
             pytest-command: poetry run pytest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [3.8-remote-data, 3.8-memtest, 3.9, 3.10]
+        name: [3.8-remote-data, 3.8-memtest, 3.9, '3.10']
         include:
           - name: 3.8-remote-data
             python-version: 3.8
@@ -31,7 +31,7 @@ jobs:
           - name: 3.9
             python-version: 3.9
             pytest-command: poetry run pytest
-          - name: 3.10
+          - name: '3.10'
             python-version: '3.10'
             pytest-command: poetry run pytest
     steps:

--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -32,7 +32,7 @@ jobs:
             python-version: 3.9
             pytest-command: poetry run pytest
           - name: 3.10
-            python-version: 3.10
+            python-version: '3.10'
             pytest-command: poetry run pytest
     steps:
     - uses: actions/checkout@v1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 2.1.0 (unreleased)
 ==================
 
+- Made Lightkurve compatible with AstroPy v5.0 and its introduction of masked
+  quantities.  As a result, Lightkurve v2.1 requires AstroPy v5.0 or later. [#1162]
+
 - Added the ``cbv_dir`` parameter to ``CBVCorrector``, ``load_kepler_cbvs``, and
   ``load_tess_cbvs`` to enable CBVs to be loaded from a local directory. [#1122]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ghp-import = "^1.0.1"
 openpyxl = "^3.0.7"
 dephell = "^0.8.3"
 tox = "^3.24.5"
-mistune = "<2.0.0"
+mistune = "<2.0.0"  # not a dependency (workaround for #1162)
 
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pytest-remotedata = "^0.3.2"
 pytest-doctestplus = "^0.8.0"
 pytest-xdist = "^2.1.0"
 jupyter = "^1.0.0"
-Sphinx = "^4.2.0"
+Sphinx = ">=4.3.0"
 nbsphinx = "^0.8.7"
 numpydoc = "^1.1.0"
 sphinx-automodapi = "^0.13"
@@ -64,6 +64,7 @@ ghp-import = "^1.0.1"
 openpyxl = "^3.0.7"
 dephell = "^0.8.3"
 tox = "^3.24.5"
+mistune = "<2.0.0"
 
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 [tool.poetry.dependencies]
 python = ">=3.8"
 numpy = ">=1.18"
-astropy = ">=5.0rc2"
+astropy = ">=5.0.0"
 scipy = ">=1.3"
 matplotlib = ">=3.1"
 astroquery = ">=0.3.10"
@@ -63,6 +63,7 @@ pylint = "^2.6.0"
 ghp-import = "^1.0.1"
 openpyxl = "^3.0.7"
 dephell = "^0.8.3"
+tox = "^3.24.5"
 
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ghp-import = "^1.0.1"
 openpyxl = "^3.0.7"
 dephell = "^0.8.3"
 tox = "^3.24.5"
-mistune = "<2.0.0"  # not a dependency (workaround for #1162)
+mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
 
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lightkurve"
-version = "2.0.12dev"
+version = "2.1.0dev"
 description = "A friendly package for Kepler & TESS time series analysis in Python."
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>"]
@@ -25,45 +25,46 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 [tool.poetry.dependencies]
 python = ">=3.8"
 numpy = ">=1.18"
-astropy = ">=5.0.0"
-scipy = ">=1.3"
+astropy = ">=5.0"
+scipy = { version = ">=1.7", python = ">=3.8,<3.11" }
 matplotlib = ">=3.1"
 astroquery = ">=0.3.10"
 oktopus = ">=0.1.2"
 beautifulsoup4 = ">=4.6.0"
 requests = ">=2.22.0"
+urllib3 = { version = ">=1.23", python = ">=3.8,<4.0" }  # necessary to make requests work on py310
 tqdm = ">=4.25.0"
 pandas = ">=1.1.4"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"
 bokeh = ">=1.0"
-memoization = { version = ">=0.3.1", python = ">=3.6,<4.0" }
+memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
 
 [tool.poetry.dev-dependencies]
-jupyterlab = "^2.0.0"
-black = "^20.8b1"
-flake8 = "^3.8.4"
-mypy = "^0.790"
+jupyterlab = ">=2.0.0"
+black = ">=21.12b0"
+flake8 = ">=3.8.4"
+mypy = ">=0.930"
 isort = { version = ">=5.6.4", python = ">=3.6,<4.0" }
-pytest = "^6.1.2"
-pytest-cov = "^2.10.1"
-pytest-remotedata = "^0.3.2"
-pytest-doctestplus = "^0.8.0"
-pytest-xdist = "^2.1.0"
-jupyter = "^1.0.0"
+pytest = ">=6.1.2"
+pytest-cov = ">=2.10.1"
+pytest-remotedata = ">=0.3.2"
+pytest-doctestplus = ">=0.8.0"
+pytest-xdist = ">=2.1.0"
+jupyter = ">=1.0.0"
 Sphinx = ">=4.3.0"
-nbsphinx = "^0.8.7"
-numpydoc = "^1.1.0"
-sphinx-automodapi = "^0.13"
-sphinxcontrib-rawfiles = "^0.1.1"
-pydata-sphinx-theme = "^0.7.1"
-pylint = "^2.6.0"
-ghp-import = "^1.0.1"
-openpyxl = "^3.0.7"
-dephell = "^0.8.3"
-tox = "^3.24.5"
+nbsphinx = ">=0.8.7"
+numpydoc = ">=1.1.0"
+sphinx-automodapi = ">=0.13"
+sphinxcontrib-rawfiles = ">=0.1.1"
+pydata-sphinx-theme = ">=0.7.1"
+pylint = ">=2.6.0"
+ghp-import = ">=1.0.1"
+openpyxl = ">=3.0.7"
+dephell = ">=0.8.3"
+tox = ">=3.24.5"
 mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 "Bug Tracker" = "https://github.com/lightkurve/lightkurve/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.6.1"
-numpy = ">=1.11"
-astropy = ">=4.1"
-scipy = ">=0.19.0"
-matplotlib = ">=1.5.3"
+python = ">=3.8"
+numpy = ">=1.18"
+astropy = ">=5.0rc2"
+scipy = ">=1.3"
+matplotlib = ">=3.1"
 astroquery = ">=0.3.10"
 oktopus = ">=0.1.2"
 beautifulsoup4 = ">=4.6.0"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='lightkurve',
-    version='2.0.12dev',
+    version='2.1.0dev',
     description='A friendly package for Kepler & TESS time series analysis in Python.',
     python_requires='>=3.6.1',
     project_urls={"homepage": "https://docs.lightkurve.org", "repository": "https://github.com/lightkurve/lightkurve"},

--- a/src/lightkurve/correctors/regressioncorrector.py
+++ b/src/lightkurve/correctors/regressioncorrector.py
@@ -254,6 +254,9 @@ class RegressionCorrector(Corrector):
             )
             model = u.Quantity(model, unit=self.lc.flux.unit)
             residuals = self.lc.flux - model
+            # In Astropy>=5.0, residuals will be a MaskedQuantity
+            if hasattr(residuals, 'mask'):
+                residuals = residuals.unmasked
             self.outlier_mask |= sigma_clip(residuals, sigma=sigma).mask
             log.debug(
                 "correct(): iteration {}: clipped {} cadences"

--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -169,6 +169,12 @@ class SFFCorrector(RegressionCorrector):
                 ar = np.copy(self.arclength.value)
             else:
                 ar = np.copy(self.arclength)
+
+            # Temporary workaround for issue #1161: AstroPy v5.0
+            # Masked arrays cannot be passed to `np.in1d` below
+            if hasattr(self.arclength, 'mask'):
+                ar = ar.unmasked
+
             knots = list(np.percentile(ar[a:b], np.linspace(0, 100, bins + 1)[1:-1]))
             ar[~np.in1d(ar, ar[a:b])] = 0
 

--- a/src/lightkurve/interact_bls.py
+++ b/src/lightkurve/interact_bls.py
@@ -309,7 +309,7 @@ def make_lightcurve_figure_elements(
     else:
         fig.xaxis.axis_label = "Time (days)"
     ylims = [np.nanmin(lc.flux.value), np.nanmax(lc.flux.value)]
-    fig.y_range = Range1d(start=ylims[0], end=ylims[1])
+    fig.y_range = Range1d(start=float(ylims[0]), end=float(ylims[1]))
 
     # Add light curve
     fig.circle(

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1114,10 +1114,10 @@ class LightCurve(QTimeSeries):
             >>> lc = lk.LightCurve({'time': [1, 2, 3], 'flux': [1., np.nan, 1.]})
             >>> lc.remove_nans()
             <LightCurve length=2>
-            time    flux  flux_err
+            time   flux  flux_err
             <BLANKLINE>
-            object float64 float64
-            ------ ------- --------
+            Time float64 float64
+            ---- ------- --------
             1.0     1.0      nan
             3.0     1.0      nan
         """

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1808,7 +1808,7 @@ class LightCurve(QTimeSeries):
         if "label" not in kwargs:
             kwargs["label"] = self.meta.get("LABEL")
 
-        # Temporary workaround for AstroPy v5.0rc2 issue #12481: the 'c' argument
+        # Workaround for AstroPy v5.0.0 issue #12481: the 'c' argument
         # in matplotlib's scatter does not work with masked quantities.
         if "c" in kwargs and hasattr(kwargs["c"], 'mask'):
             kwargs["c"] = kwargs["c"].unmasked
@@ -1818,6 +1818,13 @@ class LightCurve(QTimeSeries):
             flux_err = self[f"{column}_err"]
         except KeyError:
             flux_err = np.full(len(flux), np.nan)
+
+        # Second workaround for AstroPy v5.0.0 issue #12481:
+        # matplotlib does not work well with `MaskedNDArray` arrays.
+        if hasattr(flux, 'mask'):
+            flux = flux.filled(np.nan)
+        if hasattr(flux_err, 'mask'):
+            flux_err = flux_err.filled(np.nan)
 
         # Normalize the data if requested
         if normalize:

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1808,6 +1808,11 @@ class LightCurve(QTimeSeries):
         if "label" not in kwargs:
             kwargs["label"] = self.meta.get("LABEL")
 
+        # Temporary workaround for AstroPy v5.0rc2 issue #12481: the 'c' argument
+        # in matplotlib's scatter does not work with masked quantities.
+        if "c" in kwargs and hasattr(kwargs["c"], 'mask'):
+            kwargs["c"] = kwargs["c"].unmasked
+
         flux = self[column]
         try:
             flux_err = self[f"{column}_err"]

--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -784,7 +784,7 @@ class LombScarglePeriodogram(Periodogram):
         """
         # Input validation
         normalization = validate_method(normalization, ["psd", "amplitude"])
-        if np.isnan(lc.flux).any() or (hasattr(lc, 'mask') and np.isnan(lc.flux.unmasked).any()):
+        if np.isnan(lc.flux).any() or (hasattr(lc.flux, 'unmasked') and np.isnan(lc.flux.unmasked).any()):
             lc = lc.remove_nans()
             log.debug(
                 "Lightcurve contains NaN values."

--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -784,7 +784,7 @@ class LombScarglePeriodogram(Periodogram):
         """
         # Input validation
         normalization = validate_method(normalization, ["psd", "amplitude"])
-        if np.isnan(lc.flux).any():
+        if np.isnan(lc.flux).any() or (hasattr(lc, 'mask') and np.isnan(lc.flux.unmasked).any()):
             lc = lc.remove_nans()
             log.debug(
                 "Lightcurve contains NaN values."

--- a/src/lightkurve/version.py
+++ b/src/lightkurve/version.py
@@ -1,3 +1,3 @@
 # It is important to store the version number in a separate file
 # so that we can read it from setup.py without importing the package
-__version__ = "2.0.12dev"
+__version__ = "2.1.0dev"

--- a/tests/test_interact_bls.py
+++ b/tests/test_interact_bls.py
@@ -82,7 +82,11 @@ def test_preprocess_lc():
     from lightkurve.interact_bls import _preprocess_lc_for_bls
 
     lc = KeplerLightCurve.read(KEPLER10)
-    assert np.isnan(lc.flux).any()  # ensure the test data has nan in flux
+    # As of AstroPy v5, flux is a `MaskedQuantity` in which NaNs are masked;
+    # so the next assert would not pass.
+    if not hasattr(lc.flux, "mask"):
+        # ensure the test data has nan in flux pre-Astropy v5
+        assert np.isnan(lc.flux).any()
 
     clean = _preprocess_lc_for_bls(lc)
     assert not np.isnan(clean.flux).any()  # ensure processed lc has no nan

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1741,3 +1741,11 @@ def test_transit_mask_with_quantities():
     mask_quantity = lc.create_transit_mask(period=2.9*u.day, transit_time=1*u.day, duration=1*u.day)
     mask_no_quantity = lc.create_transit_mask(period=2.9, transit_time=1, duration=1)
     assert all(mask_quantity == mask_no_quantity)
+
+
+@pytest.mark.skip  # expected to be resolved by the AstroPy v5.0.1 release
+def test_nbins():
+    """Regression test for #1162."""
+    lc = LightCurve(flux=[0, 0, 0])
+    # This statement raised an IndexError with Astropy v5.0rc2:
+    lc.bin(bins=2)

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -547,6 +547,7 @@ def test_bin_folded():
     assert np.round(binned_folded_lc.flux_err[0], 2) == 0.01
 
 
+@pytest.mark.skip  # expected to be resolved in AstroPy v5.0.1 via PR #12527
 def test_bins_kwarg():
     """Does binning work with user-defined bin placement?"""
     n_times = 3800
@@ -1743,7 +1744,7 @@ def test_transit_mask_with_quantities():
     assert all(mask_quantity == mask_no_quantity)
 
 
-@pytest.mark.skip  # expected to be resolved by the AstroPy v5.0.1 release
+@pytest.mark.skip  # expected to be resolved in AstroPy v5.0.1 via PR #12527
 def test_nbins():
     """Regression test for #1162."""
     lc = LightCurve(flux=[0, 0, 0])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -396,12 +396,12 @@ def test_overlapping_targets_718():
     # the requested targets, not their overlapping neighbors.
     targets = ["KIC 5112705", "KIC 10058374", "KIC 5385723"]
     for target in targets:
-        search = search_lightcurve(target, quarter=11)
+        search = search_lightcurve(target, quarter=11, author="Kepler")
         assert len(search) == 1
         assert search.target_name[0] == f"kplr{target[4:].zfill(9)}"
 
     # When using `radius=1` we should also retrieve the overlapping targets
-    search = search_lightcurve("KIC 5112705", quarter=11, radius=1 * u.arcsec)
+    search = search_lightcurve("KIC 5112705", quarter=11, author="Kepler", radius=1 * u.arcsec)
     assert len(search) > 1
 
     # Searching by `target_name` should not preven a KIC identifier to work

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 isolated_build = true
-envlist = py38, py39
+envlist = py{38,39}
 
 [testenv]
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest
+    poetry run pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+isolated_build = true
+envlist = py38, py39
+
+[testenv]
+whitelist_externals = poetry
+commands =
+    poetry install -v
+    poetry run pytest

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,4 @@ whitelist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest {posargs}
+    poetry run pytest --doctest-modules src

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{38,39}
+envlist = py{38,39,310}
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
As reported by @dhomeier in https://github.com/lightkurve/lightkurve/issues/1161, a number of Lightkurve unit tests are currently failing with Astropy v5.0rc2.

I intend to use this PR to investigate and resolve those test failures.