### PR TITLE
Fix lc.fill_gaps() and lc.query_solar_system_objects() with Astropy v5.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,6 +54,7 @@ The following GitHub members directly contributed code and bugfixes:
 - `Isaac Yong <https://github.com/isaac-yong0804>`_
 - `Gutsycat <https://github.com/Sniperq2>`_
 - `Jennifer V Medina <https://github.com/jaymedina>`_
+- `Keyu Xing <https://github.com/keyuxing>`_
 
 
 Community

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@
   `TypeError: cannot write to unmasked output`. [#1175]
 
 - Fixed a bug in `search_tesscut(...).download()` which caused TESSCut
-  downloads to fail when Astroquery v0.4.6 or later is installed.
+  downloads to fail when Astroquery v0.4.6 or later is installed. [#1176]
+
+- Fixed a bug in ``LightCurve.fill_gaps()`` which triggered a
+  ``ValueError`` in the presence of masked data. [#1172]
+
 
 
 2.1.0 (2022-02-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@
 - Fixed a bug in `search_tesscut(...).download()` which caused TESSCut
   downloads to fail when Astroquery v0.4.6 or later is installed. [#1176]
 
-- Fixed a bug in ``LightCurve.fill_gaps()`` which triggered a
-  ``ValueError`` in the presence of masked data. [#1172]
+- Fixed a bug in ``LightCurve.fill_gaps()`` which caused incorrect
+  results in the presence of masked data. [#1172]
 
 
 

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1179,12 +1179,14 @@ class LightCurve(QTimeSeries):
         f[in_original] = np.copy(lc.flux)
         fe = np.zeros(len(ntime))
         fe[in_original] = np.copy(lc.flux_err)
-        
+
+        # Temporary workaround for issue #1172.  TODO: remove the `if`` statement
+        # below once we adopt AstroPy >=5.0.3 as a minimum dependency.
         if hasattr(lc.flux_err, 'mask'):
             fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
         else:
             fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
-            
+
         if method == "gaussian_noise":
             try:
                 std = lc.estimate_cdpp().to(lc.flux.unit).value
@@ -1692,6 +1694,8 @@ class LightCurve(QTimeSeries):
         # Avoid searching times with NaN flux; this is necessary because e.g.
         # `remove_outliers` includes NaNs in its mask.
         if hasattr(self.flux, 'mask'):
+            # Temporary workaround for issue #1172. TODO: remove this `if`` statement
+            # once we adopt AstroPy >=5.0.3 as a minimum dependency
             cadence_mask &= ~np.isnan(self.flux.unmasked)
         else:
             cadence_mask &= ~np.isnan(self.flux)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1691,7 +1691,10 @@ class LightCurve(QTimeSeries):
             raise ValueError("the `cadence_mask` argument is missing or invalid")
         # Avoid searching times with NaN flux; this is necessary because e.g.
         # `remove_outliers` includes NaNs in its mask.
-        cadence_mask &= ~np.isnan(self.flux)
+        if hasattr(self.flux, 'mask'):
+            cadence_mask &= ~np.isnan(self.flux.unmasked)
+        else:
+            cadence_mask &= ~np.isnan(self.flux)
 
         # Validate `location`
         if location is None:

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1182,7 +1182,7 @@ class LightCurve(QTimeSeries):
         
         try:
             fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
-        else ValueError:
+        except ValueError:
             fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
             
         if method == "gaussian_noise":

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1180,10 +1180,10 @@ class LightCurve(QTimeSeries):
         fe = np.zeros(len(ntime))
         fe[in_original] = np.copy(lc.flux_err)
         
-        try:
-            fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
-        except ValueError:
+        if hasattr(lc.flux_err, 'mask'):
             fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
+        else:
+            fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
             
         if method == "gaussian_noise":
             try:

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1180,7 +1180,7 @@ class LightCurve(QTimeSeries):
         fe = np.zeros(len(ntime))
         fe[in_original] = np.copy(lc.flux_err)
 
-        fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
+        fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
         if method == "gaussian_noise":
             try:
                 std = lc.estimate_cdpp().to(lc.flux.unit).value

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1179,8 +1179,12 @@ class LightCurve(QTimeSeries):
         f[in_original] = np.copy(lc.flux)
         fe = np.zeros(len(ntime))
         fe[in_original] = np.copy(lc.flux_err)
-
-        fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
+        
+        try:
+            fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err)
+        else ValueError:
+            fe[~in_original] = np.interp(ntime[~in_original], lc.time.value, lc.flux_err.unmasked)
+            
         if method == "gaussian_noise":
             try:
                 std = lc.estimate_cdpp().to(lc.flux.unit).value

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1262,6 +1262,27 @@ def test_SSOs():
         pytest.fail("Unsupported cadence_mask should have thrown Error")
     except ValueError:
         pass
+    
+    lc.flux = Masked(lc.flux)
+    result = lc.query_solar_system_objects(cadence_mask="all", cache=False)
+    assert len(result) == 1
+    result = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
+    assert len(result) == 1
+    result = lc.query_solar_system_objects(cadence_mask=[True], cache=False)
+    assert len(result) == 1
+    result = lc.query_solar_system_objects(cadence_mask=(True), cache=False)
+    assert len(result) == 1
+    result, mask = lc.query_solar_system_objects(
+        cadence_mask=np.asarray([True]), cache=True, return_mask=True
+    )
+    assert len(mask) == len(lc.flux)
+    try:
+        result = lc.query_solar_system_objects(
+            cadence_mask="str-not-supported", cache=False
+        )
+        pytest.fail("Unsupported cadence_mask should have thrown Error")
+    except ValueError:
+        pass
 
 
 @pytest.mark.xfail  # LightCurveFile was removed in Lightkurve v2.x

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1064,17 +1064,19 @@ def test_fill_gaps():
     assert np.any(nlc.time.value == 5)
     assert np.all(nlc.flux == 1)
     assert np.all(np.isfinite(nlc.flux))
-    
+
+    # Regression test for https://github.com/lightkurve/lightkurve/pull/1172
     lc_mask = [False, False, True, False, False, False, False]
     lc = LightCurve(
-        time=[1, 2, 3, 4, 6, 7, 8], 
-        flux=Masked([1, 1, np.nan, 1, 1, 1, 1], mask=lc_mask), 
+        time=[1, 2, 3, 4, 6, 7, 8],
+        flux=Masked([1, 1, np.nan, 1, 1, 1, 1], mask=lc_mask),
         flux_err=Masked([0, 0, np.nan, 0, 0, 0, 0], mask=lc_mask)
     )
     nlc = lc.fill_gaps()
     assert len(lc.time) < len(nlc.time)
     assert np.any(nlc.time.value == 5)
     assert np.all(nlc.flux == 1)
+    assert np.all(nlc.flux_err == 0)
     assert np.all(np.isfinite(nlc.flux))
 
     # Because fill_gaps() uses pandas, check that it works regardless of endianness

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1064,6 +1064,18 @@ def test_fill_gaps():
     assert np.any(nlc.time.value == 5)
     assert np.all(nlc.flux == 1)
     assert np.all(np.isfinite(nlc.flux))
+    
+    lc_mask = [False, False, True, False, False, False, False]
+    lc = LightCurve(
+        time=[1, 2, 3, 4, 6, 7, 8], 
+        flux=Masked([1, 1, np.nan, 1, 1, 1, 1], mask=lc_mask), 
+        flux_err=Masked([0, 0, np.nan, 0, 0, 0, 0], mask=lc_mask)
+    )
+    nlc = lc.fill_gaps()
+    assert len(lc.time) < len(nlc.time)
+    assert np.any(nlc.time.value == 5)
+    assert np.all(nlc.flux == 1)
+    assert np.all(np.isfinite(nlc.flux))
 
     # Because fill_gaps() uses pandas, check that it works regardless of endianness
     # For details see https://github.com/lightkurve/lightkurve/issues/188

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1262,27 +1262,6 @@ def test_SSOs():
         pytest.fail("Unsupported cadence_mask should have thrown Error")
     except ValueError:
         pass
-    
-    lc.flux = Masked(lc.flux)
-    result = lc.query_solar_system_objects(cadence_mask="all", cache=False)
-    assert len(result) == 1
-    result = lc.query_solar_system_objects(cadence_mask=np.asarray([True]), cache=False)
-    assert len(result) == 1
-    result = lc.query_solar_system_objects(cadence_mask=[True], cache=False)
-    assert len(result) == 1
-    result = lc.query_solar_system_objects(cadence_mask=(True), cache=False)
-    assert len(result) == 1
-    result, mask = lc.query_solar_system_objects(
-        cadence_mask=np.asarray([True]), cache=True, return_mask=True
-    )
-    assert len(mask) == len(lc.flux)
-    try:
-        result = lc.query_solar_system_objects(
-            cadence_mask="str-not-supported", cache=False
-        )
-        pytest.fail("Unsupported cadence_mask should have thrown Error")
-    except ValueError:
-        pass
 
 
 @pytest.mark.xfail  # LightCurveFile was removed in Lightkurve v2.x


### PR DESCRIPTION
Unmasked values of `lc.flux_err` are required in `numpy.interp()`