### PR TITLE
TESS quality flags are in Table 28, not 26

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -217,7 +217,7 @@ class KeplerQualityFlags(QualityFlags):
 class TessQualityFlags(QualityFlags):
     """
     This class encodes the meaning of the various TESS QUALITY bitmask flags,
-    as documented in the TESS Data Products Description Document (Ref. [1], Table 26).
+    as documented in the TESS Data Products Description Document (Ref. [1], Table 28).
 
     References
     ----------


### PR DESCRIPTION
In the [document linked](https://archive.stsci.edu/missions/tess/doc/EXP-TESS-ARC-ICD-TM-0014.pdf) for the TESS quality flags, Table 26 is the *Spike cotrending basis vector FITS binary table header*, whereas Table 28 is *Data quality bits*. I presume the docs mean to point to the latter.