### PR TITLE
Fix `TypeError` triggered by `lc.plot_river()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 2.1.1 (unreleased)
 ==================
 
+- Fixed a bug in ``LightCurve.plot_river()`` which triggered a
+  `TypeError: cannot write to unmasked output`.
 
 
 2.1.0 (2022-02-10)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2616,7 +2616,10 @@ class LightCurve(QTimeSeries):
 
         # If the method is average we need to denormalize the plot
         if method in ["mean", "median"]:
-            ar *= np.nanmedian(self.flux.value)
+            median = np.nanmedian(self.flux.value)
+            if hasattr(median, 'mask'):
+                median = median.filled(np.nan)
+            ar *= median
 
         d = np.max(
             [

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1,7 +1,6 @@
-from __future__ import division, print_function
-
 from astropy.io import fits as pyfits
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.masked import Masked
 from astropy import units as u
 from astropy.table import Table, Column, MaskedColumn
 from astropy.time import Time, TimeDelta
@@ -1750,3 +1749,11 @@ def test_nbins():
     lc = LightCurve(flux=[0, 0, 0])
     # This statement raised an IndexError with Astropy v5.0rc2:
     lc.bin(bins=2)
+
+
+def test_river_plot_with_masked_flux():
+    """Regression test."""
+    flux = Masked(np.random.normal(loc=1, scale=0.1, size=100))
+    flux_err = Masked(0.1*np.ones(100))
+    lc = LightCurve(time=np.linspace(1, 100, 100), flux=flux, flux_err=flux_err)
+    lc.plot_river(period=10.)


### PR DESCRIPTION
This PR fixes a `TypeError: cannot write to unmasked output` which is encountered when using `LightCurve.plot_river()` with AstroPy v5.0 or later.

## Example of the issue
```python
import lightkurve as lk
from astropy.utils.masked import Masked
import numpy as np

flux = Masked(np.random.normal(loc=1, scale=0.1, size=100))
flux_err = Masked(0.1*np.ones(100))
lc = lk.LightCurve(time=np.linspace(1, 100, 100), flux=flux, flux_err=flux_err)
lc.plot_river(period=10.)
```

## Traceback
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/var/folders/x4/y38zs5fj4szf7xj3354kv74m0000gn/T/ipykernel_92311/643515831.py in <module>
      6 flux_err = Masked(0.1*np.ones(100))
      7 lc = lk.LightCurve(time=np.linspace(1, 100, 100), flux=flux, flux_err=flux_err)
----> 8 lc.plot_river(period=10.)

~/Library/Caches/pypoetry/virtualenvs/lightkurve-HqDeGDfc-py3.10/lib/python3.10/site-packages/astropy/utils/decorators.py in wrapper(*args, **kwargs)
    545                     warnings.warn(msg, warning_type, stacklevel=2)
    546 
--> 547             return function(*args, **kwargs)
    548 
    549         return wrapper

~/dev/lightkurve/src/lightkurve/lightcurve.py in plot_river(self, period, epoch_time, ax, bin_points, minimum_phase, maximum_phase, method, **kwargs)
   2617         # If the method is average we need to denormalize the plot
   2618         if method in ["mean", "median"]:
-> 2619             ar *= np.nanmedian(self.flux.value)
   2620 
   2621         d = np.max(

~/Library/Caches/pypoetry/virtualenvs/lightkurve-HqDeGDfc-py3.10/lib/python3.10/site-packages/astropy/utils/masked/core.py in __array_ufunc__(self, ufunc, method, *inputs, **kwargs)
    657                     # TODO: allow writing to unmasked output if nothing is masked?
    658                     if d is not None:
--> 659                         raise TypeError('cannot write to unmasked output')
    660                 elif out_mask is None:
    661                     out_mask = m

TypeError: cannot write to unmasked output
```