### PR TITLE
Fix TESSCut downloads with Astroquery v0.4.6

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -53,6 +53,7 @@ The following GitHub members directly contributed code and bugfixes:
 - `Warrick Ball <https://github.com/warrickball>`_
 - `Isaac Yong <https://github.com/isaac-yong0804>`_
 - `Gutsycat <https://github.com/Sniperq2>`_
+- `Jennifer V Medina <https://github.com/jaymedina>`_
 
 
 Community

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - Fixed a bug in ``LightCurve.plot_river()`` which triggered a
   `TypeError: cannot write to unmasked output`. [#1175]
 
+- Fixed a bug in `search_tesscut(...).download()` which caused TESSCut
+  downloads to fail when Astroquery v0.4.6 or later is installed.
+
 
 2.1.0 (2022-02-10)
 ==================

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -503,7 +503,7 @@ class SearchResult(object):
 
         # build path string name and check if it exists
         # this is necessary to ensure cutouts are not downloaded multiple times
-        sec = TesscutClass().get_sectors(coords)
+        sec = TesscutClass().get_sectors(coordinates=coords)
         sector_name = sec[sec["sector"] == sector]["sectorName"][0]
         if isinstance(cutout_size, int):
             size_str = str(int(cutout_size)) + "x" + str(int(cutout_size))
@@ -529,7 +529,7 @@ class SearchResult(object):
         # otherwise the file will be downloaded
         else:
             cutout_path = TesscutClass().download_cutouts(
-                coords, size=cutout_size, sector=sector, path=tesscut_dir
+                coordinates=coords, size=cutout_size, sector=sector, path=tesscut_dir
             )
             path = cutout_path[0][0]  # the cutoutpath already contains testcut_dir
             log.debug("Finished downloading.")


### PR DESCRIPTION
This PR fixes the issue that TESSCut downloads via Lightkurve no longer work when users upgrade to Astroquery v0.4.6 (released two days ago).  

The issue was first discovered and reported by @jaymedina over in https://github.com/lightkurve/lightkurve/issues/873#issuecomment-1077052232.  Thank you!

### Example

The following snippet:
```python
lk.search_tesscut("TIC 123835353", sector=6).download(cutout_size=5)
```
yields a
```
TypeError: get_sectors() takes 1 positional argument but 2 were given
```

### Solution

The issue is caused by the fact that `astroquery.mast` changed a few arguments into keyword-only arguments (cf. https://github.com/astropy/astroquery/pull/2317).  Lightkurve was using these arguments as positional arguments.

The fix is trivial.  I plan to release a new version of Lightkurve later today (v2.1.1) to make this bugfix easily available.