### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -739,7 +739,7 @@ def _query_solar_system_objects(
             if df is None:
                 df = res
             else:
-                df = df.append(res)
+                df = pd.concat([df, res])
     if df is not None:
         df.reset_index(drop=True)
     return df


### PR DESCRIPTION
This is a small PR to replace `DataFrame.append` (deprecated in [pandas v1.4.0](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append)) with `pandas.concat` in `_query_solar_system_objects`.

Without this fix, executing `lc.query_solar_system_objects` currently yields the following deprecation warning:
```python
/opt/homebrew/Caskroom/mambaforge/base/lib/python3.10/site-packages/lightkurve/utils.py:742: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  df = df.append(res)
```