### PR TITLE
tutorail tweak: note the shift-clicking limiation on Jupyter Lab.

### DIFF
--- a/docs/source/tutorials/1-getting-started/interactively-inspecting-data.ipynb
+++ b/docs/source/tutorials/1-getting-started/interactively-inspecting-data.ipynb
@@ -176,13 +176,14 @@
     "Interaction modes:\n",
     "\n",
     "- Clicking on a single pixel shows the time series light curve of that pixel alone.  \n",
-    "- `shift`-clicking on multiple pixels shows the light curve using that pixel mask.\n",
-    "- `shift`-clicking on an already selected pixel will *de*select that pixel.\n",
+    "- `shift`-clicking on multiple pixels shows the light curve using that pixel mask. (*)\n",
+    "- `shift`-`ctrl`-clicking on an already selected pixel will *de*select that pixel.\n",
     "- Clicking and dragging a box will make a rectangular aperture mask — individual pixels can be deselected from this mask by shift-clicking (box deselecting does not work).\n",
     "- The screen stretch high and low limits can be changed independently by clicking and dragging each end, or simultaneously by clicking and dragging in the middle.\n",
     "- The cadence slider updates the postage stamp image at the position of the vertical red bar in the light curve.\n",
     "- Clicking on a position in the light curve automatically seeks to that cadence number.\n",
-    "- The left and right arrows can be clicked to increment the cadence number by one."
+    "- The left and right arrows can be clicked to increment the cadence number by one.\n",
+    "- (*) `shift`-clicking does not work on Jupyter Lab as of this writing, due to conflicts between Bokeh and Jupyter Lab. Refer to the [tracking issue](https://github.com/bokeh/bokeh/issues/11324) for current status."
    ]
   },
   {


### PR DESCRIPTION
As a follow-up on #1177, I suggest we state the shift-clicking limitation on the tutorial, to limit possible confusion by newbies.

I also changed the "deselect pixel" from shift-clicking to shit-ctrl-clicking, as this is how it works on Windows. I am not sure how it works on Mac, and probably needs to be furhter reworded.