### PR TITLE
Fix flux unit of flatten light curve (fixes #630)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.2.1 (unreleased)
 ==================
-
+- Fixed a bug in ``LightCurve.flatten()`` which caused the flux unit of flatten 
+  light curve is not dimensionless. [#1195]
 
 
 

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -820,6 +820,9 @@ class LightCurve(TimeSeries):
             warnings.simplefilter("ignore", RuntimeWarning)
             flatten_lc.flux = flatten_lc.flux / trend_signal
             flatten_lc.flux_err = flatten_lc.flux_err / trend_signal
+            
+        flatten_lc.meta["NORMALIZED"] = True
+            
         if return_trend:
             trend_lc = self.copy()
             trend_lc.flux = trend_signal

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -818,8 +818,8 @@ class LightCurve(TimeSeries):
         with warnings.catch_warnings():
             # ignore invalid division warnings
             warnings.simplefilter("ignore", RuntimeWarning)
-            flatten_lc.flux = flatten_lc.flux / trend_signal.value
-            flatten_lc.flux_err = flatten_lc.flux_err / trend_signal.value
+            flatten_lc.flux = flatten_lc.flux / trend_signal
+            flatten_lc.flux_err = flatten_lc.flux_err / trend_signal
         if return_trend:
             trend_lc = self.copy()
             trend_lc.flux = trend_signal

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1021,8 +1021,8 @@ def test_flatten_returns_normalized():
     )
     flat_lc, trend_lc = lc.flatten(window_length=3, polyorder=1, return_trend=True)
 
-    assert flat_lc.flux.unit is lc_flux_unit
-    assert flat_lc.flux_err.unit is lc_flux_unit
+    assert flat_lc.flux.unit == u.dimensionless_unscaled
+    assert flat_lc.flux_err.unit == u.dimensionless_unscaled
     assert trend_lc.flux.unit is lc_flux_unit
     assert trend_lc.flux_err.unit is lc_flux_unit
 

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -721,6 +721,7 @@ def test_normalize():
     with pytest.warns(None) as warn_record:
         lc.normalize()
     assert len(warn_record) == 0
+    assert lc.meta["NORMALIZED"]
 
 
 def test_invalid_normalize():
@@ -1023,6 +1024,8 @@ def test_flatten_returns_normalized():
 
     assert flat_lc.flux.unit == u.dimensionless_unscaled
     assert flat_lc.flux_err.unit == u.dimensionless_unscaled
+    assert flat_lc.meta["NORMALIZED"]
+    
     assert trend_lc.flux.unit is lc_flux_unit
     assert trend_lc.flux_err.unit is lc_flux_unit
 


### PR DESCRIPTION
As mentioned in #630, the unit of flatten light curve now is the same as the unit of the original light curve, while its value is normalized, which is inconsistent.

Here's the code:
```python
>>> import lightkurve as lk
>>> lc=lk.search_lightcurve('tic145338612', sector=34, exptime='short', author='spoc').download()
>>> lc
<TessLightCurve length=17395 LABEL="TIC 145338612" SECTOR=34 AUTHOR=SPOC FLUX_ORIGIN=pdcsap_flux>
       time             flux         flux_err       timecorr    ... mom_centr2 mom_centr2_err   pos_corr1      pos_corr2   
                    electron / s   electron / s        d        ...    pix          pix            pix            pix      
       Time           float32        float32        float32     ...  float64      float32        float32        float32    
------------------ -------------- -------------- -------------- ... ---------- -------------- -------------- --------------
   2228.7539767216            ———            ———  3.0860188e-03 ...        ———            ———            ———            ———
               ...            ...            ...            ... ...        ...            ...            ...            ...
 2254.048709173111  4.7484344e+04  2.6264700e+01  3.3853455e-03 ...   70.78659  4.8690490e-04  9.7360751e-03 -4.1746624e-02
 2254.050098052997  4.7474441e+04  2.6251503e+01  3.3853371e-03 ...   70.78720  4.8948551e-04  4.1938936e-03 -3.9621610e-02
2254.0514869326485  4.7473988e+04  2.6286346e+01  3.3853285e-03 ...   70.80321  4.8717970e-04  1.5493861e-02 -2.0552954e-02
2254.0528758125347  4.7495449e+04  2.6272943e+01  3.3853201e-03 ...   70.78400  4.8670403e-04  9.0035060e-03 -4.4571925e-02
2254.0542646921876  4.7481043e+04  2.6281324e+01  3.3853115e-03 ...   70.79778  4.8626223e-04  8.3455592e-03 -2.6918381e-02
2254.0556535720725  4.7492668e+04  2.6272184e+01  3.3853031e-03 ...   70.79406  4.8753250e-04  7.4564391e-03 -3.1229390e-02
2254.0570424517246  4.7484684e+04  2.6274233e+01  3.3852945e-03 ...   70.78500  4.8616756e-04  4.2346399e-03 -4.2261351e-02
2254.0584313316103  4.7442594e+04  2.6278799e+01  3.3852861e-03 ...   70.80057  4.8686593e-04  1.1507314e-02 -2.1662412e-02
2254.0598202112624  4.7454328e+04  2.6252466e+01  3.3852775e-03 ...   70.79653  4.8809586e-04  1.2242141e-02 -2.8012672e-02
2254.0612090911472  4.7522602e+04  2.6259182e+01  3.3852691e-03 ...   70.77993  4.8755322e-04 -3.1467217e-03 -4.8348423e-02
2254.0625979707993  4.7492230e+04  2.6282434e+01  3.3852605e-03 ...   70.79858  4.8613027e-04  1.0448601e-02 -2.5628563e-02
2254.0639868506846  4.7468309e+04  2.6269951e+01  3.3852521e-03 ...   70.79374  4.8644797e-04  7.1001109e-03 -3.2658938e-02
 2254.065375730337  4.7477332e+04  2.6268181e+01  3.3852435e-03 ...   70.79311  4.8742461e-04  1.0640028e-02 -3.3475004e-02
 2254.066764609989  4.7467715e+04  2.6269821e+01  3.3852349e-03 ...   70.79930  4.8748197e-04  5.9197727e-03 -2.4316745e-02
2254.0681534898745  4.7431129e+04  2.6261600e+01  3.3852265e-03 ...   70.79498  4.8740776e-04  1.7397223e-02 -3.1554550e-02
>>> lc.flatten()
<TessLightCurve length=17395 LABEL="TIC 145338612" SECTOR=34 AUTHOR=SPOC FLUX_ORIGIN=pdcsap_flux>
       time             flux         flux_err       timecorr    ... mom_centr2 mom_centr2_err   pos_corr1      pos_corr2   
                    electron / s   electron / s        d        ...    pix          pix            pix            pix      
       Time           float64        float64        float32     ...  float64      float32        float32        float32    
------------------ -------------- -------------- -------------- ... ---------- -------------- -------------- --------------
   2228.7539767216            ———            ———  3.0860188e-03 ...        ———            ———            ———            ———
               ...            ...            ...            ... ...        ...            ...            ...            ...
 2254.048709173111  1.0001740e+00  5.5321961e-04  3.3853455e-03 ...   70.78659  4.8690490e-04  9.7360751e-03 -4.1746624e-02
 2254.050098052997  9.9996702e-01  5.5294252e-04  3.3853371e-03 ...   70.78720  4.8948551e-04  4.1938936e-03 -3.9621610e-02
2254.0514869326485  9.9995916e-01  5.5367737e-04  3.3853285e-03 ...   70.80321  4.8717970e-04  1.5493861e-02 -2.0552954e-02
2254.0528758125347  1.0004130e+00  5.5339605e-04  3.3853201e-03 ...   70.78400  4.8670403e-04  9.0035060e-03 -4.4571925e-02
2254.0542646921876  1.0001114e+00  5.5357361e-04  3.3853115e-03 ...   70.79778  4.8626223e-04  8.3455592e-03 -2.6918381e-02
2254.0556535720725  1.0003583e+00  5.5338219e-04  3.3853031e-03 ...   70.79406  4.8753250e-04  7.4564391e-03 -3.1229390e-02
2254.0570424517246  1.0001921e+00  5.5342648e-04  3.3852945e-03 ...   70.78500  4.8616756e-04  4.2346399e-03 -4.2261351e-02
2254.0584313316103  9.9930775e-01  5.5352386e-04  3.3852861e-03 ...   70.80057  4.8686593e-04  1.1507314e-02 -2.1662412e-02
2254.0598202112624  9.9955718e-01  5.5297045e-04  3.3852775e-03 ...   70.79653  4.8809586e-04  1.2242141e-02 -2.8012672e-02
2254.0612090911472  1.0009976e+00  5.5311321e-04  3.3852691e-03 ...   70.77993  4.8755322e-04 -3.1467217e-03 -4.8348423e-02
2254.0625979707993  1.0003604e+00  5.5360435e-04  3.3852605e-03 ...   70.79858  4.8613027e-04  1.0448601e-02 -2.5628563e-02
2254.0639868506846  9.9985902e-01  5.5334281e-04  3.3852521e-03 ...   70.79374  4.8644797e-04  7.1001109e-03 -3.2658938e-02
 2254.065375730337  1.0000517e+00  5.5330699e-04  3.3852435e-03 ...   70.79311  4.8742461e-04  1.0640028e-02 -3.3475004e-02
 2254.066764609989  9.9985190e-01  5.5334306e-04  3.3852349e-03 ...   70.79930  4.8748197e-04  5.9197727e-03 -2.4316745e-02
2254.0681534898745  9.9908410e-01  5.5317147e-04  3.3852265e-03 ...   70.79498  4.8740776e-04  1.7397223e-02 -3.1554550e-02
```

This PR sets the unit of flatten light curve to dimensionless.