### PR TITLE
Correction of typos in docs & changed contribution link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,3 @@
 Lightkurve's contribution guidelines may be found at
-https://docs.lightkurve.org/about
+https://docs.lightkurve.org/about/contributing.html
 

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -65,7 +65,7 @@ A key advantage of the development environment is that any changes you make to t
 code will be reflected right away, i.e., there is no need to re-install Lightkurve or the environment
 after every change.
 
-To run code in the development environment, you will need to prefix ever Python command with
+To run code in the development environment, you will need to prefix every Python command with
 `poetry run`. For example:
 
 .. code-block:: bash
@@ -142,7 +142,7 @@ of the source code as follows:
 .. code-block:: bash
 
     $ git checkout main
-    $ pull upstream main
+    $ git pull upstream main
 
 You are now ready to create your own branch with a name of your choice:
 
@@ -176,5 +176,5 @@ Finally, send the changes to the fork of Lightkurve that resides in your GitHub 
     $ git push origin name-of-your-branch
 
 Head to https://github.com/lightkurve/lightkurve after issuing the `git push`
-command above. You should automatically see a button that say "Compare and open a pull request".
+command above. You should automatically see a button that says "Compare and open a pull request".
 Click the button and submit your pull request!

--- a/docs/source/about/install.rst
+++ b/docs/source/about/install.rst
@@ -8,7 +8,7 @@ Using pip
 =========
 
 The easiest way to install *Lightkurve* and all of its dependencies is to use the ``pip`` command,
-which which is a standard part of all Python distributions.
+which is a standard part of all Python distributions.
 To install *Lightkurve*, run the following command in a terminal window::
 
     $ python -m pip install lightkurve --upgrade

--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -102,7 +102,7 @@ We run our unit tests using `pytest <https://docs.pytest.org/en/stable/>`_. This
 
 
 How to generate an HTML report?
-----------------------------
+-------------------------------
 
 Use `pytest-html <https://pytest-html.readthedocs.io/>`_ extension. Install it by::
 

--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -42,7 +42,7 @@ If the tests are successful, you should see a green success message such as
 Why are some of the tests marked "s"/ Why are some tests skipped?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Running some of our tests requires external data, e.g. some require data to be downloaded from MAST. These tests take a little longer, and so we skip them by default. In order to run all the tests simply use::
+Running some of our tests requires external data, e.g. some require data to be downloaded from MAST. These tests take a little longer, so we skip them by default. To run all the tests simply use::
 
     poetry run pytest test_targetpixelfile.py --remote-data
 
@@ -92,7 +92,7 @@ Before you open a PR to *Lightkurve*, ideally you should run these tests locally
 Can I write my own test?
 ------------------------
 
-Ideally, any PR opened to *Lightkurve* with new functionality should include some tests. These tests check that the basic functionality of your PR works. That way, if in future people create new features that break your PR, we will be alerted. Read through the `pytest` documentation and take a look at our existing tests to get an idea of how to write your own.
+Ideally, any PR opened to *Lightkurve* with new functionality should include some tests. These tests check that the basic functionality of your PR works. That way, if in the future, people create new features that break your PR, we will be alerted. Read through the `pytest` documentation and take a look at our existing tests to get an idea of how to write your own.
 
 
 I can't run any tests.
@@ -101,7 +101,7 @@ I can't run any tests.
 We run our unit tests using `pytest <https://docs.pytest.org/en/stable/>`_. This should have been installed when you installed *Lightkurve*. However, if your tests don't run, you may want to check all the test dependencies are installed. See our guide on on :ref:`Installing the development environment<install-dev-env>`.
 
 
-How to generate HTML report?
+How to generate an HTML report?
 ----------------------------
 
 Use `pytest-html <https://pytest-html.readthedocs.io/>`_ extension. Install it by::


### PR DESCRIPTION
There were some minor typos in the docs like "which which"
in the install.rst file.
Also changed the link in the contributing.rst file from
https://docs.lightkurve.org/about to
https://docs.lightkurve.org/about/contributing.html
so that people can access the contribution guidelines page directly.
this is my first time creating a pull request, hope this is helpful