### PR TITLE
fix lc['time', 'flux']  and LightCurve(data) where data is not a dict

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -199,6 +199,9 @@ class LightCurve(TimeSeries):
             names = kwargs.get("names")
             if names is None:
                 # the first item MUST be time if no names specified
+                # this is to support base Table's select columns
+                # in __getitem__()
+                # https://github.com/astropy/astropy/blob/326435449ad8d859f1abf36800c3fb88d49c27ea/astropy/table/table.py#L1888
                 data[0] = value
             else:
                 time_idx = get_time_idx_in(names)

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1387,6 +1387,7 @@ def test_combine_kepler_tess():
 INPUT_TIME = Time(['2016-03-22T12:30:31',
                    '2015-01-21T12:30:32',
                    '2016-03-22T12:30:40'])
+INPUT_RAW_TIME = [25800000.0, 25800000.1, 25800000.2]  # raw time in JD
 PLAIN_TABLE = Table([[1, 2, 11], [3, 4, 1], [1, 1, 1]], names=['flux', 'flux_err', 'c'])
 
 
@@ -1420,6 +1421,15 @@ def test_initialization_with_time_in_data():
     # used internally by `Table.__getitem__()``:
     # https://github.com/astropy/astropy/blob/326435449ad8d859f1abf36800c3fb88d49c27ea/astropy/table/table.py#L1888
     # It is not a public API code path, and is implicitly tested in `test_select_columns_as_lightcurve()`.
+
+
+def test_initialization_with_raw_time_in_data():
+    """Variant of `test_initialization_with_time_in_data() that is Lightcurve-specific.
+       Time can be raw values in default format
+    """
+    lc = LightCurve(data=[[10, 2, 3], [4, 5, 6], INPUT_RAW_TIME], names=['flux', 'flux_err', 'time'])
+    assert set(lc.colnames) == set(['time', 'flux', 'flux_err'])
+    assert_array_equal(lc.time, Time(INPUT_RAW_TIME, format=lc.time.format, scale=lc.time.scale))
 
 
 def test_mixed_instantiation():

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1087,7 +1087,7 @@ def test_flatten_returns_normalized():
     assert flat_lc.flux.unit == u.dimensionless_unscaled
     assert flat_lc.flux_err.unit == u.dimensionless_unscaled
     assert flat_lc.meta["NORMALIZED"]
-    
+
     assert trend_lc.flux.unit is lc_flux_unit
     assert trend_lc.flux_err.unit is lc_flux_unit
 
@@ -1732,6 +1732,21 @@ def test_support_non_numeric_columns():
     lc["col1"] = ["a", "b", "c"]
     lc_copy = lc.copy()
     assert_array_equal(lc_copy["col1"], lc["col1"])
+
+
+def test_select_columns_as_lightcurve():
+    """Select a subset of columns as a lightcurve object. #1194 """
+    lc = LightCurve(time=[1, 2, 3], flux=[2, 3, 4])
+    lc["col1"] = ["a", "b", "c"]
+    lc["col2"] = [7, 8, 9]
+
+    # subset of columns inclding "time" works
+    lc_subset = lc["time", "flux", "col2"]
+    # the subset should still be an instance of LightCurve (rather than just QTable)
+    assert(isinstance(lc_subset, type(lc)))
+
+    # TODO: similar test for other LightCurve variants (BinnedLightCurve, etc.)
+    # TODO: test LightCurve constructor for `data` with various types
 
 
 def test_timedelta():

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1432,6 +1432,29 @@ def test_initialization_with_raw_time_in_data():
     assert_array_equal(lc.time, Time(INPUT_RAW_TIME, format=lc.time.format, scale=lc.time.scale))
 
 
+# case multiple time columns: handled by the base TimeSeries
+
+
+def test_initialization_with_ndarray():
+    # test init with ndarray does not exist in astropy `test_sampled.py`, and is added
+    # for completeness sake
+    data = np.array([(1.0, 0.2, 0),
+                     (3.0, 0.4, 4),
+                     (5.0, 0.6, 2)],
+                    dtype=[('flux', 'f8'), ('flux_err', 'f8'), ('c', 'i4')])
+    lc = LightCurve(time=INPUT_TIME, data=data)
+    assert lc.colnames == ['time', 'flux', 'flux_err', 'c']
+
+
+def test_initialization_with_time_in_ndarray():
+    data = np.array([(1.0, 0.2, 0, INPUT_RAW_TIME[0]),
+                     (3.0, 0.4, 4, INPUT_RAW_TIME[1]),
+                     (5.0, 0.6, 2, INPUT_RAW_TIME[2])],
+                    dtype=[('flux', 'f8'), ('flux_err', 'f8'), ('c', 'i4'), ('time', 'f8')])
+    lc = LightCurve(data=data)
+    assert lc.colnames == ['time', 'flux', 'flux_err', 'c']
+
+
 def test_mixed_instantiation():
     """Can a LightCurve be instantianted using a mix of keywords and colums?"""
     LightCurve(flux=[4, 5, 6], flux_err=[7, 8, 9], data={"time": [1, 2, 3]})


### PR DESCRIPTION
Close #1194 , #1202

- The root cause is that `LightCurve.__init__()` `data` is only supported if it is a `dict` or `Table` like ([`Table` implementation](https://github.com/astropy/astropy/blob/326435449ad8d859f1abf36800c3fb88d49c27ea/astropy/table/table.py#L1888) requires `list` in this case).
- it needs to support case `data` is a `list`
- The PR is expanded to support `data` is a `ndarray` as well, to be on parity with the parent `TimeSeries` (and what [`LightCurve` API](https://docs.lightkurve.org/reference/api/lightkurve.LightCurve.html#lightkurve.LightCurve) specifies.


Tasks:

- [x] Fix the case that `lc['time', 'flux']` leading to error
- [x] generic support in `LightCurve.__init__()` for case `data` is a `list` (+ `names` parameter)
- [x] generic support `LightCurve.__init()__` for the `data` is `ndarray`
- [x] Ensure it works for binned lightcurves.
- [x] Ensure it works for folded lightcurves.

