### PR TITLE
Fix the pixel scale of TESS in query_solar_system_objects()

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1783,7 +1783,7 @@ class LightCurve(TimeSeries):
             if (location == "kepler") | (location == "k2"):
                 radius = (4 * 15) * u.arcsecond.to(u.deg)
             elif location == "tess":
-                radius = (27 * 15) * u.arcsecond.to(u.deg)
+                radius = (21 * 15) * u.arcsecond.to(u.deg)
             else:
                 radius = 15 * u.arcsecond.to(u.deg)
 


### PR DESCRIPTION
The pixel scale of TESS should be 21 arcsec/pixel, not 27 arcsec/pixel.