### PR TITLE
fix interact_sky() add nearby tic, case type checking fails.

### DIFF
--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -399,9 +399,9 @@ def _add_tics_with_no_matching_gaia_ids_to(result, tab, gaia_ids, magnitude_limi
 
     def _dummy_like(ary, dtype):
         dummy_val = None
-        if np.issubdtype(dtype, np.integer):
+        if pd.api.types.is_integer_dtype(dtype):
             dummy_val = _MISSING_INT_VAL
-        elif np.issubdtype(dtype, float):
+        elif pd.api.types.is_float_dtype(dtype):
             dummy_val = np.nan
         return [dummy_val for i in range(len(ary))]
 


### PR DESCRIPTION
A bug fix for `interact_sky()`, the not yet released PR# #1204 (include TICs not found in Gaia)

In some cases (e.g., TIC 135100529), some  dtype of the Gaia result pandas dataframe is weird, e.g., `df['Source'].dtype` is an instance of `pd.Int64Dtype`, rather than the type class itself.

This PR includes the fix and a unit test that covers such case.

Changelog: I don't think it's needed, as PR# #1204 is not yet released.
