### PR TITLE
make default download_dir configurable 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.4.0 (unreleased)
+==================
+
+- Added the ability to configure the default cache directory used by
+  ``SearchResult.download()`` / ``SearchResult.download_all()``. [#1214]
+- Moved the default cache directory from ``$HOME/.lightkurve-cache``
+  to ``$HOME/.lightkurve/cache``. [#1214]
+
+
 2.3.0 (2022-07-07)
 ==================
 

--- a/docs/source/about/testing.rst
+++ b/docs/source/about/testing.rst
@@ -46,6 +46,17 @@ Running some of our tests requires external data, e.g. some require data to be d
 
     poetry run pytest test_targetpixelfile.py --remote-data
 
+.. note::
+    To speed up the tests, you can instruct the tests use a specific directory for data file cache, so that when the tests are re-run,
+    data files in the local directory will be used, instead of being downloaded over the network.
+
+    Specify the data file cache directory via `XDG_CACHE_HOME` environment variable. For example,
+
+    .. code-block:: bash
+
+        $ XDG_CACHE_HOME=/my_dev/lk-test-cache poetry run pytest test_targetpixelfile.py --remote-data
+
+    The data files will be cached at `/my_dev/lk-test-cache/lightkurve` in the above example.
 
 
 My tests passed, but I got warning messages

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -24,3 +24,36 @@ Access configuration values
   conf
   config.get_cache_dir
   config.get_config_dir
+
+
+Default Cache Directory Migration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting from ``Lightkurve`` version ``2.3.0``, the default cache directory is
+at ``~/.lightkurve/cache`` . The data files cached at the legacy location,
+``~/.lightkurve-cache``, will not be used.
+
+A warning is issued if the legacy ``~/.lightkurve-cache`` directory still exists.
+
+Migration suggestions for handling various scenarios:
+
+* To use the existing data files cached, move all the contents under ``~/.lightkurve-cache``
+  to ``~/.lightkurve/cache``, and remove ``~/.lightkurve-cache`` directory itself.
+
+* If you need to use older version of ``Lightkurve``, e.g., because of the requirements
+  of other packages / applications, you can:
+
+  #. Keep the cache at the legacy location ``~/.lightkurve-cache``
+  #. Instruct current ``Lightkurve`` to use the legacy location. In the user's ``lightkurve.cfg``, add:
+
+      [config]
+
+      cache_dir = /<your-home-directory>/.lightkurve-cache
+
+  #. The warning will no long appear once a custom ```cache_dir``` is specified.
+
+* To suppress the warning for any reason, you can set ``warn_legacy_cache_dir`` in the user's ``lightkurve.cfg``.
+
+    [config]
+
+    warn_legacy_cache_dir = False

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -22,4 +22,5 @@ Access configuration values
   :toctree: api/
 
   conf
+  config.get_cache_dir
   config.get_config_dir

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -29,7 +29,7 @@ Access configuration values
 Default Cache Directory Migration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting from ``Lightkurve`` version ``2.3.0``, the default cache directory is
+Starting from ``Lightkurve`` version ``2.4.0``, the default cache directory is
 at ``~/.lightkurve/cache`` . The data files cached at the legacy location,
 ``~/.lightkurve-cache``, will not be used.
 

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -68,6 +68,8 @@ class Conf(_config.ConfigNamespace):
     cache_dir
         Default cache directory for data files downloaded, etc. Defaults to ``~/.lightkurve/cache`` if not specified.
 
+    warn_legacy_cache_dir
+        If set to True, issue warning if the legacy default cache directory exists. Default is True.
     """
     # Note: when using list or string_list datatype,
     # the behavior of astropy's parsing of the config file value:
@@ -89,6 +91,12 @@ class Conf(_config.ConfigNamespace):
         module="lightkurve.config"
     )
 
+    warn_legacy_cache_dir = _config.ConfigItem(
+        True,
+        "If set to True, issue warning if the legacy default cache directory exists.",
+        cfgtype="boolean",
+        module="lightkurve.config"
+    )
 
 conf = Conf()
 
@@ -105,3 +113,6 @@ from .convenience import *
 from .collections import *
 from .io import *
 from .search import *
+
+from . import config
+config.warn_if_default_cache_dir_migration_needed()

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -71,6 +71,13 @@ class Conf(_config.ConfigNamespace):
         module="lightkurve.search"
     )
 
+    search_result_download_dir = _config.ConfigItem(
+        None,
+        "Default download directory for data files",
+        cfgtype="string",
+        module="lightkurve.search"
+    )
+
 
 conf = Conf()
 

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -86,7 +86,7 @@ class Conf(_config.ConfigNamespace):
         None,
         "Default cache directory for data files downloaded, etc.",
         cfgtype="string",
-        module="lightkurve"
+        module="lightkurve.config"
     )
 
 

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -65,8 +65,8 @@ class Conf(_config.ConfigNamespace):
     search_result_display_extra_columns
         List of extra columns to be included when displaying a SearchResult object.
 
-    search_result_download_dir
-        Default download directory for data files. Defaults to ``~/.lightkurve/cache`` if not specified.
+    cache_dir
+        Default cache directory for data files downloaded, etc. Defaults to ``~/.lightkurve/cache`` if not specified.
 
     """
     # Note: when using list or string_list datatype,
@@ -82,11 +82,11 @@ class Conf(_config.ConfigNamespace):
         module="lightkurve.search"
     )
 
-    search_result_download_dir = _config.ConfigItem(
+    cache_dir = _config.ConfigItem(
         None,
-        "Default download directory for data files",
+        "Default cache directory for data files downloaded, etc.",
         cfgtype="string",
-        module="lightkurve.search"
+        module="lightkurve"
     )
 
 

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -113,6 +113,3 @@ from .convenience import *
 from .collections import *
 from .io import *
 from .search import *
-
-from . import config
-config.warn_if_default_cache_dir_migration_needed()

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -57,6 +57,17 @@ class Conf(_config.ConfigNamespace):
 
     Refer to `Astropy documentation <https://docs.astropy.org/en/stable/config/index.html#accessing-values>`_
     for usage.
+
+    The attributes listed below are the available configuration parameters.
+
+    Attributes
+    ----------
+    search_result_display_extra_columns
+        List of extra columns to be included when displaying a SearchResult object.
+
+    search_result_download_dir
+        Default download directory for data files. Defaults to ``~/.lightkurve/cache`` if not specified.
+
     """
     # Note: when using list or string_list datatype,
     # the behavior of astropy's parsing of the config file value:

--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -113,3 +113,6 @@ from .convenience import *
 from .collections import *
 from .io import *
 from .search import *
+
+from . import config
+config.warn_if_default_cache_dir_migration_needed()

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -41,7 +41,7 @@ def get_cache_dir():
     ``$XDG_CACHE_HOME/lightkurve`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
-    Note: If users customize the default via ``search_result_download_dir``
+    Note: If users customize the default via ``cache_dir``
     configuration, the value returned by this function is ignored: the
     user-specified directory will be used instead.
 

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -76,7 +76,6 @@ def get_cache_dir():
     cache_dir = _ensure_cache_dir_exists(cache_dir)
     cache_dir = os.path.abspath(cache_dir)
 
-    warn_if_default_cache_dir_migration_needed()
     return cache_dir
 
 
@@ -108,7 +107,7 @@ def warn_if_default_cache_dir_migration_needed():
     if not(cache_dir is None or cache_dir == ""):
         # If an user has specified a custom cache dir, the check won't be performed.
         # Not only is the check somewhat irrelevant, the behavior is also required
-        # to support the case that the user configures the legacy `~/.lightkure-cache`
+        # to support the case that the user configures the legacy `~/.lightkurve-cache`
         # as the cache dir (e.g., to support running other apps/packages that require
         # older lightkurve, especially lightkurve v1.x.)
         return
@@ -118,7 +117,7 @@ def warn_if_default_cache_dir_migration_needed():
     new_cache_dir = os.path.join(os.path.expanduser("~"), ".lightkurve", "cache")
     if os.path.isdir(old_cache_dir):
         warnings.warn(
-            f"The default Lightkurve cache directory has been moved to {new_cache_dir}. "
+            f"The default Lightkurve cache directory, used by download(), etc., has been moved to {new_cache_dir}. "
             f"Please move all the files in the legacy directory {old_cache_dir} to the new location "
             f"and remove the legacy directory. "
             f"Refer to https://docs.lightkurve.org/reference/config.html#default-cache-directory-migration "

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -1,3 +1,6 @@
+import os
+import warnings
+
 import astropy.config as astropyconfig
 
 
@@ -34,20 +37,60 @@ def get_config_dir():
 def get_cache_dir():
     """
     Determines the default Lightkurve cache directory name and creates the
-    directory if it doesn't exist.
+    directory if it doesn't exist. If the directory cannot be access or created,
+    then it returns the current directory (``"."``).
 
     This directory is typically ``$HOME/.lightkurve/cache``, but if the
     XDG_CACHE_HOME environment variable is set and the
     ``$XDG_CACHE_HOME/lightkurve`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
-    Note: If users customize the default via ``cache_dir``
-    configuration, the value returned by this function is ignored: the
-    user-specified directory will be used instead.
+    The value can be also configured via ``cache_dir`` configuration parameter.
 
     Returns
     -------
     cachedir : str
         The absolute path to the cache directory.
+
+    Examples
+    --------
+    To configure "/my_research/data" as the `cache_dir`, users can set it:
+
+    1. in the user's ``lightkurve.cfg`` file::
+
+        [config]
+        cache_dir = /my_research/data
+
+    2. at run time::
+
+        import lightkurve as lk
+        lk.conf.cache_dir = '/my_research/data'
+
+    See :ref:`configuration <api.config>` for more information.
     """
-    return astropyconfig.get_cache_dir(ROOTNAME)
+    from .. import conf
+
+    cache_dir = conf.cache_dir
+    if cache_dir is None or cache_dir == "":
+        cache_dir = astropyconfig.get_cache_dir(ROOTNAME)
+    cache_dir = _ensure_cache_dir_exists(cache_dir)
+    cache_dir = os.path.abspath(cache_dir)
+    return cache_dir
+
+
+def _ensure_cache_dir_exists(cache_dir):
+    if os.path.isdir(cache_dir):
+        return cache_dir
+    else:
+        # if it doesn't exist, make a new cache directory
+        try:
+            os.mkdir(cache_dir)
+        # user current dir if OS error occurs
+        except OSError:
+            warnings.warn(
+                "Warning: unable to create {} as cache dir "
+                " (for downloading MAST files, etc.). Use the current "
+                "working directory instead.".format(cache_dir)
+            )
+            cache_dir = "."
+        return cache_dir

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -30,3 +30,24 @@ def get_config_dir():
     """
     return astropyconfig.get_config_dir(ROOTNAME)
 
+
+def get_cache_dir():
+    """
+    Determines the default Lightkurve cache directory name and creates the
+    directory if it doesn't exist.
+
+    This directory is typically ``$HOME/.lightkurve/cache``, but if the
+    XDG_CACHE_HOME environment variable is set and the
+    ``$XDG_CACHE_HOME/lightkurve`` directory exists, it will be that directory.
+    If neither exists, the former will be created and symlinked to the latter.
+
+    Note: If users customize the default via ``search_result_download_dir``
+    configuration, the value returned by this function is ignored: the
+    user-specified directory will be used instead.
+
+    Returns
+    -------
+    cachedir : str
+        The absolute path to the cache directory.
+    """
+    return astropyconfig.get_cache_dir(ROOTNAME)

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -94,3 +94,26 @@ def _ensure_cache_dir_exists(cache_dir):
             )
             cache_dir = "."
         return cache_dir
+
+
+def warn_if_default_cache_dir_migration_needed():
+    from .. import conf
+
+    if not conf.warn_legacy_cache_dir:
+        return
+
+    cache_dir = conf.cache_dir
+    if not(cache_dir is None or cache_dir == ""):
+        return
+
+    # migration check done only if default is used
+    old_cache_dir = os.path.join(os.path.expanduser("~"), ".lightkurve-cache")
+    new_cache_dir = os.path.join(os.path.expanduser("~"), ".lightkurve", "cache")
+    if os.path.isdir(old_cache_dir):
+        warnings.warn(
+            f"The default Lightkurve cache directory has been moved to {new_cache_dir}. "
+            f"Please move all the files in the legacy directory {old_cache_dir} to the new location "
+            f"and remove the legacy directory. "
+            f"Refer to https://docs.lightkurve.org/reference/config.html#default-cache-directory-migration "
+            f"for more information."
+        )

--- a/src/lightkurve/config/__init__.py
+++ b/src/lightkurve/config/__init__.py
@@ -75,6 +75,8 @@ def get_cache_dir():
         cache_dir = astropyconfig.get_cache_dir(ROOTNAME)
     cache_dir = _ensure_cache_dir_exists(cache_dir)
     cache_dir = os.path.abspath(cache_dir)
+
+    warn_if_default_cache_dir_migration_needed()
     return cache_dir
 
 
@@ -104,6 +106,11 @@ def warn_if_default_cache_dir_migration_needed():
 
     cache_dir = conf.cache_dir
     if not(cache_dir is None or cache_dir == ""):
+        # If an user has specified a custom cache dir, the check won't be performed.
+        # Not only is the check somewhat irrelevant, the behavior is also required
+        # to support the case that the user configures the legacy `~/.lightkure-cache`
+        # as the cache dir (e.g., to support running other apps/packages that require
+        # older lightkurve, especially lightkurve v1.x.)
         return
 
     # migration check done only if default is used

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -406,6 +406,7 @@ class SearchResult(object):
 
         1. in the user's ``lightkurve.cfg`` file::
 
+            [config]
             cache_dir = /my_research/data
 
         2. at run time::
@@ -495,6 +496,7 @@ class SearchResult(object):
 
         1. in the user's ``lightkurve.cfg`` file::
 
+            [config]
             cache_dir = /my_research/data
 
         2. at run time::

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -21,6 +21,7 @@ from .collections import TargetPixelFileCollection, LightCurveCollection
 from .utils import LightkurveError, suppress_stdout, LightkurveWarning, LightkurveDeprecationWarning
 from .io import read
 from . import conf
+from . import config
 from . import PACKAGEDIR
 
 log = logging.getLogger(__name__)
@@ -508,7 +509,7 @@ class SearchResult(object):
         """
         download_dir = conf.search_result_download_dir
         if download_dir is None or download_dir == "":
-            download_dir = os.path.join(os.path.expanduser("~"), ".lightkurve", "cache")
+            download_dir = config.get_cache_dir()
         if os.path.isdir(download_dir):
             return download_dir
         else:

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -379,6 +379,8 @@ class SearchResult(object):
             Location where the data files will be stored.
             If `None` is passed, the value from `cache_dir` configuration parameter is used,
             with "~/.lightkurve/cache" as the default.
+
+            See `~lightkurve.config.get_cache_dir()` for details.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
@@ -400,21 +402,6 @@ class SearchResult(object):
         SearchError
             If any other error occurs.
 
-        Examples
-        --------
-        To configure "/my_research/data" as the default `download_dir`, users can set it:
-
-        1. in the user's ``lightkurve.cfg`` file::
-
-            [config]
-            cache_dir = /my_research/data
-
-        2. at run time::
-
-            import lightkurve as lk
-            lk.conf.cache_dir = '/my_research/data'
-
-        See :ref:`configuration <api.config>` for more information.
         """
         if len(self.table) == 0:
             warnings.warn(
@@ -467,6 +454,8 @@ class SearchResult(object):
             Location where the data files will be stored.
             If `None` is passed, the value from `cache_dir` configuration parameter is used,
             with "~/.lightkurve/cache" as the default.
+
+            See `~lightkurve.config.get_cache_dir()` for details.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
@@ -489,22 +478,6 @@ class SearchResult(object):
             If the TESSCut service times out (i.e. returns HTTP status 504).
         SearchError
             If any other error occurs.
-
-        Examples
-        --------
-        To configure "/my_research/data" as the default `download_dir`, users can set it:
-
-        1. in the user's ``lightkurve.cfg`` file::
-
-            [config]
-            cache_dir = /my_research/data
-
-        2. at run time::
-
-            import lightkurve as lk
-            lk.conf.cache_dir = '/my_research/data'
-
-        See :ref:`configuration <api.config>` for more information.
         """
         if len(self.table) == 0:
             warnings.warn(
@@ -530,36 +503,7 @@ class SearchResult(object):
             return LightCurveCollection(products)
 
     def _default_download_dir(self):
-        """Returns the default path to the directory where files will be downloaded.
-
-        By default, this method will return "~/.lightkurve-cache" and create
-        this directory if it does not exist.  If the directory cannot be
-        access or created, then it returns the local directory (".").
-
-        Returns
-        -------
-        download_dir : str
-            Path to location of `mastDownload` folder where data downloaded from MAST are stored
-        """
-        download_dir = conf.cache_dir
-        if download_dir is None or download_dir == "":
-            download_dir = config.get_cache_dir()
-        if os.path.isdir(download_dir):
-            return download_dir
-        else:
-            # if it doesn't exist, make a new cache directory
-            try:
-                os.mkdir(download_dir)
-            # downloads locally if OS error occurs
-            except OSError:
-                log.warning(
-                    "Warning: unable to create {}. "
-                    "Downloading MAST files to the current "
-                    "working directory instead.".format(download_dir)
-                )
-                download_dir = "."
-
-        return download_dir
+        return config.get_cache_dir()
 
     def _fetch_tesscut_path(self, target, sector, download_dir, cutout_size):
         """Downloads TESS FFI cutout and returns path to local file.

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -377,7 +377,7 @@ class SearchResult(object):
             See the :class:`KeplerQualityFlags <lightkurve.utils.KeplerQualityFlags>` or :class:`TessQualityFlags <lightkurve.utils.TessQualityFlags>` class for details on the bitmasks.
         download_dir : str, optional
             Location where the data files will be stored.
-            If `None` is passed, the value from `search_result_download_dir` configuration parameter is used,
+            If `None` is passed, the value from `cache_dir` configuration parameter is used,
             with "~/.lightkurve/cache" as the default.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
@@ -406,13 +406,12 @@ class SearchResult(object):
 
         1. in the user's ``lightkurve.cfg`` file::
 
-            [search]
-            search_result_download_dir = /my_research/data
+            cache_dir = /my_research/data
 
         2. at run time::
 
             import lightkurve as lk
-            lk.conf.search_result_download_dir = '/my_research/data'
+            lk.conf.cache_dir = '/my_research/data'
 
         See :ref:`configuration <api.config>` for more information.
         """
@@ -465,7 +464,7 @@ class SearchResult(object):
             See the :class:`KeplerQualityFlags <lightkurve.utils.KeplerQualityFlags>` or :class:`TessQualityFlags <lightkurve.utils.TessQualityFlags>` class for details on the bitmasks.
         download_dir : str, optional
             Location where the data files will be stored.
-            If `None` is passed, the value from `search_result_download_dir` configuration parameter is used,
+            If `None` is passed, the value from `cache_dir` configuration parameter is used,
             with "~/.lightkurve/cache" as the default.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
@@ -496,13 +495,12 @@ class SearchResult(object):
 
         1. in the user's ``lightkurve.cfg`` file::
 
-            [search]
-            search_result_download_dir = /my_research/data
+            cache_dir = /my_research/data
 
         2. at run time::
 
             import lightkurve as lk
-            lk.conf.search_result_download_dir = '/my_research/data'
+            lk.conf.cache_dir = '/my_research/data'
 
         See :ref:`configuration <api.config>` for more information.
         """
@@ -541,7 +539,7 @@ class SearchResult(object):
         download_dir : str
             Path to location of `mastDownload` folder where data downloaded from MAST are stored
         """
-        download_dir = conf.search_result_download_dir
+        download_dir = conf.cache_dir
         if download_dir is None or download_dir == "":
             download_dir = config.get_cache_dir()
         if os.path.isdir(download_dir):

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -377,7 +377,8 @@ class SearchResult(object):
             See the :class:`KeplerQualityFlags <lightkurve.utils.KeplerQualityFlags>` or :class:`TessQualityFlags <lightkurve.utils.TessQualityFlags>` class for details on the bitmasks.
         download_dir : str, optional
             Location where the data files will be stored.
-            Defaults to "~/.lightkurve-cache" if `None` is passed.
+            If `None` is passed, the value from `search_result_download_dir` configuration parameter is used,
+            with "~/.lightkurve/cache" as the default.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
@@ -398,6 +399,22 @@ class SearchResult(object):
             If the TESSCut service times out (i.e. returns HTTP status 504).
         SearchError
             If any other error occurs.
+
+        Examples
+        --------
+        To configure "/my_research/data" as the default `download_dir`, users can set it:
+
+        1. in the user's ``lightkurve.cfg`` file::
+
+            [search]
+            search_result_download_dir = /my_research/data
+
+        2. at run time::
+
+            import lightkurve as lk
+            lk.conf.search_result_download_dir = '/my_research/data'
+
+        See :ref:`configuration <api.config>` for more information.
         """
         if len(self.table) == 0:
             warnings.warn(
@@ -448,7 +465,8 @@ class SearchResult(object):
             See the :class:`KeplerQualityFlags <lightkurve.utils.KeplerQualityFlags>` or :class:`TessQualityFlags <lightkurve.utils.TessQualityFlags>` class for details on the bitmasks.
         download_dir : str, optional
             Location where the data files will be stored.
-            Defaults to "~/.lightkurve-cache" if `None` is passed.
+            If `None` is passed, the value from `search_result_download_dir` configuration parameter is used,
+            with "~/.lightkurve/cache" as the default.
         cutout_size : int, float or tuple, optional
             Side length of cutout in pixels. Tuples should have dimensions (y, x).
             Default size is (5, 5)
@@ -471,6 +489,22 @@ class SearchResult(object):
             If the TESSCut service times out (i.e. returns HTTP status 504).
         SearchError
             If any other error occurs.
+
+        Examples
+        --------
+        To configure "/my_research/data" as the default `download_dir`, users can set it:
+
+        1. in the user's ``lightkurve.cfg`` file::
+
+            [search]
+            search_result_download_dir = /my_research/data
+
+        2. at run time::
+
+            import lightkurve as lk
+            lk.conf.search_result_download_dir = '/my_research/data'
+
+        See :ref:`configuration <api.config>` for more information.
         """
         if len(self.table) == 0:
             warnings.warn(

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -506,7 +506,9 @@ class SearchResult(object):
         download_dir : str
             Path to location of `mastDownload` folder where data downloaded from MAST are stored
         """
-        download_dir = os.path.join(os.path.expanduser("~"), ".lightkurve-cache")
+        download_dir = conf.search_result_download_dir
+        if download_dir is None or download_dir == "":
+            download_dir = os.path.join(os.path.expanduser("~"), ".lightkurve", "cache")
         if os.path.isdir(download_dir):
             return download_dir
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,20 @@ def pytest_collection_modifyitems(config, items):
         if 'memtest' in item.keywords:
             item.add_marker(skip_memtest)
 
-# Make sure we use temporary directories for the config
+# Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 
 os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('lightkurve_config')
 os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'lightkurve'))
+
+# Let users optionally specify XDG_CACHE_HOME for a test run
+# use case: in a local dev env, an user might want to reuse an existing dir for cache,
+# so as to speed up remote-data tests
+if os.environ.get('XDG_CACHE_HOME', '') == '':
+    os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('lightkurve_cache')
+else:
+    print(f"lightkurve conftest: Use user-specified XDG_CACHE_HOME: {os.environ['XDG_CACHE_HOME']}")
+
+_cache_dir = os.path.join(os.environ['XDG_CACHE_HOME'], 'lightkurve')
+if not os.path.isdir(_cache_dir):
+    os.mkdir(_cache_dir)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,9 +1,12 @@
 from astropy.utils.data import get_pkg_data_filename
 
+import os
 from pathlib import Path
 import shutil
+import tempfile
 
 import lightkurve as lk
+
 
 def test_read_conf_from_file():
     """Sanity test to ensure lightkurve per-user config is in the expected location."""
@@ -15,7 +18,7 @@ def test_read_conf_from_file():
         use_custom_config_file("data/lightkurve_sr_cols_added.cfg")
         assert ['proposal_id'] == lk.conf.search_result_display_extra_columns
     finally:
-        # cleanup: remvoe the custom config file and its effect
+        # cleanup: remove the custom config file and its effect
         remove_custom_config()
 
 
@@ -31,3 +34,29 @@ def remove_custom_config():
     cfg_dest_path = Path(lk.config.get_config_dir(), 'lightkurve.cfg')
     cfg_dest_path.unlink()
     lk.conf.reload()
+
+
+def test_get_cache_dir():
+    # Sanity test default download dir
+    # We can't meaningful assert the location for typical cases.
+    # Because in test environment, it is overriden by XDG_CACHE_HOME env var
+    # (typically to some temp location)
+    actual_dir = lk.config.get_cache_dir()
+    assert os.path.isdir(actual_dir)
+
+    # Test customized default download dir
+    with tempfile.TemporaryDirectory() as expected_base:
+        try:
+            # I want to test that the impl would create a dir if not there
+            expected_dir = os.path.join(expected_base, "some_subdir")
+            lk.conf.cache_dir = expected_dir
+            actual_dir = lk.config.get_cache_dir()
+            assert expected_dir == actual_dir
+            assert os.path.isdir(actual_dir)
+
+            # repeated calls would work
+            # (e.g., it won't raise errors in attempting to mkdir for an existing dir)
+            actual_dir = lk.config.get_cache_dir()
+            assert expected_dir == actual_dir
+        finally:
+            lk.conf.cache_dir = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -628,7 +628,7 @@ def test_customize_default_download_dir():
         try:
             # I want to test that the impl would create a dir if not there
             expected_dir = os.path.join(expected_base, "some_subdir")
-            lk.conf.search_result_download_dir = expected_dir
+            lk.conf.cache_dir = expected_dir
             actual_dir = search._default_download_dir()
             assert expected_dir == actual_dir
             assert os.path.isdir(actual_dir)
@@ -638,4 +638,4 @@ def test_customize_default_download_dir():
             actual_dir = search._default_download_dir()
             assert expected_dir == actual_dir
         finally:
-            lk.conf.search_result_download_dir = None
+            lk.conf.cache_dir = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -613,3 +613,29 @@ def test_customize_search_result_display_case_nonexistent_column():
     search = search_lightcurve("TIC390021728")
     search.display_extra_columns = ['foo_col']
     assert 'foo_col' not in search.__repr__()
+
+
+def test_customize_default_download_dir():
+    search = SearchResult()
+
+    # Test default download dir
+    actual_dir = search._default_download_dir()
+    assert os.path.join(os.path.expanduser("~"), ".lightkurve", "cache") == actual_dir
+    assert os.path.isdir(actual_dir)
+
+    # Test customized default download dir
+    with tempfile.TemporaryDirectory() as expected_base:
+        try:
+            # I want to test that the impl would create a dir if not there
+            expected_dir = os.path.join(expected_base, "some_subdir")
+            lk.conf.search_result_download_dir = expected_dir
+            actual_dir = search._default_download_dir()
+            assert expected_dir == actual_dir
+            assert os.path.isdir(actual_dir)
+
+            # repeated calls would work
+            # (e.g., it won't raise errors in attempting to mkdir for an existing dir)
+            actual_dir = search._default_download_dir()
+            assert expected_dir == actual_dir
+        finally:
+            lk.conf.search_result_download_dir = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -613,29 +613,3 @@ def test_customize_search_result_display_case_nonexistent_column():
     search = search_lightcurve("TIC390021728")
     search.display_extra_columns = ['foo_col']
     assert 'foo_col' not in search.__repr__()
-
-
-def test_customize_default_download_dir():
-    search = SearchResult()
-
-    # Test default download dir
-    actual_dir = search._default_download_dir()
-    assert lk.config.get_cache_dir() == actual_dir
-    assert os.path.isdir(actual_dir)
-
-    # Test customized default download dir
-    with tempfile.TemporaryDirectory() as expected_base:
-        try:
-            # I want to test that the impl would create a dir if not there
-            expected_dir = os.path.join(expected_base, "some_subdir")
-            lk.conf.cache_dir = expected_dir
-            actual_dir = search._default_download_dir()
-            assert expected_dir == actual_dir
-            assert os.path.isdir(actual_dir)
-
-            # repeated calls would work
-            # (e.g., it won't raise errors in attempting to mkdir for an existing dir)
-            actual_dir = search._default_download_dir()
-            assert expected_dir == actual_dir
-        finally:
-            lk.conf.cache_dir = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -620,7 +620,7 @@ def test_customize_default_download_dir():
 
     # Test default download dir
     actual_dir = search._default_download_dir()
-    assert os.path.join(os.path.expanduser("~"), ".lightkurve", "cache") == actual_dir
+    assert lk.config.get_cache_dir() == actual_dir
     assert os.path.isdir(actual_dir)
 
     # Test customized default download dir


### PR DESCRIPTION
Close #1212

Tasks:
- [x] make default `download_dir` configurable: a new config item `search_result_download_dir`
- [x] move the default `download_dir` from `~/.lightkurve-cache` to `~/.lightkurve/cache`
- [x] Support users in migration from `~/.lightkurve-cache` to `~/.lightkurve/cache`: issue an warning, and/or provide helper function for migration
- [x] Support override the default `download_dir` with `XDG_CACHE_HOME` environment variable, analogous to [Astropy config](https://docs.astropy.org/en/stable/config/index.html)
- [x] Update documentation:
  - [`download()`](https://docs.lightkurve.org/reference/api/lightkurve.SearchResult.download.html#lightkurve.SearchResult.download) and [`download_all()`](https://docs.lightkurve.org/reference/api/lightkurve.SearchResult.download_all.html#lightkurve.SearchResult.download_all) functions.
  - dev doc: use of `XDG_CACHE_HOME` to speed up remote-data test in local dev environment

Maybe:
- Let users specify `download_dir` for `CBVCorrector` (used when CBV corrector searches and downloads neighbor lightcurves).
