### PR TITLE
Support Eleanor / HLSP GSFC-ELEANOR-LITE lightcurve products

### DIFF
--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -2,7 +2,7 @@
 from .detect import *
 from .read import *
 
-from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, kepseismic
+from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, eleanor, kepseismic
 from . import cdips
 from .. import LightCurve
 
@@ -23,6 +23,7 @@ try:
     registry.register_reader("pathos", LightCurve, pathos.read_pathos_lightcurve)
     registry.register_reader('cdips', LightCurve, cdips.read_cdips_lightcurve)
     registry.register_reader("tasoc", LightCurve, tasoc.read_tasoc_lightcurve)
+    registry.register_reader("eleanor", LightCurve, eleanor.read_eleanor_lightcurve)
     registry.register_reader("kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -27,6 +27,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'TASOC'`
         * `'KEPSEISMIC'`
         * `'CDIPS'`
+        * `'ELEANOR'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -73,6 +74,13 @@ def detect_filetype(hdulist: HDUList) -> str:
     # cf. http://archive.stsci.edu/hlsp/cdips
     if "cdips" in hdulist[0].header.get("ORIGIN","").lower():
         return "CDIPS"
+
+    # Is it a ELEANOR / GSFC-ELEANOR-LITE light curve?
+    # cf. https://github.com/afeinstein20/eleanor , used by
+    # https://archive.stsci.edu/hlsp/gsfc-eleanor-lite
+    # OPEN: One can't really distinguish GSFC-ELEANOR-LITE from fits from regular eleanor
+    if hdulist[0].header.get("GITHUB") == "https://github.com/afeinstein20/eleanor":
+        return "ELEANOR"
 
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.

--- a/src/lightkurve/io/eleanor.py
+++ b/src/lightkurve/io/eleanor.py
@@ -1,0 +1,83 @@
+"""Reader for ELEANOR light curve files.
+
+Website: https://github.com/afeinstein20/eleanor
+
+It is used by HLSP GSFC-ELEANOR-LITE.
+
+Website: https://archive.stsci.edu/hlsp/gsfc-eleanor-lite
+"""
+from astropy import units as u
+from matplotlib.pyplot import tick_params
+import numpy as np
+
+from ..lightcurve import TessLightCurve
+from ..utils import TessQualityFlags
+
+from .generic import read_generic_lightcurve
+
+
+def read_eleanor_lightcurve(filename, flux_column="corr_flux", quality_bitmask=None):
+    """Returns a `TessLightCurve` object given a light curve file from the ELEANOR.
+
+    By default, ELEANOR's `corr_flux` column is used to populate the `flux` values,
+    with no flux error (corr_flux does not come with error).
+
+    Parameters
+    ----------
+    filename : str
+        Local path or remote url of a Eleanor light curve FITS file.
+    flux_column : 'raw_flux', 'corr_flux', 'pca_flux', "psf_flux', or 'flux_bkg'
+        Which column in the FITS file contains the preferred flux data?
+        By default the corrected flux (corr_flux) is used.
+    quality_bitmask:
+        ignored. It is retained to be compatible with generic read interface.
+    """
+
+    # See eleanor's TargetData.save() for how the files are created
+    # https://adina.feinste.in/eleanor/api.html#eleanor.TargetData.save
+    # A recent version:
+    # https://github.com/afeinstein20/eleanor/blob/cf19a998a99d0cea09c8426f8db2248fdc55f12c/eleanor/targetdata.py#L1366
+
+    lc = read_generic_lightcurve(filename, flux_column=flux_column, flux_err_column=None, time_format="btjd")
+
+    # Eleanor FITS file do not have units specified. re-add them.
+    for colname in ["flux", "flux_err", "raw_flux", "corr_flux", "pca_flux", "psf_flux"]:
+        if colname in lc.colnames:
+            if lc[colname].unit is not None:
+                # for case flux, flux_err, lightkurve has forced it to be u.dimensionless_unscaled
+                # can't reset a unit, so we create a new column
+                lc[colname] = u.Quantity(lc[colname].value, "electron/s")
+            else:
+                lc[colname].unit = "electron/s"
+
+    for colname in ["flux_bkg"]:
+        if colname in lc.colnames:
+            lc[colname].unit = u.percent
+
+    for colname in ["barycorr"]:
+        if colname in lc.colnames:
+            lc[colname].unit = u.day
+
+    # OPEN: x_centroid	y_centroid	x_com	y_com
+
+    # In Eleanor fits file, raw_flux's error is in flux_err, which breaks Lightkurve convention.
+    # Fix it here
+    lc["raw_flux_err"] = lc["flux_err"]
+    if flux_column.lower() != 'raw_flux':  #
+        lc["flux_err"] = np.full_like(lc["flux_err"], np.nan)
+
+    if lc.meta.get("AUTHOR") is not None:
+        # the author header is populated with "Adina D. Feinstein", which is not as useful in Lightkurve context
+        lc.meta["AUTHOR_ELEANOR"] = lc.meta.get("AUTHOR")
+    lc.meta["AUTHOR"] = "ELEANOR"
+
+    tic = lc.meta.get("TIC_ID")
+    if tic is not None:
+        # compatibility with SPOC, QLP, etc.
+        lc.meta["TARGETID"] = tic
+        lc.meta["TICID"] = tic
+        lc.meta["OBJECT"] = f"TIC {tic}"
+        # for Lightkurve's plotting methods
+        lc.meta["LABEL"] = f"TIC {tic}"
+
+    return TessLightCurve(data=lc)

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -98,6 +98,8 @@ def read(path_or_url, **kwargs):
         return TessLightCurve.read(path_or_url, format='cdips', **kwargs)
     elif filetype == "TASOC":
         return TessLightCurve.read(path_or_url, format="tasoc", **kwargs)
+    elif filetype == "ELEANOR":
+        return TessLightCurve.read(path_or_url, format="eleanor", **kwargs)
     elif filetype == "K2SFF":
         return KeplerLightCurve.read(path_or_url, format="k2sff", **kwargs)
     elif filetype == "EVEREST":

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -44,6 +44,7 @@ AUTHOR_LINKS = {
     "TASOC": "https://archive.stsci.edu/hlsp/tasoc",
     "PATHOS": "https://archive.stsci.edu/hlsp/pathos",
     "CDIPS": "https://archive.stsci.edu/hlsp/cdips",
+    "GSFC-ELEANOR-LITE": "https://archive.stsci.edu/hlsp/gsfc-eleanor-lite",
     "K2SFF": "https://archive.stsci.edu/hlsp/k2sff",
     "EVEREST": "https://archive.stsci.edu/hlsp/everest",
     "TESScut": "https://mast.stsci.edu/tesscut/",

--- a/tests/io/test_eleanor.py
+++ b/tests/io/test_eleanor.py
@@ -1,0 +1,53 @@
+import pytest
+
+from astropy.io import fits
+from astropy import units as u
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from lightkurve import search_lightcurve
+from lightkurve.io.eleanor import read_eleanor_lightcurve
+from lightkurve.io.detect import detect_filetype
+
+
+@pytest.mark.remote_data
+def test_read_eleanor():
+    """Can we read in ELEANOR / GSFC-ELEANOR-LITE light curves?"""
+    # pi Men in sector 1
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/gsfc-eleanor-lite/s0001/0000/0002/6113/6679/hlsp_gsfc-eleanor-lite_tess_ffi_s0001-0000000261136679_tess_v1.0_lc.fits"
+    with fits.open(url, mode="readonly") as hdulist:
+        # Can we auto-detect a QLP file?
+        assert detect_filetype(hdulist) == "ELEANOR"
+        # Are the correct fluxes read in?
+        lc = read_eleanor_lightcurve(url)
+        assert lc.meta["FLUX_ORIGIN"] == "corr_flux"
+        assert_array_equal(lc.flux.value, hdulist[1].data["CORR_FLUX"])
+        assert lc.flux.unit == u.electron / u.second
+        assert np.isnan(lc.flux_err.value).all()
+
+        # Are the correct fluxes read in? case raw flux
+        lc = read_eleanor_lightcurve(url, flux_column="raw_flux")
+        assert lc.meta["FLUX_ORIGIN"] == "raw_flux"
+        assert_array_equal(lc.flux.value, hdulist[1].data["RAW_FLUX"])
+        assert lc.flux.unit == u.electron / u.second
+        assert_array_equal(lc.flux_err.value, hdulist[1].data["FLUX_ERR"])
+        assert lc.flux_err.unit == u.electron / u.second
+
+        # assert misc metadata compatibility fixes
+        assert lc.meta["AUTHOR"] == "ELEANOR"
+        assert lc.meta["TARGETID"] == 261136679
+        assert lc.meta["TICID"] == 261136679
+        assert lc.meta["OBJECT"] == "TIC 261136679"
+        assert lc.meta["LABEL"] == "TIC 261136679"
+
+
+@pytest.mark.remote_data
+def test_search_gsfc_eleanor_lite():
+    """Can we search and download GSFC-ELEANOR-LITE light curves from MAST?"""
+    search = search_lightcurve("TIC 261136679", author="GSFC-ELEANOR-LITE")
+    assert len(search) > 0
+    assert search.table["author"][0] == "GSFC-ELEANOR-LITE"
+    lc = search[0].download()
+    assert type(lc).__name__ == "TessLightCurve"
+    assert lc.sector == search[0].table["sequence_number"]
+    assert lc.author == "ELEANOR"


### PR DESCRIPTION
To support FFI lightcurve products from HLSP [GSFC-ELEANOR-LITE](https://archive.stsci.edu/hlsp/gsfc-eleanor-lite). 

Because GSFC-ELEANOR-LITE uses `eleanor` to produce the LCs, the work is applicable to LC FITS files from vanilla `eleanor` as well.

Note 1 - the default flux used is [systematics-corrected flux](https://adina.feinste.in/eleanor/api.html#eleanor.TargetData.corr_flux) . I think this is probably the typical use case.

Note 2 - on `AUTHOR` header:
- Currently, `AUTHOR` is set to `ELEANOR` . It could be a bit of a surprise to users getting the LCs by downloading `GSFC-ELEANOR-LITE` products from MAST.
- It is done so because the reader can't tell whether a FITS file is created from vanilla `eleanor` or from `GSFC-ELEANOR-LITE` pipeline.
- I'm undecided if we should try to distinguish between those from `GSFC-ELEANOR-LITE` pipeline and those from vanilla `eleanor`.