### PR TITLE
Add a `show_progress` argument for `query_solar_system_objects()`

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1672,6 +1672,7 @@ class LightCurve(TimeSeries):
         location=None,
         cache=True,
         return_mask=False,
+        show_progress=True,
     ):
         """Returns a list of asteroids or comets which affected the light curve.
 
@@ -1722,6 +1723,8 @@ class LightCurve(TimeSeries):
             to request the search again.
         return_mask: optional, bool
             If True will return a boolean mask in time alongside the result
+        show_progress: optional, bool
+            If True will display a progress bar during the download
 
         Returns
         -------
@@ -1794,6 +1797,7 @@ class LightCurve(TimeSeries):
             location=location,
             radius=radius,
             cache=cache,
+            show_progress=show_progress,
         )
         if return_mask:
             return res, np.in1d(self.time.jd, res.epoch)

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -922,6 +922,7 @@ class TargetPixelFile(object):
         sigma=3,
         cache=True,
         return_mask=False,
+        show_progress=True
     ):
         """Returns a list of asteroids or comets which affected the target pixel files.
 
@@ -970,6 +971,8 @@ class TargetPixelFile(object):
             to request the search again.
         return_mask: optional, bool
             If True will return a boolean mask in time alongside the result
+        show_progress: optional, bool
+            If True will display a progress bar during the download
 
         Returns
         -------
@@ -1034,6 +1037,7 @@ class TargetPixelFile(object):
             location=location,
             radius=radius,
             cache=cache,
+            show_progress=show_progress,
         )
         if return_mask:
             return res, np.in1d(self.time.jd, res.epoch)

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -672,7 +672,7 @@ def centroid_quadratic(data, mask=None):
 
 
 def _query_solar_system_objects(
-    ra, dec, times, radius=0.1, location="kepler", cache=True
+    ra, dec, times, radius=0.1, location="kepler", cache=True, show_progress=True
 ):
     """Returns a list of asteroids/comets given a position and time.
 
@@ -693,6 +693,8 @@ def _query_solar_system_objects(
         Spacecraft location. Options include `'kepler'` and `'tess'`.
     cache : bool
         Whether to cache the search result. Default is True.
+    show_progress : bool
+        Whether to display a progress bar during the download. Default is True.
 
     Returns
     -------
@@ -718,9 +720,9 @@ def _query_solar_system_objects(
 
     df = None
     times = np.atleast_1d(times)
-    for time in tqdm(times, desc="Querying for SSOs"):
+    for time in tqdm(times, desc="Querying for SSOs", disable=~show_progress):
         url_queried = url + "EPOCH={}".format(time)
-        response = download_file(url_queried, cache=cache)
+        response = download_file(url_queried, cache=cache, show_progress=show_progress)
         if open(response).read(10) == "# Flag: -1":  # error code detected?
             raise IOError(
                 "SkyBot Solar System query failed.\n"


### PR DESCRIPTION
A `show_progress` argument was added for `query_solar_system_objects()` to control whether to display a progress bar and the urls during the download.

**Before:**
```
>>> lc.query_solar_system_objects()
Querying for SSOs:   0%|                                 | 0/74 [00:00<?, ?it/s]
Downloading http://vo.imcce.fr/webservices/skybot/skybotconesearch_query.php?-mime=text&-ra=247.292944&-dec=78.077754&-bd=0.0875&-loc=C57&EPOCH=2458684.8525856505
|==========================================| 217 /217  (100.00%)         0s
Querying for SSOs:   1%|▎                        | 1/74 [00:03<04:10,  3.44s/it]
Downloading http://vo.imcce.fr/webservices/skybot/skybotconesearch_query.php?-mime=text&-ra=247.292944&-dec=78.077754&-bd=0.0875&-loc=C57&EPOCH=2458684.8539745416
......
Querying for SSOs:  99%|███████████████████████▋| 73/74 [01:09<00:00,  1.05it/s]
Downloading http://vo.imcce.fr/webservices/skybot/skybotconesearch_query.php?-mime=text&-ra=247.292944&-dec=78.077754&-bd=0.0875&-loc=C57&EPOCH=2458709.4124718853
|==========================================| 217 /217  (100.00%)         0s
Querying for SSOs: 100%|████████████████████████| 74/74 [01:10<00:00,  1.05it/s]
>>>
```

**After:**
```
>>> lc.query_solar_system_objects(show_progress=False)
>>>
```