### PR TITLE
Ignore UnitsWarnings raised when reading FITS file with Astropy 5.1

### DIFF
--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -40,6 +40,11 @@ def read_generic_lightcurve(
     if isinstance(ext, str):
         validate_method(ext, supported_methods=[hdu.name.lower() for hdu in hdulist])
     with warnings.catch_warnings():
+        # By default, AstroPy emits noisy warnings about units commonly used
+        # in archived TESS data products (e.g., "e-/s" and "pixels").
+        # We ignore them here because they don't affect Lightkurve's features.
+        # Inconsistencies between TESS data products and the FITS standard
+        # out to be addressed at the archive level. (See issue #1216.)
         warnings.simplefilter("ignore", category=UnitsWarning)
         tab = Table.read(hdulist[ext], format="fits")
 

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -1,9 +1,11 @@
 """Read a generic FITS table containing a light curve."""
 import logging
+import warnings
 
 from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
+from astropy.units import UnitsWarning
 import numpy as np
 
 from ..utils import validate_method
@@ -37,7 +39,9 @@ def read_generic_lightcurve(
     # Raise an exception if the requested extension is invalid
     if isinstance(ext, str):
         validate_method(ext, supported_methods=[hdu.name.lower() for hdu in hdulist])
-    tab = Table.read(hdulist[ext], format="fits")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UnitsWarning)
+        tab = Table.read(hdulist[ext], format="fits")
 
     # Make sure the meta data also includes header fields from extension #0
     tab.meta.update(hdulist[0].header)


### PR DESCRIPTION
This PR fixes #1216.

It catches and ignores the UnitsWarning raised when reading FITS file, which occurs with Astropy 5.1.