### PR TITLE
Reflect TESS GI proposal url changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
 
 - Allow users to include more columns in ``SearchResult`` display via a new
   ``SearchResult.display_extra_columns`` attribute, with defaults set by an
-  Astropy-based configuration system. [#1134]
+  Astropy-based configuration system. [#1134, #1232]
 
 - Added a ``show_progress`` parameter to ``query_solar_system_objects()``,
   which shows the download progress by default. [#1225]

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -153,6 +153,12 @@ class SearchResult(object):
             )[0]
 
     def __repr__(self, html=False):
+        def to_tess_gi_url(proposal_id):
+            if re.match("^G0[12].+", proposal_id) is not None:
+                return f"https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs-primary.html#:~:text={proposal_id}"
+            else:
+                return f"https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs.html#:~:text={proposal_id}"
+
         out = "SearchResult containing {} data products.".format(len(self.table))
         if len(self.table) == 0:
             return out
@@ -180,7 +186,7 @@ class SearchResult(object):
                     continue
                 # e.g., handle cases with multiple proposals, e.g.,  G12345_G67890
                 p_id_links = [f"""\
-<a href='https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs.html#:~:text={p_id}'>{p_id}</a>\
+<a href='{to_tess_gi_url(p_id)}'>{p_id}</a>\
 """ for p_id in p_ids.split("_")]
                 out = out.replace(f">{p_ids}<", f">{' , '.join(p_id_links)}<")
         return out


### PR DESCRIPTION
An amendment to the not-yet-released PR #1134.

At some point TESS office has changed the URL of the list of primary mission GI. 
This PR provides a fix to reflect th changes.

No need of a new entry in the changelog, but we could add the PR number to the existing one referencing #1134
