### PR TITLE
Expose data product-specific doc as public API doc

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,6 +58,7 @@ The following GitHub members directly contributed code and bugfixes:
 - `Lieven Govaerts <https://github.com/lgov>`_
 - `DeepekshGupta <https://github.com/DeepekshGupta>`_
 - `vvilhelmus <https://github.com/vvilhelmus>`_
+- `vbkostov <https://github.com/vbkostov>`_
 
 
 Community

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 2.3.0 (unreleased)
 ==================
 
+- Added support for reading in GSFC-ELEANOR-LITE High Level Science Product
+  light curves. [#1217]
+
+- Provide data product specific documentation. [#1233]
+
 - Allow users to include more columns in ``SearchResult`` display via a new
   ``SearchResult.display_extra_columns`` attribute, with defaults set by an
   Astropy-based configuration system. [#1134]
@@ -9,7 +14,7 @@
   which shows the download progress by default. [#1225]
 
 - Added the new TESS quality flag bits 13-15 to ``TessQualityFlags``. [#1218]
-  
+
 - Fixed an issue which caused unnecessary ``UnitsWarning`` being raised when
   reading light curve files and CBV files with AstroPy v5.1 installed. [#1226, #1229]
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -18,6 +18,7 @@ methods.
    periodogram
    seismology
    correctors
+   io
    config
    misc
 

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -1,0 +1,45 @@
+.. _api.io:
+
+=====================
+Reading Data Products
+=====================
+.. currentmodule:: lightkurve.io
+
+
+.. autosummary::
+  :toctree: api/
+
+    read
+
+In general, users only need to call `read` function, also available as ``lightkurve.read``,
+to read all supported Kepler / TESS data products.
+
+The data product-specific functions below **should not** be called directly.
+They do, however, contain information pertaining to specific products, as well as
+optional parameters that can be passed to the generic `read()`.
+
+
+Kepler Data Products
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+  :toctree: api/
+
+    kepler.read_kepler_lightcurve
+    everest.read_everest_lightcurve
+    kepseismic.read_kepseismic_lightcurve
+    k2sff.read_k2sff_lightcurve
+
+
+TESS Data Products
+~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+  :toctree: api/
+
+    tess.read_tess_lightcurve
+    cdips.read_cdips_lightcurve
+    eleanorlite.read_eleanorlite_lightcurve
+    pathos.read_pathos_lightcurve
+    qlp.read_qlp_lightcurve
+    tasoc.read_tasoc_lightcurve

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -11,12 +11,16 @@ Reading Data Products
 
     read
 
-In general, users only need to call `read` function, also available as ``lightkurve.read``,
-to read all supported Kepler / TESS data products.
+In general, users only need to call the `read` function, also available as
+``lightkurve.read``.  This function will auto-detect the type of data product
+being opened and pass it on to a product-specific reader function.
 
-The data product-specific functions below **should not** be called directly.
-They do, however, contain information pertaining to specific products, as well as
-optional parameters that can be passed to the generic `read()`.
+Below we list the product-specific reader functions.  These functions
+are not intended to be called directly because it is much easier to
+simply call the `read` function.  We include the functions here because
+their documentation lists the optional parameters that can be passed to
+the generic `read()` function, and because they document information
+pertaining to specific products.
 
 
 Kepler Data Products

--- a/docs/source/reference/lightcurve.rst
+++ b/docs/source/reference/lightcurve.rst
@@ -103,7 +103,6 @@ Conversions
   LightCurve.to_periodogram
   LightCurve.to_seismology
   LightCurve.to_table
-  LightCurve.read
   LightCurve.write
 
 

--- a/src/lightkurve/io/cdips.py
+++ b/src/lightkurve/io/cdips.py
@@ -16,7 +16,7 @@ def read_cdips_lightcurve(filename,
                             flux_column="IRM1",
                             include_inst_errs=False,
                             quality_bitmask=None):
-    """Returns a `TessLightCurve`.
+    """Returns a TESS CDIPS `~lightkurve.lightcurve.LightCurve`.
 
     Note: CDIPS light curves have already had quality filtering applied, and
     do not provide the bitflags necessary for a user to apply a new bitmask.
@@ -24,6 +24,8 @@ def read_cdips_lightcurve(filename,
     are removed according to Bouma et al. 2019, and no other quality filtering
     is allowed. The `quality_bitmask` parameter is ignored but accepted for
     compatibility with other data format readers.
+
+    More information: https://archive.stsci.edu/hlsp/cdips
 
     Parameters
     ----------

--- a/src/lightkurve/io/kepler.py
+++ b/src/lightkurve/io/kepler.py
@@ -8,7 +8,7 @@ from .generic import read_generic_lightcurve
 def read_kepler_lightcurve(
     filename, flux_column="pdcsap_flux", quality_bitmask="default"
 ):
-    """Returns a KeplerLightCurve.
+    """Returns a Kepler `~lightkurve.lightcurve.LightCurve`.
 
     Parameters
     ----------
@@ -29,7 +29,7 @@ def read_kepler_lightcurve(
             * "hardest": removes all data that has been flagged
               (`quality_bitmask=2096639`). This mask is not recommended.
 
-        See the :class:`KeplerQualityFlags` class for details on the bitmasks.
+        See the `~lightkurve.utils.KeplerQualityFlags` class for details on the bitmasks.
     """
     lc = read_generic_lightcurve(
         filename,

--- a/src/lightkurve/io/pathos.py
+++ b/src/lightkurve/io/pathos.py
@@ -12,7 +12,9 @@ from .generic import read_generic_lightcurve
 def read_pathos_lightcurve(
     filename, flux_column="PSF_FLUX_COR", quality_bitmask="default"
 ):
-    """Returns a `TessLightCurve`.
+    """Returns a TESS PATHOS `~lightkurve.lightcurve.LightCurve`.
+
+    More information: https://archive.stsci.edu/hlsp/pathos
 
     Parameters
     ----------
@@ -26,15 +28,14 @@ def read_pathos_lightcurve(
         be used to mask out bad cadences. If a string is passed, it has the
         following meaning:
 
-            * "none": no cadences will be ignored (`quality_bitmask=0`).
-            * "default": cadences with severe quality issues will be ignored
-              (`quality_bitmask=1130799`).
-            * "hard": more conservative choice of flags to ignore
-              (`quality_bitmask=1664431`). This is known to remove good data.
-            * "hardest": removes all data that has been flagged
-              (`quality_bitmask=2096639`). This mask is not recommended.
+            * "none": no cadences will be ignored.
+            * "default": cadences with severe quality issues will be ignored.
+            * "hard": more conservative choice of flags to ignore.
+              This is known to remove good data.
+            * "hardest": removes all data that has been flagged.
+              This mask is not recommended.
 
-        See the :class:`TessQualityFlags` class for details on the bitmasks.
+        See the `~lightkurve.utils.TessQualityFlags` class for details on the bitmasks.
     """
     lc = read_generic_lightcurve(
         filename,

--- a/src/lightkurve/io/qlp.py
+++ b/src/lightkurve/io/qlp.py
@@ -10,11 +10,13 @@ from .generic import read_generic_lightcurve
 
 
 def read_qlp_lightcurve(filename, flux_column="sap_flux", flux_err_column="kspsap_flux_err", quality_bitmask="default"):
-    """Returns a `TessLightCurve` object given a light curve file from the MIT Quicklook Pipeline (QLP).
+    """Returns a `~lightkurve.lightcurve.LightCurve` object given a light curve file from the MIT Quicklook Pipeline (QLP).
 
     By default, QLP's `sap_flux` column is used to populate the `flux` values,
     and 'kspsap_flux_err' is used to populate `flux_err`. For a discussion
     related to this choice, see https://github.com/lightkurve/lightkurve/issues/1083
+
+    More information: https://archive.stsci.edu/hlsp/qlp
 
     Parameters
     ----------
@@ -30,15 +32,14 @@ def read_qlp_lightcurve(filename, flux_column="sap_flux", flux_err_column="kspsa
         be used to mask out bad cadences. If a string is passed, it has the
         following meaning:
 
-            * "none": no cadences will be ignored (`quality_bitmask=0`).
-            * "default": cadences with severe quality issues will be ignored
-              (`quality_bitmask=1130799`).
-            * "hard": more conservative choice of flags to ignore
-              (`quality_bitmask=1664431`). This is known to remove good data.
-            * "hardest": removes all data that has been flagged
-              (`quality_bitmask=2096639`). This mask is not recommended.
+            * "none": no cadences will be ignored.
+            * "default": cadences with severe quality issues will be ignored.
+            * "hard": more conservative choice of flags to ignore.
+              This is known to remove good data.
+            * "hardest": removes all data that has been flagged.
+              This mask is not recommended.
 
-        See the :class:`TessQualityFlags` class for details on the bitmasks.
+        See the `~lightkurve.utils.TessQualityFlags` class for details on the bitmasks.
     """
     lc = read_generic_lightcurve(filename, flux_column=flux_column, flux_err_column=flux_err_column, time_format="btjd")
 

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -27,7 +27,7 @@ def open(path_or_url, **kwargs):
 def read(path_or_url, **kwargs):
     """Reads any valid Kepler or TESS data file and returns an instance of
     `~lightkurve.lightcurve.LightCurve` or
-    :class:`TargetPixelFile <lightkurve.targetpixelfile>`
+    `TargetPixelFile <../targetpixelfile.html>`_
 
     This function will automatically detect the type of the data product, and return the
     appropriate object. File types currently supported include::
@@ -57,10 +57,12 @@ def read(path_or_url, **kwargs):
     flux_column : str, optional
         (Applicable to LightCurve products only) The column in the FITS file to be read as `flux`. Defaults to 'pdcsap_flux'.
         Typically 'pdcsap_flux' or 'sap_flux'.
+    **kwargs : dict
+        Dictionary of arguments to be passed to underlying data product type specific reader.
 
     Returns
     -------
-    data : a subclass of :class:`TargetPixelFile <lightkurve.targetpixelfile>` or `~lightkurve.lightcurve.LightCurve`
+    data : a subclass of `~lightkurve.lightcurve.LightCurve` or `TargetPixelFile <../targetpixelfile.html>`_
            depending on the detected file type.
 
     Raises

--- a/src/lightkurve/io/tasoc.py
+++ b/src/lightkurve/io/tasoc.py
@@ -1,5 +1,5 @@
 """TESS Asteroseismic Science Operations Center - https://tasoc.dk
-   TESS Data For Asteroseismology Lightcurves - https://archive.stsci.edu/hlsp/tasoc 
+   TESS Data For Asteroseismology Lightcurves - https://archive.stsci.edu/hlsp/tasoc
    Data provided with this release have been extracted using the TASOC Photometry pipeline. The TASOC
    pipeline used to generate the data is open source and available on GitHub - https://github.com/tasoc
 """
@@ -10,7 +10,9 @@ from .generic import read_generic_lightcurve
 
 
 def read_tasoc_lightcurve(filename, flux_column="FLUX_RAW", quality_bitmask=None):
-    """Returns a `TessLightCurve`.
+    """Returns a TESS TASOC `~lightkurve.lightcurve.LightCurve`.
+
+    More information: https://archive.stsci.edu/hlsp/tasoc
 
     Parameters
     ----------

--- a/src/lightkurve/io/tess.py
+++ b/src/lightkurve/io/tess.py
@@ -8,7 +8,7 @@ from .generic import read_generic_lightcurve
 def read_tess_lightcurve(
     filename, flux_column="pdcsap_flux", quality_bitmask="default"
 ):
-    """Returns a `TessLightCurve`.
+    """Returns a TESS `~lightkurve.lightcurve.LightCurve`.
 
     Parameters
     ----------
@@ -21,15 +21,14 @@ def read_tess_lightcurve(
         be used to mask out bad cadences. If a string is passed, it has the
         following meaning:
 
-            * "none": no cadences will be ignored (`quality_bitmask=0`).
-            * "default": cadences with severe quality issues will be ignored
-              (`quality_bitmask=1130799`).
-            * "hard": more conservative choice of flags to ignore
-              (`quality_bitmask=1664431`). This is known to remove good data.
-            * "hardest": removes all data that has been flagged
-              (`quality_bitmask=2096639`). This mask is not recommended.
+            * "none": no cadences will be ignored.
+            * "default": cadences with severe quality issues will be ignored.
+            * "hard": more conservative choice of flags to ignore.
+              This is known to remove good data.
+            * "hardest": removes all data that has been flagged.
+              This mask is not recommended.
 
-        See the :class:`TessQualityFlags` class for details on the bitmasks.
+        See the `~lightkurve.utils.TessQualityFlags` class for details on the bitmasks.
     """
     lc = read_generic_lightcurve(filename, flux_column=flux_column, time_format="btjd")
 


### PR DESCRIPTION
It also:
- exposes the generic `lk.read()` function
- removes [LightCurve.read()](https://docs.lightkurve.org/reference/api/lightkurve.LightCurve.read.html) from public documentation. 
  - Users can't really directly use it to read lightcurve FITS file anyway (only concrete subclass `Kepler / TessLightCurve` would work).
  - It does have a auto-generated list of supported format. But I think the new `io` section serves similar purpose.

There are some editing that can be done (adding links to correspond HLSP doc, fixing broken links, etc.) on individual functions. If we agree on the general approach, the additional editing can be added to this PR or some subsequent ones.

The PR assumes GSFC-ELEANOR-LITE support PR #1217 will be merged, and contains references to it.
But even if #1217 is not merged, the PR won't break doc build (just causes some additional warning).