### PR TITLE
Make  github git blame view ignore formatting commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# global code reformatting with black
+d9f9ba1145cad12ddc2b2bef0413827fc7e4a09c


### PR DESCRIPTION
It'd make git blame view on github ignore formatting commits, currently d9f9ba1145cad12ddc2b2bef0413827fc7e4a09c

See: 
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
