### PR TITLE
fix SearchResult TESS GI proposal links for cycles 3/4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Fixed interact features, e.g. ``tpf.interact()``, to work with bokeh v3.x [#1262]
 
+- Fixed ``SearchResult`` HTML display for links to TESS GI cycles 3/4 proposals. [#1260]
+
 
 2.3.0 (2022-07-07)
 ==================

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -157,6 +157,8 @@ class SearchResult(object):
         def to_tess_gi_url(proposal_id):
             if re.match("^G0[12].+", proposal_id) is not None:
                 return f"https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs-primary.html#:~:text={proposal_id}"
+            elif re.match("^G0[34].+", proposal_id) is not None:
+                return f"https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs-em1.html#:~:text={proposal_id}"
             else:
                 return f"https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs.html#:~:text={proposal_id}"
 


### PR DESCRIPTION
TESS GI proposal page was restructured.
The completed cycle 3/4 proposals are moved to a new URL. They are now listed in https://heasarc.gsfc.nasa.gov/docs/tess/approved-programs-em1.html

This PR updates the links to SearchResult accordingly.

chanelog to add
```
- Fixed ``SearchResult`` HTML display, for TESS GI proposal links for cycles 3/4 proposals. [#1260]
```