### PR TITLE
Fix interact features for bokeh v3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,11 @@
 
 - Added the ability to configure the default cache directory used by
   ``SearchResult.download()`` / ``SearchResult.download_all()``. [#1214]
+
 - Moved the default cache directory from ``$HOME/.lightkurve-cache``
   to ``$HOME/.lightkurve/cache``. [#1214]
+
+- Fixed interact features, e.g. ``tpf.interact()``, to work with bokeh v3.x [#1262]
 
 
 2.3.0 (2022-07-07)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,8 @@ pandas = ">=1.1.4"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"
-# tpf.interact_sky() tap selection requires a bug fix due to
-#  https://github.com/bokeh/bokeh/issues/6508
-bokeh = ">=1.1"
+# bokeh v2+ requirement due to https://github.com/lightkurve/lightkurve/issues/1261
+bokeh = ">=2.0.0"
 memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
 

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -234,7 +234,10 @@ def prepare_tpf_datasource(tpf, aperture_mask):
     xa = xa.flatten()
     ya = ya.flatten()
     tpf_source = ColumnDataSource(data=dict(xx=xa.astype(float), yy=ya.astype(float)))
-    tpf_source.selected.indices = aperture_mask_to_selected_indices(aperture_mask)
+    # convert the ndarray from aperture_mask_to_selected_indices() to plain list
+    # because bokeh v3.0.2 does not accept ndarray (and causes js error)
+    # see https://github.com/bokeh/bokeh/issues/12624
+    tpf_source.selected.indices = list(aperture_mask_to_selected_indices(aperture_mask))
     return tpf_source
 
 

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -287,8 +287,8 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
 
     fig = figure(
         title=title,
-        plot_height=340,
-        plot_width=600,
+        height=340,
+        width=600,
         tools="pan,wheel_zoom,box_zoom,tap,reset",
         toolbar_location="below",
         border_fill_color="whitesmoke",
@@ -768,8 +768,8 @@ def make_tpf_figure_elements(
     tpf_source_selectable=True,
     pedestal=None,
     fiducial_frame=None,
-    plot_width=370,
-    plot_height=340,
+    width=370,
+    height=340,
     scale="log",
     vmin=None,
     vmax=None,
@@ -823,8 +823,8 @@ def make_tpf_figure_elements(
     # We subtract 0.5 from the range below because pixel coordinates refer to
     # the middle of a pixel, e.g. (col, row) = (10.0, 20.0) is a pixel center.
     fig = figure(
-        plot_width=plot_width,
-        plot_height=plot_height,
+        width=width,
+        height=height,
         x_range=(tpf.column - 0.5, tpf.column + tpf.shape[2] - 0.5),
         y_range=(tpf.row - 0.5, tpf.row + tpf.shape[1] - 0.5),
         title=title,
@@ -1352,8 +1352,8 @@ def show_skyview_widget(tpf, notebook_url="localhost:8888", aperture_mask="empty
             tpf_source,
             tpf_source_selectable=False,
             fiducial_frame=fiducial_frame,
-            plot_width=640,
-            plot_height=600,
+            width=640,
+            height=600,
             tools="tap,box_zoom,wheel_zoom,reset"
         )
         fig_tpf, r, message_selected_target = add_gaia_figure_elements(

--- a/src/lightkurve/interact_bls.py
+++ b/src/lightkurve/interact_bls.py
@@ -293,8 +293,8 @@ def make_lightcurve_figure_elements(
     # Make figure
     fig = figure(
         title="Light Curve",
-        plot_height=300,
-        plot_width=900,
+        height=300,
+        width=900,
         tools="pan,box_zoom,wheel_zoom,reset",
         toolbar_location="below",
         border_fill_color="#FFFFFF",
@@ -395,8 +395,8 @@ def make_folded_figure_elements(
     # Build Figure
     fig = figure(
         title="Folded Light Curve",
-        plot_height=340,
-        plot_width=450,
+        height=340,
+        width=450,
         tools="pan,box_zoom,wheel_zoom,reset",
         toolbar_location="below",
         border_fill_color="#FFFFFF",
@@ -488,8 +488,8 @@ def make_bls_figure_elements(result, bls_source, help_source):
     # Build Figure
     fig = figure(
         title="BLS Periodogram",
-        plot_height=340,
-        plot_width=450,
+        height=340,
+        width=450,
         tools="pan,box_zoom,wheel_zoom,tap,reset",
         toolbar_location="below",
         border_fill_color="#FFFFFF",

--- a/src/lightkurve/seismology/core.py
+++ b/src/lightkurve/seismology/core.py
@@ -423,8 +423,8 @@ class Seismology(object):
         maximum_frequency=None,
         smooth_filter_width=0.1,
         scale="linear",
-        plot_width=490,
-        plot_height=340,
+        width=490,
+        height=340,
         title="Echelle",
     ):
         """Helper function to make the elements of the echelle diagram for bokeh plotting."""
@@ -446,8 +446,8 @@ class Seismology(object):
         )
 
         fig = figure(
-            plot_width=plot_width,
-            plot_height=plot_height,
+            width=width,
+            height=height,
             x_range=(0, 1),
             y_range=(y_f[0].value, y_f[-1].value),
             title=title,

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -144,7 +144,9 @@ def test_interact_functions():
     # ensure proper 2D - 1D conversion
     assert tpf_source.data["xx"].ndim == 1
     assert tpf_source.data["yy"].ndim == 1
-    assert tpf_source.selected.indices.ndim == 1
+    # for bokeh v3, .indices needs to plain list .
+    # cf. https://github.com/bokeh/bokeh/issues/12624
+    assert isinstance(tpf_source.selected.indices, list)
 
     # the lower-level function aperture_mask_from_selected_indices() is used in
     # callback _create_lightcurve_from_pixels(), which cannot be easily tested.


### PR DESCRIPTION
Fix #1261

- replace all `plot_height` / `plot_width` with `height` / `width` in bokeh calls.
- additional fix `tpf.interact()` to make pixel selection compatible with bokeh v3.

changelog to add:
```
- Fixed interactive features to work with bokeh v3. [#1262]
```