### PR TITLE
fixing np.int and np.float

### DIFF
--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -51,7 +51,7 @@ class Collection(object):
         return len(self.data)
 
     def __getitem__(self, index_or_mask):
-        if isinstance(index_or_mask, (int, np.integer)):
+        if isinstance(index_or_mask, (int, np.int_)):
             return self.data[index_or_mask]
         elif isinstance(index_or_mask, slice):
             return type(self)(self.data[index_or_mask])

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -1248,7 +1248,7 @@ def show_interact_widget(
                     exported_filename,
                     overwrite=True,
                     flux_column_name="SAP_FLUX",
-                    aperture_mask=lc_new.meta["APERTURE_MASK"].astype(np.int),
+                    aperture_mask=lc_new.meta["APERTURE_MASK"].astype(np.int_),
                     SOURCE="lightkurve interact",
                     NOTE="custom mask",
                     MASKNPIX=np.nansum(lc_new.meta["APERTURE_MASK"]),

--- a/src/lightkurve/io/eleanor.py
+++ b/src/lightkurve/io/eleanor.py
@@ -106,7 +106,7 @@ def read_eleanor_lightcurve(filename,
     # convert to int to ensure we stick with the convention
     for colname in ["ffiindex", "cadenceno"]:
         if colname in lc.colnames:
-            if not np.issubdtype(lc[colname].dtype, np.integer):
+            if not np.issubdtype(lc[colname].dtype, np.int_):
                 lc[colname] = np.asarray(lc[colname].value, dtype=int)
 
     if (

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1485,7 +1485,7 @@ class LightCurve(TimeSeries):
             )
         elif bins is not None:
             if (bins not in ('blocks', 'knuth', 'scott', 'freedman') and
-                    np.array(bins).dtype != np.int):
+                    np.array(bins).dtype != np.int_):
                 raise TypeError("``bins`` must have integer type.")
             elif (isinstance(bins, str) or np.size(bins) != 1) and not _HAS_VAR_BINS:
                 raise ValueError("Sequence or method for ``bins`` requires Astropy 5.0.")
@@ -3359,7 +3359,7 @@ def _boolean_mask_to_bitmask(aperture_mask):
     # Masks can either be boolean input or Kepler pipeline style
     clean_mask = np.nan_to_num(aperture_mask)
 
-    contains_bit2 = (clean_mask.astype(np.int) & 2).any()
+    contains_bit2 = (clean_mask.astype(np.int_) & 2).any()
     all_zeros_or_ones = (clean_mask.dtype in ["float", "int"]) & (
         (set(np.unique(clean_mask)) - {0, 1}) == set()
     )

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -651,12 +651,12 @@ class TargetPixelFile(object):
             elif aperture_mask == "empty":
                 aperture_mask = np.zeros((self.shape[1], self.shape[2]), dtype=bool)
             elif (
-                np.issubdtype(aperture_mask.dtype, np.integer)
+                np.issubdtype(aperture_mask.dtype, np.int_)
                 and ((aperture_mask & 2) == 2).any()
             ):
                 # Kepler and TESS pipeline style integer flags
                 aperture_mask = (aperture_mask & 2) == 2
-            elif isinstance(aperture_mask.flat[0], (np.integer, np.float)):
+            elif isinstance(aperture_mask.flat[0], (np.int_, np.float_)):
                 aperture_mask = aperture_mask.astype(bool)
         self._last_aperture_mask = aperture_mask
         return aperture_mask

--- a/tests/correctors/test_pldcorrector.py
+++ b/tests/correctors/test_pldcorrector.py
@@ -13,7 +13,7 @@ from lightkurve.correctors import PLDCorrector
 
 @pytest.mark.remote_data
 def test_kepler_pld_corrector():
-    tpf = search_targetpixelfile("K2-199")[0].download()
+    tpf = search_targetpixelfile("EPIC 212779596")[0].download()
     pld = PLDCorrector(tpf)
     # Is the correct filetype returned?
     clc = pld.correct()

--- a/tests/io/test_eleanor.py
+++ b/tests/io/test_eleanor.py
@@ -30,7 +30,7 @@ def test_gsfc_eleanor_lite():
         assert ((lc["quality"] & 2**17) != 0).any() and ((lc["quality"] & 2**18) != 0).any()
         lc = read_eleanor_lightcurve(url, quality_bitmask='hardest')
         assert not (lc["quality"] & (2**17 | 2**18)).any()
-        assert np.issubdtype(lc["cadenceno"].dtype, np.integer)
+        assert np.issubdtype(lc["cadenceno"].dtype, np.int_)
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_vanilla_eleanor(url):
         # vanilla eleanor's output cadenceno (FFIINDEX) dtype in the
         # FITS file is float, breaking convention
         # ensure we compensate it.
-        assert np.issubdtype(lc["cadenceno"].dtype, np.integer)
+        assert np.issubdtype(lc["cadenceno"].dtype, np.int_)
 
 
 @pytest.mark.remote_data

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -28,8 +28,8 @@ def test_sine_sff():
     """Can we recover a synthetic sine curve using SFF and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the SFF algorithm
     lc = tpf.to_lightcurve()
@@ -79,8 +79,8 @@ def test_transit_sff():
     """Can we recover a synthetic exoplanet signal using SFF and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = float(tpf.hdu[3].header["RPRS"])
     true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
     max_depth = 1 - np.min(true_transit_lc)
 
@@ -121,8 +121,8 @@ def test_transit_pld():
     """Can we recover a synthetic exoplanet signal using PLD and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = float(tpf.hdu[3].header["RPRS"])
     true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
     max_depth = 1 - np.min(true_transit_lc)
 
@@ -164,8 +164,8 @@ def test_sine_pld():
     """Can we recover a synthetic sine wave using PLD and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the PLD algorithm
     corrector = tpf.to_corrector("pld")


### PR DESCRIPTION
[`numpy` deprecated the `np.int` and `np.float` features in v1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and so we need to replace them, because as of version 1.24 it causes exceptions. I'm replacing them with `np.int_` and `np.float_` and checking if the tests pass. We might be better off replacing them with `int` and `float`.

Note: K2-199 was used in a test for PLD, but now that name returns no results from our search. I've updated the target name to the EPIC number for that target [EPIC 212779596](https://simbad.u-strasbg.fr/simbad/sim-basic?Ident=EPIC212779596).