### PR TITLE
Numpyfix v2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Fixed ``SearchResult`` HTML display for links to TESS GI cycles 3/4 proposals. [#1260]
 
+- Fixed references to np.int and np.float due to changes in numpy v1.24. [#1279]
+
 
 2.3.0 (2022-07-07)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-numpy = "1.24.1"
-astropy = "5.2.1"
+numpy = ">=1.18"
+astropy = ">=5.0"
 scipy = { version = ">=1.7", python = ">=3.8,<3.11" }
 matplotlib = ">=3.1"
 astroquery = ">=0.3.10"
@@ -42,7 +42,6 @@ fbpca = ">=1.0"
 bokeh = ">=2.0.0"
 memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
-ipython = "^8.9.0"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = ">=2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-numpy = ">=1.18"
-astropy = ">=5.0"
+numpy = "1.24.1"
+astropy = "5.2.1"
 scipy = { version = ">=1.7", python = ">=3.8,<3.11" }
 matplotlib = ">=3.1"
 astroquery = ">=0.3.10"
@@ -42,6 +42,7 @@ fbpca = ">=1.0"
 bokeh = ">=2.0.0"
 memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
+ipython = "^8.9.0"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = ">=2.0.0"

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -1248,7 +1248,7 @@ def show_interact_widget(
                     exported_filename,
                     overwrite=True,
                     flux_column_name="SAP_FLUX",
-                    aperture_mask=lc_new.meta["APERTURE_MASK"].astype(np.int),
+                    aperture_mask=lc_new.meta["APERTURE_MASK"].astype(np.int_),
                     SOURCE="lightkurve interact",
                     NOTE="custom mask",
                     MASKNPIX=np.nansum(lc_new.meta["APERTURE_MASK"]),

--- a/src/lightkurve/io/eleanor.py
+++ b/src/lightkurve/io/eleanor.py
@@ -106,7 +106,7 @@ def read_eleanor_lightcurve(filename,
     # convert to int to ensure we stick with the convention
     for colname in ["ffiindex", "cadenceno"]:
         if colname in lc.colnames:
-            if not np.issubdtype(lc[colname].dtype, np.integer):
+            if not np.issubdtype(lc[colname].dtype, np.int_):
                 lc[colname] = np.asarray(lc[colname].value, dtype=int)
 
     if (

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1485,7 +1485,7 @@ class LightCurve(TimeSeries):
             )
         elif bins is not None:
             if (bins not in ('blocks', 'knuth', 'scott', 'freedman') and
-                    np.array(bins).dtype != np.integer):
+                    np.array(bins).dtype != np.int_):
                 raise TypeError("``bins`` must have integer type.")
             elif (isinstance(bins, str) or np.size(bins) != 1) and not _HAS_VAR_BINS:
                 raise ValueError("Sequence or method for ``bins`` requires Astropy 5.0.")

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1379,7 +1379,7 @@ class LightCurve(TimeSeries):
         with warnings.catch_warnings():  # Ignore warnings due to NaNs or Infs
             warnings.simplefilter("ignore")
             outlier_mask = sigma_clip(
-                data=self.flux,
+                data=self.flux.data,
                 sigma=sigma,
                 sigma_lower=sigma_lower,
                 sigma_upper=sigma_upper,
@@ -1485,7 +1485,7 @@ class LightCurve(TimeSeries):
             )
         elif bins is not None:
             if (bins not in ('blocks', 'knuth', 'scott', 'freedman') and
-                    np.array(bins).dtype != np.int):
+                    np.array(bins).dtype != np.integer):
                 raise TypeError("``bins`` must have integer type.")
             elif (isinstance(bins, str) or np.size(bins) != 1) and not _HAS_VAR_BINS:
                 raise ValueError("Sequence or method for ``bins`` requires Astropy 5.0.")
@@ -3359,7 +3359,7 @@ def _boolean_mask_to_bitmask(aperture_mask):
     # Masks can either be boolean input or Kepler pipeline style
     clean_mask = np.nan_to_num(aperture_mask)
 
-    contains_bit2 = (clean_mask.astype(np.int) & 2).any()
+    contains_bit2 = (clean_mask.astype(np.int_) & 2).any()
     all_zeros_or_ones = (clean_mask.dtype in ["float", "int"]) & (
         (set(np.unique(clean_mask)) - {0, 1}) == set()
     )

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -656,7 +656,7 @@ class TargetPixelFile(object):
             ):
                 # Kepler and TESS pipeline style integer flags
                 aperture_mask = (aperture_mask & 2) == 2
-            elif isinstance(aperture_mask.flat[0], (np.integer, np.float)):
+            elif isinstance(aperture_mask.flat[0], (np.integer, np.float_)):
                 aperture_mask = aperture_mask.astype(bool)
         self._last_aperture_mask = aperture_mask
         return aperture_mask

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -651,7 +651,7 @@ class TargetPixelFile(object):
             elif aperture_mask == "empty":
                 aperture_mask = np.zeros((self.shape[1], self.shape[2]), dtype=bool)
             elif (
-                np.issubdtype(aperture_mask.dtype, np.integer)
+                np.issubdtype(aperture_mask.dtype, np.int_)
                 and ((aperture_mask & 2) == 2).any()
             ):
                 # Kepler and TESS pipeline style integer flags
@@ -659,6 +659,7 @@ class TargetPixelFile(object):
             elif isinstance(aperture_mask.flat[0], (np.integer, np.float_)):
                 aperture_mask = aperture_mask.astype(bool)
         self._last_aperture_mask = aperture_mask
+        
         return aperture_mask
 
     def create_threshold_mask(self, threshold=3, reference_pixel="center"):

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -28,8 +28,8 @@ def test_sine_sff():
     """Can we recover a synthetic sine curve using SFF and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the SFF algorithm
     lc = tpf.to_lightcurve()
@@ -79,8 +79,8 @@ def test_transit_sff():
     """Can we recover a synthetic exoplanet signal using SFF and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = float(tpf.hdu[3].header["RPRS"])
     true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
     max_depth = 1 - np.min(true_transit_lc)
 
@@ -121,8 +121,8 @@ def test_transit_pld():
     """Can we recover a synthetic exoplanet signal using PLD and BLS?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_transit)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_rprs = np.float(tpf.hdu[3].header["RPRS"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_rprs = float(tpf.hdu[3].header["RPRS"])
     true_transit_lc = tpf.hdu[3].data["NOISELESS_INPUT"]
     max_depth = 1 - np.min(true_transit_lc)
 
@@ -164,8 +164,8 @@ def test_sine_pld():
     """Can we recover a synthetic sine wave using PLD and LombScargle?"""
     # Retrieve the custom, known signal properties
     tpf = KeplerTargetPixelFile(filename_synthetic_sine)
-    true_period = np.float(tpf.hdu[3].header["PERIOD"])
-    true_amplitude = np.float(tpf.hdu[3].header["SINE_AMP"])
+    true_period = float(tpf.hdu[3].header["PERIOD"])
+    true_amplitude = float(tpf.hdu[3].header["SINE_AMP"])
 
     # Run the PLD algorithm
     corrector = tpf.to_corrector("pld")

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -803,7 +803,7 @@ def test_missing_pipeline_mask():
     TPFs produced by TESSCut contain an empty pipeline mask.  When the pipeline
     mask is missing or empty, we want `to_lightcurve()` to fall back on the
     'threshold' mask by default, to avoid creating a light curve based on zero pixels."""
-    tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=1)
+    tpf = search_tesscut("Proxima Cen", sector=12).download(cutout_size=3)
     lc = tpf.to_lightcurve()
     assert np.isfinite(lc.flux).any()
     assert lc.meta.get("APERTURE_MASK", None) == "threshold"


### PR DESCRIPTION
Modification of the pull request #1272 

[numpy deprecated the np.int and np.float features in v1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and so we need to replace them, because as of version 1.24 it causes exceptions. 

The change to numpy's masked_invalid in v24 also affected the call to sigma_clip in lightcurve.py (also noted in issue #1263), so changed to specify self.flux.data. 

Also modified the targetpixelfile test. There seems to be a behavior change in tesscut so that cutout_size=1 or cutout_size=2 raises an error. Changed to cutout_size=3.