### PR TITLE
Workaround sigma_clip bug with MaskedQuantity

### DIFF
--- a/src/lightkurve/correctors/cbvcorrector.py
+++ b/src/lightkurve/correctors/cbvcorrector.py
@@ -14,6 +14,7 @@ from astropy.time import Time
 from astropy.timeseries import TimeSeries
 from astropy.units import Quantity, Unit, UnitsWarning
 from astropy.utils.decorators import deprecated
+from astropy.utils.masked import Masked
 
 from bs4 import BeautifulSoup
 import matplotlib.pyplot as plt
@@ -1152,11 +1153,12 @@ class CotrendingBasisVectors(TimeSeries):
                 _, ax = plt.subplots(1)
 
             # Plot gaps as NaN
-            timeArray = np.array(self.time.copy().value)
-            try:
-                timeArray[~self.time.value.mask] = np.nan # kepler cbvs are masked arrays and do not support item assignment
-            except:
-                pass
+            # time array is a Masked array so need to fill masks with nans
+            timeArray = self.time.copy().value
+            if isinstance(timeArray, (Masked, np.ma.MaskedArray)):
+                if np.issubdtype(timeArray.dtype, np.int_):
+                    timeArray = timeArray.astype(float)
+                timeArray = timeArray.filled(np.nan)
             timeArray[np.nonzero(self.gap_indicators)[0]] = np.nan
 
             # Get the CBV arrays that were requested

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1378,8 +1378,14 @@ class LightCurve(TimeSeries):
         # First, we create the outlier mask using AstroPy's sigma_clip function
         with warnings.catch_warnings():  # Ignore warnings due to NaNs or Infs
             warnings.simplefilter("ignore")
+            # workaround for https://github.com/astropy/astropy/issues/14360
+            # in passing MaskedQuantity to sigma_clip
+            from astropy.utils.masked import Masked
+            flux = self.flux
+            if isinstance(flux, Masked):
+                flux = flux.filled(np.nan)
             outlier_mask = sigma_clip(
-                data=self.flux.data,
+                data=flux,
                 sigma=sigma,
                 sigma_lower=sigma_lower,
                 sigma_upper=sigma_upper,

--- a/tests/correctors/test_cbvcorrector.py
+++ b/tests/correctors/test_cbvcorrector.py
@@ -378,7 +378,7 @@ def test_CBVCorrector():
     lc_median = np.nanmedian(lc.flux)
     assert_allclose(lc.flux, lc_median)
     ax = cbvCorrector.diagnose()
-    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
+    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes.Axes)
 
     # Now add a strong regularization term and under-fit the data
     lc = cbvCorrector.correct_gaussian_prior(
@@ -405,7 +405,7 @@ def test_CBVCorrector():
     lc_median = np.nanmedian(lc.flux)
     assert_allclose(lc.flux, lc_median, rtol=1e-3)
     ax = cbvCorrector.diagnose()
-    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
+    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes.Axes)
     # Now add a strong regularization term and under-fit the data
     lc = cbvCorrector.correct_elasticnet(
         cbv_type=None, cbv_indices=None, alpha=1e9, l1_ratio=0.5, ext_dm=dm
@@ -456,7 +456,7 @@ def test_CBVCorrector_retrieval():
     # Check that returned lightcurve is in flux units
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
-    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
+    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes.Axes)
 
     # ElasticNet corrections
     lc = cbvCorrector.correct_elasticnet(
@@ -465,7 +465,7 @@ def test_CBVCorrector_retrieval():
     assert isinstance(lc, TessLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
-    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
+    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes.Axes)
 
     # Correction optimizer
     lc = cbvCorrector.correct(
@@ -478,7 +478,7 @@ def test_CBVCorrector_retrieval():
     assert isinstance(lc, TessLightCurve)
     assert lc.flux.unit == u.Unit("electron / second")
     ax = cbvCorrector.diagnose()
-    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes._subplots.Axes)
+    assert len(ax) == 2 and isinstance(ax[0], matplotlib.axes.Axes)
 
     # Goodness metric scan plot
     ax = cbvCorrector.goodness_metric_scan_plot(

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1365,10 +1365,11 @@ def test_fold_v2():
 @pytest.mark.remote_data
 def test_combine_kepler_tess():
     """Can we append or stitch a TESS light curve to a Kepler light curve?"""
-    lc_kplr = search_lightcurve("Kepler-10", mission="Kepler", author="Kepler")[
+    # KIC 11904151: Kepler-10
+    lc_kplr = search_lightcurve("KIC 11904151", mission="Kepler", author="Kepler")[
         0
     ].download()
-    lc_tess = search_lightcurve("Kepler-10", mission="TESS", author="SPOC")[
+    lc_tess = search_lightcurve("KIC 11904151", mission="TESS", author="SPOC")[
         0
     ].download()
     # Can we use append()?

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -104,7 +104,7 @@ def test_search_split_campaigns():
 def test_search_lightcurve(caplog):
     # We should also be able to resolve it by its name instead of KIC ID
     assert (
-        len(search_lightcurve("Kepler-10", mission="Kepler", cadence="long").table)
+        len(search_lightcurve("KIC 11904151", mission="Kepler", cadence="long").table)
         == 15
     )
     # An invalid KIC/EPIC ID or target name should be dealt with gracefully
@@ -215,13 +215,13 @@ def test_search_tesscut_download(caplog):
 @pytest.mark.remote_data
 def test_search_with_skycoord():
     """Can we pass both names, SkyCoord objects, and coordinate strings?"""
-    sr_name = search_targetpixelfile("Kepler-10", mission="Kepler", cadence="long")
+    sr_name = search_targetpixelfile("KIC 11904151", mission="Kepler", cadence="long")
     assert (
         len(sr_name) == 15
     )  # Kepler-10 as observed during 15 quarters in long cadence
     # Can we search using a SkyCoord objects?
     sr_skycoord = search_targetpixelfile(
-        SkyCoord.from_name("Kepler_10"), mission="Kepler", cadence="long"
+        SkyCoord.from_name("KIC 11904151"), mission="Kepler", cadence="long"
     )
     assert_array_equal(
         sr_name.table["productFilename"], sr_skycoord.table["productFilename"]
@@ -249,7 +249,7 @@ def test_search_with_skycoord():
 
 @pytest.mark.remote_data
 def test_searchresult():
-    sr = search_lightcurve("Kepler-10", mission="Kepler")
+    sr = search_lightcurve("KIC 11904151", mission="Kepler")
     assert len(sr) == len(sr.table)  # Tests SearchResult.__len__
     assert len(sr[2:7]) == 5  # Tests SearchResult.__get__
     assert len(sr[2]) == 1
@@ -260,9 +260,9 @@ def test_searchresult():
 @pytest.mark.remote_data
 def test_month():
     # In short cadence, if we specify both quarter and month
-    sr = search_targetpixelfile("Kepler-10", quarter=11, month=1, cadence="short")
+    sr = search_targetpixelfile("KIC 11904151", quarter=11, month=1, cadence="short")
     assert len(sr) == 1
-    sr = search_targetpixelfile("Kepler-10", quarter=11, month=[1, 3], cadence="short")
+    sr = search_targetpixelfile("KIC 11904151", quarter=11, month=[1, 3], cadence="short")
     assert len(sr) == 2
 
 
@@ -370,7 +370,7 @@ def test_corrupt_download_handling_case_empty():
         os.makedirs(expected_dir)
         open(expected_fn, "w").close()  # create "corrupt" i.e. empty file
         with pytest.raises(LightkurveError) as err:
-            search_targetpixelfile("Kepler-10", quarter=4, cadence="long").download(
+            search_targetpixelfile("KIC 11904151", quarter=4, cadence="long").download(
                 download_dir=tmpdirname
             )
         assert "may be corrupt" in err.value.args[0]


### PR DESCRIPTION
A follow up on PR #1279 on the workaround for Astropy `sigma_clip()` issue with `MaskedQuantity` (https://github.com/astropy/astropy/issues/14360).

PR #1279 uses a workaround by providing `self.flux.data` instead of `self.flux` to `sigma_clip()`.

Two potential concerns:
1. `self.flux.data` is an undocumented attribute `.data` for [`Quantity`](https://docs.astropy.org/en/stable/api/astropy.units.quantity.Quantity.html) / [`MaskedQuantity`](https://docs.astropy.org/en/stable/utils/masked/index.html) of type `memoryview` (rather than some array-like type). While it works as-is, it could be error prone to internal changes in Astropy.
2. in the case flux is `MaskedQuantity` (the default type for TESS / Kepler readers), it effectively passed unmasked values to sigma_clip().
In common usage, it is not an issue because the masked values are just NaNs. However, if users deliberately mask specific non-NaN flux values, it'd produce incorrect result (without any error).

The fix here is to convert `MaskedQuantity` to the unmasked version, substituting masked values with NaN explicitly.
