### PR TITLE
Revert column to be Quantity for Kepler/TESS LCs, pre lk v2.1 / Astropy5 behavior

### DIFF
--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import MaskedColumn, Table
 from astropy.time import Time
 from astropy.units import UnitsWarning
 import numpy as np
@@ -47,6 +47,17 @@ def read_generic_lightcurve(
         # out to be addressed at the archive level. (See issue #1216.)
         warnings.simplefilter("ignore", category=UnitsWarning)
         tab = Table.read(hdulist[ext], format="fits")
+
+    # Turn any MaskedColumn into regular Column. Later they will be turned
+    # to regular Quantity.
+    # This is done to avoid the use of MaskedQuantity.
+    #
+    # The logic mimics Astropy's built-in Kepler / TESS reader:
+    # https://github.com/astropy/astropy/blob/6fda4d5dc40e94e8944c2d23ba5a7004be330479/astropy/timeseries/io/kepler.py#L79
+    for colname in tab.colnames:
+        unit = tab[colname].unit
+        if unit and isinstance(tab[colname], MaskedColumn):
+            tab[colname] = tab[colname].filled(np.nan)
 
     # Make sure the meta data also includes header fields from extension #0
     tab.meta.update(hdulist[0].header)


### PR DESCRIPTION
This PR is to make Quantity-like columns for TESS / Kepler lightcurves, e.g., flux, sap_flux, etc. to be `Quantity`, rather than `MaskedQuantity`.

It essentially reverts to the behavior of Lightkurve 2.0.x with Astropy 4.x.
The reason is to avoid various complication with `MaskedQuantity`, most recently errors involving astropy `sigma_clip()` with numpy 1.24

