### PR TITLE
fix test for search lc by name

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -103,8 +103,10 @@ def test_search_split_campaigns():
 @pytest.mark.remote_data
 def test_search_lightcurve(caplog):
     # We should also be able to resolve it by its name instead of KIC ID
+    # The name Kepler-10 somehow no longer works on MAST. So we use 2MASS instead:
+    #   https://simbad.cds.unistra.fr/simbad/sim-id?Ident=%405506010&Name=Kepler-10
     assert (
-        len(search_lightcurve("KIC 11904151", mission="Kepler", cadence="long").table)
+        len(search_lightcurve("2MASS J19024305+5014286", mission="Kepler", cadence="long").table)
         == 15
     )
     # An invalid KIC/EPIC ID or target name should be dealt with gracefully


### PR DESCRIPTION
A further teak on the test fix in fc0cc0bcb81dd89d45f3631ecc45558cb2f46c66 for MAST's Kepler-10 issue.

One of the tests is to test search lc by name, so the fix of using KIC ID inadvertently rendered the test useless. The PR uses a different name.

P.S. Is the Kepler-10 issue someone in MAST (or the underlying name resolution service) should be contacted?  It seems to be specific to Kepler-10 only. I tried 
1. a few other Kepler names (e.g, Kepler-4). They still all work.
2. increase search radius to 2arcmin (`lk.search_lightcurve("Kepler-10", mission="Kepler", radius=120)`) in case somehow the cooridinate of the resolved Kepler-10 has shifted slightly. It still returns nothing.
