### PR TITLE
doc bug fix: ensure tpfs got are from Kepler and TESS.

### DIFF
--- a/docs/source/tutorials/1-getting-started/plotting-target-pixel-files.ipynb
+++ b/docs/source/tutorials/1-getting-started/plotting-target-pixel-files.ipynb
@@ -78,6 +78,7 @@
    },
    "outputs": [],
    "source": [
+    "from astropy import units as u\n",
     "import lightkurve as lk\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
@@ -774,8 +775,8 @@
    },
    "outputs": [],
    "source": [
-    "kep = datalist[6].download()\n",
-    "tes = datalist[15].download()"
+    "kep = datalist[(datalist.author == \"Kepler\") & (datalist.exptime == 60*u.second)][0].download()\n",
+    "tes = datalist[(datalist.author == \"SPOC\") & (datalist.exptime == 120*u.second)][0].download()"
    ]
   },
   {
@@ -941,7 +942,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -955,7 +956,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.9.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed a small bug in plotting tpf tutorial

https://docs.lightkurve.org/tutorials/1-getting-started/plotting-target-pixel-files.html

- It tries to plot a TESS and Kepler lightcurve side by side in cell 20.
- The codes to select TESS / Kepler tpfs no longer work correctly due to changes in MAST query result.
- This PR fixes it, and ensures the codes would work with future changes in MAST query result.


