### PR TITLE
re-adding files from @orionlee #1282 and #1284

### DIFF
--- a/docs/source/tutorials/1-getting-started/plotting-target-pixel-files.ipynb
+++ b/docs/source/tutorials/1-getting-started/plotting-target-pixel-files.ipynb
@@ -78,6 +78,7 @@
    },
    "outputs": [],
    "source": [
+    "from astropy import units as u\n",
     "import lightkurve as lk\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
@@ -774,8 +775,8 @@
    },
    "outputs": [],
    "source": [
-    "kep = datalist[6].download()\n",
-    "tes = datalist[15].download()"
+    "kep = datalist[(datalist.author == \"Kepler\") & (datalist.exptime == 60*u.second)][0].download()\n",
+    "tes = datalist[(datalist.author == \"SPOC\") & (datalist.exptime == 120*u.second)][0].download()"
    ]
   },
   {
@@ -941,7 +942,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -955,7 +956,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.9.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -103,8 +103,10 @@ def test_search_split_campaigns():
 @pytest.mark.remote_data
 def test_search_lightcurve(caplog):
     # We should also be able to resolve it by its name instead of KIC ID
+    # The name Kepler-10 somehow no longer works on MAST. So we use 2MASS instead:
+    #   https://simbad.cds.unistra.fr/simbad/sim-id?Ident=%405506010&Name=Kepler-10
     assert (
-        len(search_lightcurve("KIC 11904151", mission="Kepler", cadence="long").table)
+        len(search_lightcurve("2MASS J19024305+5014286", mission="Kepler", cadence="long").table)
         == 15
     )
     # An invalid KIC/EPIC ID or target name should be dealt with gracefully


### PR DESCRIPTION
Earlier I merged in #1282 and #1284 which had passing tests but they broke our tests due to `poetry`'s v1.4.1 update, `poetry` had updated between the tests passing and me merging. I reverted the changes until I could figure out exactly why they were breaking. I changed our continuous integration in #1289 to make sure that `poetry` is able to install all of our dependencies. Now I'm opening this PR to add the functionality that @orionlee added in #1282 and #1284 back in. Please see those closed PRs for more information on each of these fixes.

Thanks for the hard work @orionlee!