### PR TITLE
added TGLC reader for new HLSP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.4.1dev (unreleased)
 =====================
 
+- Added the ability to open light curves from the TGLC High Level Science Product
 
 2.4.0 (2023-02-14)
 ==================

--- a/docs/source/reference/io.rst
+++ b/docs/source/reference/io.rst
@@ -47,3 +47,4 @@ TESS Data Products
     pathos.read_pathos_lightcurve
     qlp.read_qlp_lightcurve
     tasoc.read_tasoc_lightcurve
+    tglc.read_tglc_lightcurve

--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -1,13 +1,22 @@
 """The .io sub-package provides functions for reading data."""
-from .detect import *
-from .read import *
-
-from . import kepler, tess, qlp, k2sff, everest, pathos, tasoc, kepseismic, eleanor
-from . import cdips
-from .. import LightCurve
-
 from astropy.io import registry
 
+from .. import LightCurve
+from . import (
+    cdips,
+    eleanor,
+    everest,
+    k2sff,
+    kepler,
+    kepseismic,
+    pathos,
+    qlp,
+    tasoc,
+    tess,
+    tglc,
+)
+from .detect import *
+from .read import *
 
 __all__ = ["read", "open"]
 
@@ -22,8 +31,11 @@ try:
     registry.register_reader("k2sff", LightCurve, k2sff.read_k2sff_lightcurve)
     registry.register_reader("everest", LightCurve, everest.read_everest_lightcurve)
     registry.register_reader("pathos", LightCurve, pathos.read_pathos_lightcurve)
-    registry.register_reader('cdips', LightCurve, cdips.read_cdips_lightcurve)
+    registry.register_reader("cdips", LightCurve, cdips.read_cdips_lightcurve)
     registry.register_reader("tasoc", LightCurve, tasoc.read_tasoc_lightcurve)
-    registry.register_reader("kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve)
+    registry.register_reader(
+        "kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve
+    )
+    registry.register_reader("tglc", LightCurve, tglc.read_tglc_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -1,7 +1,6 @@
 """Provides a function to automatically detect Kepler/TESS file types."""
-from astropy.io.fits import HDUList
 from astropy.io import fits
-
+from astropy.io.fits import HDUList
 
 __all__ = ["detect_filetype"]
 
@@ -28,6 +27,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'TASOC'`
         * `'KEPSEISMIC'`
         * `'CDIPS'`
+        * `'TGLC'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -79,7 +79,7 @@ def detect_filetype(hdulist: HDUList) -> str:
 
     # Is it a CDIPS TESS light curve?
     # cf. http://archive.stsci.edu/hlsp/cdips
-    if "cdips" in hdulist[0].header.get("ORIGIN","").lower():
+    if "cdips" in hdulist[0].header.get("ORIGIN", "").lower():
         return "CDIPS"
 
     # Is it a K2VARCAT file?
@@ -113,6 +113,10 @@ def detect_filetype(hdulist: HDUList) -> str:
     # Is it a KEPSEISMIC file?
     if hdulist[0].header.get("ORIGIN") == "CEA & SSI":
         return "KEPSEISMIC"
+
+    # Is it a TGLC file?
+    if hdulist[0].header.get("ORIGIN") == "UCSB/TGLC":
+        return "TGLC"
 
     # Is it an official data product?
     header = hdulist[0].header

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -4,9 +4,9 @@ import logging
 from astropy.io import fits
 from astropy.utils import deprecated
 
-from .detect import detect_filetype
 from ..lightcurve import KeplerLightCurve, TessLightCurve
 from ..utils import LightkurveDeprecationWarning, LightkurveError
+from .detect import detect_filetype
 
 log = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ def read(path_or_url, **kwargs):
         elif filetype == "PATHOS":
             return TessLightCurve.read(path_or_url, format="pathos", **kwargs)
         elif filetype == "CDIPS":
-            return TessLightCurve.read(path_or_url, format='cdips', **kwargs)
+            return TessLightCurve.read(path_or_url, format="cdips", **kwargs)
         elif filetype == "TASOC":
             return TessLightCurve.read(path_or_url, format="tasoc", **kwargs)
         elif filetype == "K2SFF":
@@ -109,13 +109,15 @@ def read(path_or_url, **kwargs):
             return KeplerLightCurve.read(path_or_url, format="everest", **kwargs)
         elif filetype == "KEPSEISMIC":
             return KeplerLightCurve.read(path_or_url, format="kepseismic", **kwargs)
+        elif filetype == "TGLC":
+            return TessLightCurve.read(path_or_url, format="tglc", **kwargs)
     except BaseException as exc:
         # ensure path_or_url is in the error
         raise LightkurveError(
             f"Error in reading Data product {path_or_url} of type {filetype} .\n"
             "This file may be corrupt due to an interrupted download. "
             "Please remove it from your disk and try again."
-            ) from exc
+        ) from exc
 
     # Official data products;
     # if the filetype is recognized, instantiate a class of that name
@@ -124,7 +126,8 @@ def read(path_or_url, **kwargs):
             return getattr(__import__("lightkurve"), filetype)(path_or_url, **kwargs)
         except AttributeError as exc:
             raise LightkurveError(
-                f"Data product f{path_or_url} of type {filetype} is not supported " "in this version of Lightkurve."
+                f"Data product f{path_or_url} of type {filetype} is not supported "
+                "in this version of Lightkurve."
             ) from exc
     else:
         # if these keywords don't exist, raise `ValueError`

--- a/src/lightkurve/io/tglc.py
+++ b/src/lightkurve/io/tglc.py
@@ -19,9 +19,9 @@ def read_tglc_lightcurve(
     provided by this HLSP.
 
     Note this reader does not use the TGLC_FLAG extension to inform the bitmask for the
-    returned light curve, but can still be accessed.
+    returned light curve, but those flags can still be accessed.
 
-    More information on eleanor: https://archive.stsci.edu/hlsp/tglc
+    More information on TGLC: https://archive.stsci.edu/hlsp/tglc
 
     Parameters
     ----------

--- a/src/lightkurve/io/tglc.py
+++ b/src/lightkurve/io/tglc.py
@@ -1,0 +1,96 @@
+"""Reader for TGLC light curve files.
+Details can be found at https://archive.stsci.edu/hlsp/tglc
+"""
+import numpy as np
+from astropy import units as u
+
+from ..lightcurve import TessLightCurve
+from ..utils import TessQualityFlags
+from .generic import read_generic_lightcurve
+
+
+def read_tglc_lightcurve(
+    filename, flux_column="cal_psf_flux", quality_bitmask="default"
+):
+    """Returns a `~lightkurve.lightcurve.LightCurve` object given a light curve file from
+    TGLC HLSP
+
+    By default, TGLC's `cal_psf_flux` values are used for the `flux` column. No errors are
+    provided by this HLSP.
+
+    Note this reader does not use the TGLC_FLAG extension to inform the bitmask for the
+    returned light curve, but can still be accessed.
+
+    More information on eleanor: https://archive.stsci.edu/hlsp/tglc
+
+    Parameters
+    ----------
+    filename : str
+        Local path or remote url of a TGLC light curve FITS file.
+    flux_column : 'CAL_PSF_FLUX', 'CAL_APER_FLUX', 'PSF_FLUX', or 'APERTURE_FLUX'
+        Which column in the FITS file contains the preferred flux data?
+        By default the "Corrected PSF Flux" flux (CAL_PSF_FLUX) is used.
+    quality_bitmask : str or int
+        Bitmask (integer) which identifies the quality flag bitmask that should
+        be used to mask out bad cadences. If a string is passed, it has the
+        following meaning:
+            * "none": no cadences will be ignored (`quality_bitmask=0`).
+            * "default": cadences with flags indicating AttitudeTweak, SafeMode, CoarsePoint, EarthPoint, Desat, or
+              ManualExclude will be ignored.
+            * "hard": cadences with default flags, ApertureCosmic, CollateralCosmic, Straylight, or Straylight2 will be
+              ignored.
+            * "hardest": cadences with all the above flags will be ignored, in addition to cadences with GSFC-ELEANOR-LITE
+              bit flags of 17 (decimal value 131072) and 18 (decimal value 262144).
+    """
+
+    lc = read_generic_lightcurve(
+        filename,
+        time_column="time",
+        flux_column=flux_column.lower(),
+        quality_column="tess_flags",
+        cadenceno_column="cadence_num",
+        time_format="btjd",
+    )
+
+    quality_mask = TessQualityFlags.create_quality_mask(
+        quality_array=lc["quality"], bitmask=quality_bitmask
+    )
+
+    # TGLC FITS file do not have units specified. re-add them.
+    for colname in ["psf_flux", "aperture_flux", "background"]:
+        if colname in lc.colnames:
+            if lc[colname].unit is not None:
+                # for case flux, flux_err, lightkurve has forced it to be u.dimensionless_unscaled
+                # can't reset a unit, so we create a new column
+                lc[colname] = u.Quantity(
+                    lc[colname].value, "electron/s", dtype=np.float32
+                )
+            else:
+                lc[colname].unit = "electron/s"
+
+    # Calibrated columns are normalized, so they are unitless
+    for colname in ["cal_psf_flux", "cal_aper_flux"]:
+        if colname in lc.colnames:
+            if lc[colname].unit is not None:
+                # for case flux, flux_err, lightkurve has forced it to be u.dimensionless_unscaled
+                # can't reset a unit, so we create a new column
+                lc[colname] = u.Quantity(lc[colname].value, "", dtype=np.float32)
+            else:
+                lc[colname].unit = ""
+
+    lc = lc[quality_mask]
+    lc.meta["AUTHOR"] = "TGLC"
+    lc.meta["TARGETID"] = lc.meta.get("OBJECT")
+    lc.meta["QUALITY_BITMASK"] = quality_bitmask
+    lc.meta["QUALITY_MASK"] = quality_mask
+    lc.meta["NORMALIZED"] = True
+    tic = lc.meta.get("TICID")
+    if tic is not None:
+        tic = int(tic)
+        # compatibility with SPOC, QLP, etc.
+        lc.meta["TARGETID"] = tic
+        lc.meta["TICID"] = tic
+        lc.meta["OBJECT"] = f"TIC {tic}"
+        # for Lightkurve's plotting methods
+        lc.meta["LABEL"] = f"TIC {tic}"
+    return TessLightCurve(data=lc)

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -1,28 +1,32 @@
 """Defines tools to retrieve Kepler data from the archive at MAST."""
 from __future__ import division
-import os
+
 import glob
 import logging
+import os
 import re
 import warnings
-from requests import HTTPError
 
-from memoization import cached
 import numpy as np
-from astropy.table import join, Table, Row
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii
-from astropy import units as u
-from astropy.utils import deprecated
+from astropy.table import Row, Table, join
 from astropy.time import Time
+from astropy.utils import deprecated
+from memoization import cached
+from requests import HTTPError
 
-from .targetpixelfile import TargetPixelFile
-from .collections import TargetPixelFileCollection, LightCurveCollection
-from .utils import LightkurveError, suppress_stdout, LightkurveWarning, LightkurveDeprecationWarning
+from . import PACKAGEDIR, conf, config
+from .collections import LightCurveCollection, TargetPixelFileCollection
 from .io import read
-from . import conf
-from . import config
-from . import PACKAGEDIR
+from .targetpixelfile import TargetPixelFile
+from .utils import (
+    LightkurveDeprecationWarning,
+    LightkurveError,
+    LightkurveWarning,
+    suppress_stdout,
+)
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +53,7 @@ AUTHOR_LINKS = {
     "EVEREST": "https://archive.stsci.edu/hlsp/everest",
     "TESScut": "https://mast.stsci.edu/tesscut/",
     "GSFC-ELEANOR-LITE": "https://archive.stsci.edu/hlsp/gsfc-eleanor-lite",
+    "TGLC": "https://archive.stsci.edu/hlsp/tglc",
 }
 
 REPR_COLUMNS_BASE = [
@@ -188,9 +193,12 @@ class SearchResult(object):
                 if p_ids == "N/A" or (not isinstance(p_ids, str)):
                     continue
                 # e.g., handle cases with multiple proposals, e.g.,  G12345_G67890
-                p_id_links = [f"""\
+                p_id_links = [
+                    f"""\
 <a href='{to_tess_gi_url(p_id)}'>{p_id}</a>\
-""" for p_id in p_ids.split("_")]
+"""
+                    for p_id in p_ids.split("_")
+                ]
                 out = out.replace(f">{p_ids}<", f">{' , '.join(p_id_links)}<")
         return out
 
@@ -339,6 +347,7 @@ class SearchResult(object):
                 log.debug("File found in local cache.")
             else:
                 from astroquery.mast import Observations
+
                 download_url = table[:1]["dataURL"][0]
                 log.debug("Started downloading {}.".format(download_url))
                 download_response = Observations.download_products(
@@ -348,7 +357,7 @@ class SearchResult(object):
                     raise LightkurveError(
                         f"Download of {download_url} failed. "
                         f"MAST returns {download_response['Status']}: {download_response['Message']}"
-                        )
+                    )
                 path = download_response["Local Path"]
                 log.debug("Finished downloading.")
             return read(path, quality_bitmask=quality_bitmask, **kwargs)
@@ -1023,7 +1032,7 @@ def _search_products(
             # K2 campaigns 9, 10, and 11 were split into two sections, which are
             # listed separately in the table with suffixes "a" and "b"
             if obs_project == "K2" and result["sequence_number"][idx] in [9, 10, 11]:
-                for half,letter in zip([1,2],['a','b']):
+                for half, letter in zip([1, 2], ["a", "b"]):
                     if f"c{tmp_seqno}{half}" in result["productFilename"][idx]:
                         obs_seqno = f"{int(tmp_seqno):02d}{letter}"
             result["mission"][idx] = "{} {} {}".format(
@@ -1126,8 +1135,8 @@ def _query_mast(
         Table detailing the available observations on MAST.
     """
     # Local astroquery import because the package is not used elsewhere
+    from astroquery.exceptions import NoResultsWarning, ResolverError
     from astroquery.mast import Observations
-    from astroquery.exceptions import ResolverError, NoResultsWarning
 
     # If passed a SkyCoord, convert it to an "ra, dec" string for MAST
     if isinstance(target, SkyCoord):

--- a/tests/io/test_tglc.py
+++ b/tests/io/test_tglc.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+from astropy.io import fits
+from numpy.testing import assert_array_equal
+
+from lightkurve import search_lightcurve
+from lightkurve.io.detect import detect_filetype
+from lightkurve.io.tglc import read_tglc_lightcurve
+
+
+@pytest.mark.remote_data
+def test_gsfc_eleanor_lite():
+    """Can we read in TGLC light curves?"""
+    url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/tglc/s0001/cam4-ccd2/0046/2474/2688/9442/hlsp_tglc_tess_ffi_gaiaid-4624742688944261376-s0001-cam4-ccd2_tess_v1_llc.fits"
+    with fits.open(url, mode="readonly") as hdulist:
+        # Can we auto-detect a GSFC-ELEANOR-LITE file?
+        assert detect_filetype(hdulist) == "TGLC"
+        # Are the correct fluxes read in?
+        lc = read_tglc_lightcurve(url, quality_bitmask=0)
+        assert lc.meta["AUTHOR"] == "TGLC"
+        assert lc.meta["FLUX_ORIGIN"] == "cal_psf_flux"
+        assert_array_equal(lc.flux.value, hdulist[1].data["cal_psf_flux"])
+        assert np.issubdtype(lc["cadenceno"].dtype, np.integer)
+
+
+@pytest.mark.remote_data
+def test_search_tglc():
+    """Can we search and download a TGLC light curve?"""
+    # Try an early campaign
+    search = search_lightcurve("TIC 140898436", author="TGLC", sector=1, mission="TESS")
+    assert len(search) == 1
+    assert search.table["author"][0] == "TGLC"
+    lc = search.download()
+    assert type(lc).__name__ == "TessLightCurve"
+    assert lc.targetid == 140898436
+    assert lc.sector == 1
+    assert lc.camera == 4
+    assert lc.ccd == 2

--- a/tests/io/test_tglc.py
+++ b/tests/io/test_tglc.py
@@ -9,11 +9,11 @@ from lightkurve.io.tglc import read_tglc_lightcurve
 
 
 @pytest.mark.remote_data
-def test_gsfc_eleanor_lite():
+def test_tglc():
     """Can we read in TGLC light curves?"""
     url = "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/tglc/s0001/cam4-ccd2/0046/2474/2688/9442/hlsp_tglc_tess_ffi_gaiaid-4624742688944261376-s0001-cam4-ccd2_tess_v1_llc.fits"
     with fits.open(url, mode="readonly") as hdulist:
-        # Can we auto-detect a GSFC-ELEANOR-LITE file?
+        # Can we auto-detect a TGLC file?
         assert detect_filetype(hdulist) == "TGLC"
         # Are the correct fluxes read in?
         lc = read_tglc_lightcurve(url, quality_bitmask=0)


### PR DESCRIPTION
#1286 has pointed out that the new [TGLC HLSP](https://archive.stsci.edu/hlsp/tglc) can not be read in by `Lightkurve`, and will break the `download_all` function if there is a TGLC light curve in the search result. This PR adds the functionality to read in the `TGLC` light curves and checks they do not break searches. 

Note TGLC does not provide errors, but this is the case for other HLSPs we allow (e.g. K2SFF)

I've use the `cal_psf_flux` as the default flux here, as this seems to be their key data product. They also provide calibrated aperture flux as an option which can be obtained using
`lc.select_flux('cal_psf_flux')`