### PR TITLE
WCS plotting

### DIFF
--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1155,8 +1155,8 @@ class TargetPixelFile(object):
             #If an axes is passed that used WCS projection, don't use img_extent
             #This addresses lk issue #1095, where the tpf was incorrectly plotted
             try: 
-            	if hasattr(ax, "wcs"):
-            		img_extent = None
+                if hasattr(ax, "wcs"):
+                    img_extent = None
             except NameError:
             	pass
 

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1172,8 +1172,7 @@ class TargetPixelFile(object):
             )
             ax.grid(False)
             
-            #if not hasattr(ax, "wcs"):
-            #Make sure the ticks show integer values for col/row
+            # Make sure the ticks show integer values for col/row
             ax.yaxis.get_major_locator().set_params(integer=True) 
             ax.xaxis.get_major_locator().set_params(integer=True) 
 
@@ -1184,7 +1183,7 @@ class TargetPixelFile(object):
                 for j in range(self.shape[2]):
                     if aperture_mask[i, j]:
                         if hasattr(ax, "wcs"):
-                            #When using WCS coordinates, do not add col/row to mask coords
+                            # When using WCS coordinates, do not add col/row to mask coords
                     	    xy = (j - 0.5, i - 0.5)
                         else:
                     	    xy = (j + self.column - 0.5, i + self.row - 0.5)

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1153,12 +1153,13 @@ class TargetPixelFile(object):
             )
             
             #If an axes is passed that used WCS projection, don't use img_extent
-            #This addresses lk issue #1095
+            #This addresses lk issue #1095, where the tpf was incorrectly plotted
             try: 
             	if hasattr(ax, "wcs"):
             		img_extent = None
             except NameError:
             	pass
+
             	
             ax = plot_image(
                 data_to_plot,
@@ -1170,6 +1171,11 @@ class TargetPixelFile(object):
                 **kwargs,
             )
             ax.grid(False)
+            
+            #if not hasattr(ax, "wcs"):
+            #Make sure the ticks show integer values for col/row
+            ax.yaxis.get_major_locator().set_params(integer=True) 
+            ax.xaxis.get_major_locator().set_params(integer=True) 
 
         # Overlay the aperture mask if given
         if aperture_mask is not None:
@@ -1177,8 +1183,13 @@ class TargetPixelFile(object):
             for i in range(self.shape[1]):
                 for j in range(self.shape[2]):
                     if aperture_mask[i, j]:
+                        if hasattr(ax, "wcs"):
+                            #When using WCS coordinates, do not add col/row to mask coords
+                    	    xy = (j - 0.5, i - 0.5)
+                        else:
+                    	    xy = (j + self.column - 0.5, i + self.row - 0.5)
                         rect = patches.Rectangle(
-                            xy=(j + self.column - 0.5, i + self.row - 0.5),
+                            xy=xy,
                             width=1,
                             height=1,
                             color=mask_color,

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1152,13 +1152,14 @@ class TargetPixelFile(object):
                 self.row + self.shape[1] - 0.5,
             )
             
-            #If an axes is passed that used WCS projection, don't use img_extent
-            #This addresses lk issue #1095, where the tpf was incorrectly plotted
-            try: 
+            # If an axes is passed that used WCS projection, don't use img_extent
+            # This addresses lk issue #1095, where the tpf coordinates were incorrectly plotted
+            
+            # By default ax=None
+            if ax != None:
                 if hasattr(ax, "wcs"):
                     img_extent = None
-            except NameError:
-            	pass
+
 
             	
             ax = plot_image(
@@ -1172,9 +1173,6 @@ class TargetPixelFile(object):
             )
             ax.grid(False)
             
-            # Make sure the ticks show integer values for col/row
-            ax.yaxis.get_major_locator().set_params(integer=True) 
-            ax.xaxis.get_major_locator().set_params(integer=True) 
 
         # Overlay the aperture mask if given
         if aperture_mask is not None:

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1142,6 +1142,7 @@ class TargetPixelFile(object):
                 title = "Target ID: {}, Cadence: {}".format(
                     self.targetid, self.cadenceno[frame]
                 )
+            
             # We subtract -0.5 because pixel coordinates refer to the middle of
             # a pixel, e.g. (col, row) = (10.0, 20.0) is a pixel center.
             img_extent = (
@@ -1150,6 +1151,15 @@ class TargetPixelFile(object):
                 self.row - 0.5,
                 self.row + self.shape[1] - 0.5,
             )
+            
+            #If an axes is passed that used WCS projection, don't use img_extent
+            #This addresses lk issue #1095
+            try: 
+            	if hasattr(ax, "wcs"):
+            		img_extent = None
+            except NameError:
+            	pass
+            	
             ax = plot_image(
                 data_to_plot,
                 ax=ax,


### PR DESCRIPTION
This addresses lightkurve issue #1095. When providing an axes with WCS coordinates, TPFs were plotted incorrectly. This is because the img_extent keyword, which was set to display the appropriate row and pixel values, also modified the plotted WCS coordinates. The displayed coordinates no longer were correct for the target star. The aperture mask plotting also needed to be changed to account for whether or not the column/row values were used for the axes.  