### PR TITLE
Ensure FITS filestream is closed on generic read

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,6 @@ testpaths = [
     "tests",
     "src",
 ]
+filterwarnings = [
+    "error::ResourceWarning",
+]

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -1,6 +1,7 @@
 """Read a generic FITS table containing a light curve."""
 import logging
 import warnings
+from copy import deepcopy
 
 from astropy.io import fits
 from astropy.table import Table
@@ -34,7 +35,8 @@ def read_generic_lightcurve(
     if isinstance(filename, fits.HDUList):
         hdulist = filename  # Allow HDUList to be passed
     else:
-        hdulist = fits.open(filename)
+        with fits.open(filename) as hdulist:
+            hdulist = deepcopy(hdulist)
 
     # Raise an exception if the requested extension is invalid
     if isinstance(ext, str):

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -615,7 +615,7 @@ class LightCurve(TimeSeries):
     )
     def hdu(self):
         with fits.open(self.filename) as hdulist:
-            hdulist = deepcopy(hdulist)
+            hdulist = hdulist.copy()
         return hdulist
 
     @property

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -614,7 +614,9 @@ class LightCurve(TimeSeries):
         warning_type=LightkurveDeprecationWarning,
     )
     def hdu(self):
-        return fits.open(self.filename)
+        with fits.open(self.filename) as hdulist:
+            hdulist = deepcopy(hdulist)
+        return hdulist
 
     @property
     @deprecated("2.0", warning_type=LightkurveDeprecationWarning)

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -102,7 +102,8 @@ class TargetPixelFile(object):
         if isinstance(path, fits.HDUList):
             self.hdu = path
         else:
-            self.hdu = fits.open(self.path, **kwargs)
+            with fits.open(self.path, **kwargs) as hdulist:
+                self.hdu = deepcopy(hdulist)
         self.quality_bitmask = quality_bitmask
         self.targetid = targetid
 
@@ -1653,7 +1654,8 @@ class TargetPixelFile(object):
             elif isinstance(img, fits.HDUList):
                 hdu = img[extension]
             else:
-                hdu = fits.open(img)[extension]
+                with fits.open(img) as hdulist:
+                    hdu = deepcopy(hdulist[extension])
             return hdu
 
         # Define a helper function to cutout images if not None

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1655,7 +1655,7 @@ class TargetPixelFile(object):
                 hdu = img[extension]
             else:
                 with fits.open(img) as hdulist:
-                    hdu = deepcopy(hdulist[extension])
+                    hdu = hdulist[extension].copy()
             return hdu
 
         # Define a helper function to cutout images if not None


### PR DESCRIPTION
The generic light curve reader opens FITS files to determine how to parse the contents. The call to `fits.open` leaves a file stream open, which can prevent later and/or downstream calls from opening that same file. This workaround ensures the filestream is closed, and simply makes a copy of the list `hdulist`.