### PR TITLE
Fixing invalid escape sequences in docstrings

### DIFF
--- a/src/lightkurve/correctors/regressioncorrector.py
+++ b/src/lightkurve/correctors/regressioncorrector.py
@@ -29,17 +29,17 @@ log = logging.getLogger(__name__)
 
 
 class RegressionCorrector(Corrector):
-    """Remove noise using linear regression against a `.DesignMatrix`.
+    r"""Remove noise using linear regression against a `.DesignMatrix`.
 
     .. math::
 
-        \\newcommand{\\y}{\\mathbf{y}}
-        \\newcommand{\\cov}{\\boldsymbol\Sigma_\y}
-        \\newcommand{\\w}{\\mathbf{w}}
-        \\newcommand{\\covw}{\\boldsymbol\Sigma_\w}
-        \\newcommand{\\muw}{\\boldsymbol\mu_\w}
-        \\newcommand{\\sigw}{\\boldsymbol\sigma_\w}
-        \\newcommand{\\varw}{\\boldsymbol\sigma^2_\w}
+        \newcommand{\y}{\mathbf{y}}
+        \newcommand{\cov}{\boldsymbol\Sigma_\y}
+        \newcommand{\w}{\mathbf{w}}
+        \newcommand{\covw}{\boldsymbol\Sigma_\w}
+        \newcommand{\muw}{\boldsymbol\mu_\w}
+        \newcommand{\sigw}{\boldsymbol\sigma_\w}
+        \newcommand{\varw}{\boldsymbol\sigma^2_\w}
 
     Given a column vector of data :math:`\y`
     and a design matrix of regressors :math:`X`,

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1194,7 +1194,7 @@ class LightCurve(TimeSeries):
         return self[~np.isnan(self[column])]  # This will return a sliced copy
 
     def fill_gaps(self, method: str = "gaussian_noise"):
-        """Fill in gaps in time.
+        r"""Fill in gaps in time.
 
         By default, the gaps will be filled with random white Gaussian noise
         distributed according to
@@ -2750,12 +2750,12 @@ class LightCurve(TimeSeries):
                 if bin_points == 1:
                     cbar.set_label(
                         "Flux in units of Standard Deviation "
-                        "$(f - \overline{f})/(\sigma_f)$"
+                        r"$(f - \overline{f})/(\sigma_f)$"
                     )
                 else:
                     cbar.set_label(
                         "Average Flux in Bin in units of Standard Deviation "
-                        "$(f - \overline{f})/(\sigma_f)$"
+                        r"$(f - \overline{f})/(\sigma_f)$"
                     )
 
             ax.set_xlabel("Phase")
@@ -3384,8 +3384,8 @@ def _boolean_mask_to_bitmask(aperture_mask):
         out_mask = aperture_mask.astype(np.uint8)
     else:
         log.warn(
-            "The input aperture mask must be boolean or follow the \
-                Kepler-pipeline standard; returning None."
+            "The input aperture mask must be boolean or follow the "
+            "Kepler-pipeline standard; returning None."
         )
         out_mask = None
     return out_mask

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -1158,15 +1158,15 @@ def _query_mast(
     exact_target_name = None
     target_lower = str(target).lower()
     # Was a Kepler target ID passed?
-    kplr_match = re.match("^(kplr|kic) ?(\d+)$", target_lower)
+    kplr_match = re.match(r"^(kplr|kic) ?(\d+)$", target_lower)
     if kplr_match:
         exact_target_name = f"kplr{kplr_match.group(2).zfill(9)}"
     # Was a K2 target ID passed?
-    ktwo_match = re.match("^(ktwo|epic) ?(\d+)$", target_lower)
+    ktwo_match = re.match(r"^(ktwo|epic) ?(\d+)$", target_lower)
     if ktwo_match:
         exact_target_name = f"ktwo{ktwo_match.group(2).zfill(9)}"
     # Was a TESS target ID passed?
-    tess_match = re.match("^(tess|tic) ?(\d+)$", target_lower)
+    tess_match = re.match(r"^(tess|tic) ?(\d+)$", target_lower)
     if tess_match:
         exact_target_name = f"{tess_match.group(2).zfill(9)}"
 


### PR DESCRIPTION
This PR squashes some of the simplest warnings that are emitted when running the tests.

Fixes #1303 (to some extent)