### PR TITLE
Improve install instructions in the readme and developer docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,42 @@ Documentation
 Read the documentation at `https://docs.lightkurve.org <https://docs.lightkurve.org>`_.
 
 
-Quickstart
-----------
+Quickstart and Installation
+---------------------------
 
-Please visit our quickstart guide at `https://docs.lightkurve.org/quickstart.html <https://docs.lightkurve.org/quickstart.html>`_.
+Please visit our quickstart guide at `https://docs.lightkurve.org/quickstart.html <https://docs.lightkurve.org/quickstart.html>`_. 
+
+The easiest way to install *Lightkurve* and all of its dependencies is to use the ``pip`` command,
+which is a standard part of all Python distributions.
+To install *Lightkurve*, run the following command in a terminal window::
+
+    $ python -m pip install lightkurve --upgrade
+
+The ``--upgrade`` flag is optional, but recommended if you already
+have *Lightkurve* installed and want to upgrade to the latest version.
+
+Depending on the specific Python environment, you may need to replace ``python``
+with the correct Python interpreter, e.g., ``python3``.
+
+If you want to experiment with the latest development version of
+*Lightkurve*, you can install it straight from the main branch on GitHub:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/lightkurve/lightkurve.git
+    $ cd lightkurve
+    $ python -m pip install .
+
+If you want to have a so-called editable install which enables the installed
+version to immediately reflect changes made in the source tree, you can use:
+
+.. code-block:: bash
+
+    $ python -m pip install poetry
+    $ poetry install
+
+Please see our guide on `https://docs.lightkurve.org/development/index.html <https://docs.lightkurve.org/development/index.html>`_.
+for additional instructions.
 
 
 Contributing

--- a/docs/source/development/documentation.rst
+++ b/docs/source/development/documentation.rst
@@ -24,22 +24,26 @@ Building the *lightkurve* documentation requires `sphinx` and a few extra packag
 
     $ poetry install
 
-To build the documentation in HTML format, execute::
+To make a clean directory for the docs use::
 
     $ cd docs
     $ make clean
+
+To build the documentation in HTML format, execute::
+
+    $ cd docs
     $ make html
 
-This will save the documentation website in the ``../../lightkurve-docs`` directory
-on your system.  The notebook-based tutorials will not be recompiled by default
-because they take some time to build.  To recompile the notebooks, type::
+Note if you build the documentation after cleaning the directory this will compile the notebooks, which can take a significant amount of time (over 30 minutes). This will save the documentation website in the ``../../lightkurve-docs`` directory
+on your system.  If you re-run the `make html` command the notebook-based tutorials will not be recompiled by default
+because they take some time to build.  To recompile the just the notebooks, type::
 
-    make notebooks
+    $ make notebooks
 
 Finally, if you have write permission to *lightkurve*'s GitHub repository,
 you can upload the documentation to the web server using::
 
-    make upload
+    $ make upload
 
 .. note::
 
@@ -54,6 +58,10 @@ you can upload the documentation to the web server using::
 
 .. note::
     
-    To build the docs on a Mac you may have to install the Xcode Command Line Tools, which you can do using
+    To build the docs on a Mac you may have to install the Xcode Command Line Tools, which you can do using::
 
         $ xcode-select --install
+    
+
+
+

--- a/docs/source/development/documentation.rst
+++ b/docs/source/development/documentation.rst
@@ -24,17 +24,6 @@ Building the *lightkurve* documentation requires `sphinx` and a few extra packag
 
     $ poetry install
 
-.. note::
-
-    If you encounter the error ``Pandoc wasn't found``, you will have to install ``pandoc`` separately as well following its `installation instruction <https://pandoc.org/installing.html>`_  .
-    For example, on Mac OS you can install ``pandoc`` using ``homebrew``::
-
-        $ brew install pandoc
-
-    An alternative method is to install pandoc using ``conda``::
-
-        $ conda install --channel=conda-forge pandoc
-
 To build the documentation in HTML format, execute::
 
     $ cd docs
@@ -51,3 +40,20 @@ Finally, if you have write permission to *lightkurve*'s GitHub repository,
 you can upload the documentation to the web server using::
 
     make upload
+
+.. note::
+
+    If you encounter the error ``Pandoc wasn't found``, you will have to install ``pandoc`` separately as well following its `installation instruction <https://pandoc.org/installing.html>`_  .
+    For example, on Mac OS you can install ``pandoc`` using ``homebrew``::
+
+        $ brew install pandoc
+
+    An alternative method is to install pandoc using ``conda``::
+
+        $ conda install --channel=conda-forge pandoc
+
+.. note::
+    
+    To build the docs on a Mac you may have to install the Xcode Command Line Tools, which you can do using
+
+        $ xcode-select --install

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -3,7 +3,7 @@
 Developing for Lightkurve
 =========================
 
-Lightkurve is an open-source, community driven package. We strongly encourage users to contribute and develop new features for Lightkurve. These pages first discuss the vision of Lightkurve, and then how to contribute Pull Requests on github for new features. These pages also discuss how to compile our documentation (including this page!) and how we release a new version of Lightkurve.
+Lightkurve is an open-source, community driven package. We strongly encourage users to contribute and develop new features for Lightkurve. These pages first discuss the vision of Lightkurve, and then how to contribute Pull Requests on github for new features. These pages also discuss how to compile our documentation (including this page!) and how we release a new version of Lightkurve. Use the menu bar on the left to scroll through the docs or click below.
 
 Developer documentation
 -----------------------
@@ -16,3 +16,115 @@ Developer documentation
     testing.rst
     documentation.rst
     release-procedure.rst
+
+Setting up a Development Environment
+====================================
+
+To set up a development environment for Lightkurve you can follow the steps below.
+
+1. Fork Lightkurve's GitHub repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The first step is to create a copy of Lightkurve's GitHub repository by logging into GitHub, browsing to
+`https://github.com/lightkurve/lightkurve <https://github.com/lightkurve/lightkurve>`_,
+and clicking the ``Fork`` button in the top right corner.
+
+2. Clone the fork to your computer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Head to a local directory of your choice and download your fork:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/YOUR-GITHUB-USERNAME/lightkurve.git
+
+
+.. _install-dev-env:
+
+3. Install the development environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lightkurve uses the `poetry <https://python-poetry.org/>`_ package to create an isolated development
+environment which you can use to modify and test changes to the source code without interfering with
+your existing Python environment.
+
+You can set up the environment as follows:
+
+.. code-block:: bash
+
+    $ cd lightkurve
+    $ python -m pip install poetry
+    $ poetry install
+
+A key advantage of the development environment is that any changes you make to the Lightkurve source
+code will be reflected right away, i.e., there is no need to re-install Lightkurve or the environment
+after every change.
+
+To run code in the development environment, you will need to prefix every Python command with
+`poetry run`. For example:
+
+.. code-block:: bash
+
+    $ poetry run python YOUR-SCRIPT.py
+    $ poetry run jupyter notebook
+    $ poetry run pytest  # runs all the unit tests
+
+You can find more details on the `poetry website <https://python-poetry.org/>`_,
+and you can find additional examples of tasks developers commonly execute in the development
+environment in Lightkurve's `Makefile <https://github.com/lightkurve/lightkurve/blob/main/Makefile>`_.
+
+.. note::
+
+    The use of `poetry` is not required to prepare and propose modifications to Lightkurve.
+    If you wish to do so, you can install the development version in your current
+    Python environment as follows:
+
+    .. code-block:: bash
+
+        $ cd lightkurve
+        $ python -m pip install .
+
+    In this scenario, you will have to re-run `pip install .` every time you make changes
+    to the source code.
+
+    To avoid this extra step, you have the option of creating a symbolic
+    link from your environment's `site-packages` directory to the lightkurve source code tree
+    as follows:
+
+    .. code-block:: bash
+
+        $ python -m pip uninstall lightkurve
+        $ python -m pip install --editable .  # creates the symbolic link
+
+    This "editable install" method requires `pip` version `21.3` or higher.
+    While this method of installing Lightkurve is not usually recommended, it can be useful
+    when you wish to modify and test multiple different packages in a single environment.
+
+
+4. Add a link to the main repository to your git environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To be able to pull in any recent changes, we need to tell your copy of lightkurve
+where the upstream repository is located:
+
+.. code-block:: bash
+
+    $ git remote add upstream https://github.com/lightkurve/lightkurve.git
+
+To verify that everything is setup correctly, execute:
+
+.. code-block:: bash
+
+    $ git remote -v
+
+You should see something like this:
+
+.. code-block:: bash
+
+    origin	https://github.com/YOUR-GITHUB-USERNAME/lightkurve.git (fetch)
+    origin	https://github.com/YOUR-GITHUB-USERNAME/lightkurve.git (push)
+    upstream	https://github.com/lightkurve/lightkurve.git (fetch)
+    upstream	https://github.com/lightkurve/lightkurve.git (push)
+
+
+


### PR DESCRIPTION
Our readme was missing install instructions and it's hard to find the development environment install instructions, so I have added them on the landing page of the development docs. 