### PR TITLE
Updating GitHub workflow triggers

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -11,7 +11,13 @@
 
 name: Lightkurve-tests
 
-on: [push, pull_request]
+on:
+  # We always want to run tests on main
+  push:
+    branches:
+      - main
+  # And we'll also run tests on pull requests
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
Right now, when a new branch is created on the `lightkurve/lightkurve` repo, the tests are automatically run on GitHub Actions, but they _also_ get run when a PR from that branch gets opened. This means that the same tests are run twice. This shouldn't affect most users, but @dependabot does create branches on this repo, so it's tests get doubled up. This PR will fix that, but not change things for other users.