### PR TITLE
Add a `PeriodogramCollection` object

### DIFF
--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -383,7 +383,7 @@ class Periodogram(object):
             ax.set_title(title)
         return ax
 
-    def flatten(self, method="logmedian", filter_width=0.01):
+    def flatten(self, method="logmedian", filter_width=0.1):
         """Estimates the Signal-To-Noise (SNR) spectrum by dividing out an
         estimate of the noise background.
 
@@ -629,7 +629,7 @@ class SNRPeriodogram(Periodogram):
         self.bkg.plot(ax=ax, scale='log', label='Background',
                     lw = 2)
         ax.set_title(f'Method: {self.bkg.meta["FLAT_METHOD"]}, ' +  
-                     f'filter width {self.bkg.meta["FLAT_FILT_WIDTH"]}.')
+                     f'filter width {self.bkg.meta["FLAT_FILT_WIDTH"]}')
     
         return ax
 

--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -600,8 +600,13 @@ class SNRPeriodogram(Periodogram):
     """
 
     def __init__(self, *args, **kwargs):
-        super(SNRPeriodogram, self).__init__(args[0], args[1], **kwargs)
-        self.background = args[2]
+        super(SNRPeriodogram, self).__init__(*args[:2], **kwargs)
+        
+        # Check if the SNRPeriodogram was initiated with its background
+        if len(args) == 3:
+            self.background = args[2]
+        else:
+            self.background = None
 
     def __repr__(self):
         return "SNRPeriodogram(ID: {})".format(self.label)
@@ -622,6 +627,11 @@ class SNRPeriodogram(Periodogram):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
+        if self.background == None:
+            raise ValueError("This SNRPeriodogram was initiated without the removed " +
+                            "background trend, so it can't be viewed.")
+            
+
         pg = self * self.background.power.value
         pg.power *= 1 * self.background.power.unit
 

--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -601,7 +601,7 @@ class SNRPeriodogram(Periodogram):
 
     def __init__(self, *args, **kwargs):
         super(SNRPeriodogram, self).__init__(args[0], args[1], **kwargs)
-        self.bkg = args[2]
+        self.background = args[2]
 
     def __repr__(self):
         return "SNRPeriodogram(ID: {})".format(self.label)
@@ -622,14 +622,14 @@ class SNRPeriodogram(Periodogram):
         ax : `~matplotlib.axes.Axes`
             The matplotlib axes object.
         """
-        pg = self * self.bkg.power.value
-        pg.power *= 1 * self.bkg.power.unit
+        pg = self * self.background.power.value
+        pg.power *= 1 * self.background.power.unit
 
         ax = pg.plot(**kwargs)
-        self.bkg.plot(ax=ax, scale='log', label='Background',
+        self.background.plot(ax=ax, scale='log', label='Background',
                     lw = 2)
-        ax.set_title(f'Method: {self.bkg.meta["FLAT_METHOD"]}, ' +  
-                     f'filter width {self.bkg.meta["FLAT_FILT_WIDTH"]}')
+        ax.set_title(f'Method: {self.background.meta["FLAT_METHOD"]}, ' +  
+                     f'filter width {self.background.meta["FLAT_FILT_WIDTH"]}')
     
         return ax
 

--- a/tests/test_periodogram.py
+++ b/tests/test_periodogram.py
@@ -234,9 +234,12 @@ def test_flatten():
         np.mean(p.flatten(method="logmedian").power.value), 1.0, atol=0.05
     )
 
-    # Check return trend works
-    s, b = p.flatten(return_trend=True)
-    assert all(b.power == p.smooth(method="logmedian", filter_width=0.01).power)
+    # Check that the background trend returned to SNRPeriodogram works
+    s = p.flatten()
+    b = s.background
+    assert all(b.power == p.smooth(method="logmedian", filter_width=0.1).power)
+    
+    # Check that the SNRPeriodogram works
     assert all(s.power == p.flatten().power)
     str(s)
     s.plot()


### PR DESCRIPTION
There are established use cases where a `PeriodogramCollection` may be useful. These are, for example:
- Averaging the power spectra of time-separated sectors of TESS data to avoid aliasing
- Studying signals of variability independently in time separated sectors of TESS data (i.e. looking at spot rotation).
- Separately treating periodograms of light cuves of the same target with different exposure times (i.e. stars observed by Kepler and TESS, stars observed in TESS FFIs across the extended mission).

A `PeriodogramCollection` can be established by a user passing in a list of `lightkurve.Periodogram` objects, or by using the function `lightkurve.LightCurveCollection.to_periodograms(**kwargs)`, which passes all the keyword arguments of `lightcurve.to_periodogram()`.

An important discussion point is how to combine consecutive sectors of Kepler and TESS data, and whether to do that by default. Maybe there should be a `LightCurveCollection.partial_stitch()` method?

To do:
- Build `PeriodogramCollection.flatten()` function
- Build `PeriodogramCollection.normalize()` function
- Build `PeriodogramCollection.average()` function
- Build unit tests
- Establish workflow for partial stitching of light curves
- Build code into `LightCurveCollection` to partially stitch light curves.