### PR TITLE
Raise a RuntimeError in case arclength cant be computed

### DIFF
--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -502,7 +502,12 @@ def _estimate_arclength(centroid_col, centroid_row):
     """
     col = centroid_col - np.nanmin(centroid_col)
     row = centroid_row - np.nanmin(centroid_row)
+    if np.all((col.value == 0) & (row.value == 0)):
+        raise RuntimeError("Arclength cannot be computed because there is no "
+                           "centroid motion. Make sure that the aperture of "
+                           "the TPF at least two pixels.")
     # Force c to be correlated not anticorrelated
     if np.polyfit(col.data, row.data, 1)[0] < 0:
         col = np.nanmax(col) - col
-    return (col ** 2 + row ** 2) ** 0.5
+    arclength = (col ** 2 + row ** 2) ** 0.5
+    return arclength 

--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -502,7 +502,7 @@ def _estimate_arclength(centroid_col, centroid_row):
     """
     col = centroid_col - np.nanmin(centroid_col)
     row = centroid_row - np.nanmin(centroid_row)
-    if np.all((col.value == 0) & (row.value == 0)):
+    if np.all((col == 0) & (row == 0)):
         raise RuntimeError("Arclength cannot be computed because there is no "
                            "centroid motion. Make sure that the aperture of "
                            "the TPF at least two pixels.")


### PR DESCRIPTION
The issue is that there seems to be no way to compute arclengths (centroid motion) if the TPF aperture contains only one pixel, so we just raise a ``RuntimError`` explaining that.

closes #563
