### PR TITLE
Expose n_iters to the pca method in DesignMatrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.4.1dev (unreleased)
 =====================
 
+- Exposed niters parameter in the PCA function of design matrix
 - Fixed the aperture parsing functions inside TPFs to be compliant with `numpy` v1.25 [#1360]
 - Made `LombScarglePeriodogram` compatible with Astropy v5.3 [#1342]
 - Updated the TPF plotting function to work correctly with WCS plotting [#1298]

--- a/src/lightkurve/correctors/designmatrix.py
+++ b/src/lightkurve/correctors/designmatrix.py
@@ -249,7 +249,7 @@ class DesignMatrix:
         dm.df = new_df
         return dm
 
-    def pca(self, nterms=6):
+    def pca(self, nterms=6, n_iter=10):
         """Returns a new `.DesignMatrix` with a smaller number of regressors.
 
         This method will use Principal Components Analysis (PCA) to reduce
@@ -259,6 +259,10 @@ class DesignMatrix:
         ----------
         nterms : int
             Number of columns in the new matrix.
+
+        n_iter : int
+            Number of iterations that will be run by the power iteration
+            algorithm to compute the principal components.
 
         Returns
         -------
@@ -274,7 +278,7 @@ class DesignMatrix:
         # produces more stable results.
         from fbpca import pca  # local import because not used elsewhere
 
-        new_values, _, _ = pca(self.values, nterms, n_iter=10)
+        new_values, _, _ = pca(self.values, nterms, n_iter)
         return DesignMatrix(new_values, name=self.name)
 
     def append_constant(self, prior_mu=0, prior_sigma=np.inf, inplace=False):

--- a/src/lightkurve/correctors/designmatrix.py
+++ b/src/lightkurve/correctors/designmatrix.py
@@ -278,7 +278,7 @@ class DesignMatrix:
         # produces more stable results.
         from fbpca import pca  # local import because not used elsewhere
 
-        new_values, _, _ = pca(self.values, nterms, n_iter)
+        new_values, _, _ = pca(self.values, nterms, n_iter=n_iter)
         return DesignMatrix(new_values, name=self.name)
 
     def append_constant(self, prior_mu=0, prior_sigma=np.inf, inplace=False):


### PR DESCRIPTION
In this way, users can better control the accuracy of the PCAs computed via `fbpca`.  This is related to #1125.