### PR TITLE
Make `LombScarglePeriodogram` compatible with Astropy v5.3

### DIFF
--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -17,13 +17,8 @@ from astropy.units import cds
 from astropy.convolution import convolve, Box1DKernel
 from astropy.time import Time
 
-# LombScargle was moved from astropy.stats to astropy.timeseries in AstroPy v3.2
-try:
-    from astropy.timeseries import LombScargle
-    from astropy.timeseries import implementations  # for .main._is_regular
-except ImportError:
-    from astropy.stats import LombScargle
-    from astropy.stats.lombscargle import implementations
+from astropy.timeseries import LombScargle
+from astropy.timeseries.periodograms.lombscargle import implementations  # for .main._is_regular
 
 
 from . import MPLSTYLE


### PR DESCRIPTION
In this PR, I am addressing an import error that was introduced with the release of Astropy 5.3. This new version added a `LombScargleMultiband` class (https://github.com/astropy/astropy/pull/14016), which led to a change of the `implementations` object in `periodogram.py`. It caused the `lc.to_periodogram()` function to fail with an `AttributeError`, as detailed below:
```
>>> pg = lc.to_periodogram()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 pg = lc.to_periodogram()

File ~/mambaforge/lib/python3.11/site-packages/lightkurve/lightcurve.py:2363, in LightCurve.to_periodogram(self, method, **kwargs)
   2360 else:
   2361     from .periodogram import LombScarglePeriodogram
-> 2363     return LombScarglePeriodogram.from_lightcurve(lc=self, **kwargs)

File ~/mambaforge/lib/python3.11/site-packages/lightkurve/periodogram.py:918, in LombScarglePeriodogram.from_lightcurve(lc, minimum_frequency, maximum_frequency, minimum_period, maximum_period, frequency, period, nterms, nyquist_factor, oversample_factor, freq_unit, normalization, ls_method, **kwargs)
    915 frequency = u.Quantity(frequency, freq_unit)
    917 # Change to compatible ls method if sampling not even in frequency
--> 918 if not implementations.main._is_regular(frequency) and ls_method in [
    919     "fastchi2",
    920     "fast",
    921 ]:
    922     oldmethod = ls_method
    923     ls_method = {"fastchi2": "chi2", "fast": "slow"}[ls_method]

AttributeError: module 'astropy.timeseries.periodograms.lombscargle_multiband.implementations.main' has no attribute '_is_regular'
```

To resolve this issue, I have modified the import path to specifically import the `implementations` object from `astropy.timeseries.periodograms.lombscargle`.

Furthermore, I removed the redundant import code which was intended to backport compatibility for older versions of Astropy. Given the current requirement of lightkurve for Astropy is `>=5.0`, this backward compatibility code is unnecessary.