### PR TITLE
Implicit JupyterHub support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.4.1dev (unreleased)
 =====================
 
+- Updated interact features to work with JupyterHub (e.g. TiKE) [#1349]
 - Made `LombScarglePeriodogram` compatible with Astropy v5.3 [#1342]
 - Updated the TPF plotting function to work correctly with WCS plotting [#1298]
 - Added the ability to open light curves from the TGLC High Level Science Product

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -28,7 +28,9 @@ from astropy.utils.exceptions import AstropyUserWarning
 import pandas as pd
 from pandas import Series
 
-from .utils import KeplerQualityFlags, LightkurveWarning, LightkurveError
+
+from .utils import KeplerQualityFlags, LightkurveWarning, LightkurveError, finalize_notebook_url
+
 
 log = logging.getLogger(__name__)
 
@@ -978,7 +980,7 @@ def make_default_export_name(tpf, suffix="custom-lc"):
 
 def show_interact_widget(
     tpf,
-    notebook_url="localhost:8888",
+    notebook_url=None,
     lc=None,
     max_cadences=200000,
     aperture_mask="default",
@@ -1013,6 +1015,9 @@ def show_interact_widget(
         will need to supply this value for the application to display
         properly. If no protocol is supplied in the URL, e.g. if it is
         of the form "localhost:8888", then "http" will be used.
+        For use with JupyterHub, set the environment variable LK_JUPYTERHUB_EXTERNAL_URL
+        to the public hostname of your JupyterHub and notebook_url will
+        be defined appropriately automatically.
     max_cadences: int
         Raise a RuntimeError if the number of cadences shown is larger than
         this value. This limit helps keep browsers from becoming unresponsive.
@@ -1064,6 +1069,8 @@ def show_interact_widget(
             "you can install bokeh using e.g. `conda install bokeh`."
         )
         return None
+
+    notebook_url = finalize_notebook_url(notebook_url)
 
     aperture_mask = tpf._parse_aperture_mask(aperture_mask)
     if ~aperture_mask.any():
@@ -1297,7 +1304,8 @@ def show_interact_widget(
     return show(create_interact_ui, notebook_url=notebook_url)
 
 
-def show_skyview_widget(tpf, notebook_url="localhost:8888", aperture_mask="empty",  magnitude_limit=18):
+
+def show_skyview_widget(tpf, notebook_url=None, aperture_mask="empty",  magnitude_limit=18):
     """skyview
 
     Parameters
@@ -1313,6 +1321,9 @@ def show_skyview_widget(tpf, notebook_url="localhost:8888", aperture_mask="empty
         will need to supply this value for the application to display
         properly. If no protocol is supplied in the URL, e.g. if it is
         of the form "localhost:8888", then "http" will be used.
+        For use with JupyterHub, set the environment variable LK_JUPYTERHUB_EXTERNAL_URL
+        to the public hostname of your JupyterHub and notebook_url will
+        be defined appropriately automatically.
     aperture_mask : array-like, 'pipeline', 'threshold', 'default', 'background', or 'empty'
         Highlight pixels selected by aperture_mask.
         Default is 'empty': no pixel is highlighted.
@@ -1332,6 +1343,8 @@ def show_skyview_widget(tpf, notebook_url="localhost:8888", aperture_mask="empty
             "you can install bokeh using e.g. `conda install bokeh`."
         )
         return None
+
+    notebook_url = finalize_notebook_url(notebook_url)
 
     # Try to identify the "fiducial frame", for which the TPF WCS is exact
     zp = (tpf.pos_corr1 == 0) & (tpf.pos_corr2 == 0)

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -32,8 +32,6 @@ from pandas import Series
 from .utils import KeplerQualityFlags, LightkurveWarning, LightkurveError, finalize_notebook_url
 
 
-log = logging.getLogger(__name__)
-
 # Import the optional Bokeh dependency, or print a friendly error otherwise.
 try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
@@ -140,8 +138,8 @@ def _get_corrected_coordinate(tpf_or_lc):
     ra_corrected, dec_corrected, pm_corrected = _correct_with_proper_motion(
             ra * u.deg, dec *u.deg,
             pm_ra * pm_unit, pm_dec * pm_unit,
-            # e.g., equinox 2000 is treated as J2000 is set to be noon of 2000-01-01 TT
-            Time(equinox, format="decimalyear", scale="tt") + 0.5,
+            # we assume the data is in J2000 epoch
+            Time('2000', format='byear'),
             new_time)
     return ra_corrected.to(u.deg).value,  dec_corrected.to(u.deg).value, pm_corrected
 
@@ -462,7 +460,6 @@ def _add_nearby_tics_if_tess(tpf, magnitude_limit, result):
 
     # nearby TICs from ExoFOP
     tab = _search_nearby_of_tess_target(tic_id)
-
     gaia_ids = result['Source'].array
 
     # merge the TICs with matching Gaia entries
@@ -538,7 +535,7 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
     """Make the Gaia Figure Elements"""
 
     result = _get_nearby_gaia_objects(tpf, magnitude_limit)
-
+    
     source_colnames_extras = []
     tooltips_extras = []
     try:
@@ -557,7 +554,6 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
             tpf.time[0])
     result.RA_ICRS = ra_corrected.to(u.deg).value
     result.DE_ICRS = dec_corrected.to(u.deg).value
-
     # Convert to pixel coordinates
     radecs = np.vstack([result["RA_ICRS"], result["DE_ICRS"]]).T
     coords = tpf.wcs.all_world2pix(radecs, 0)
@@ -1356,7 +1352,6 @@ def show_skyview_widget(tpf, notebook_url=None, aperture_mask="empty",  magnitud
         fiducial_frame = 0
 
     aperture_mask = tpf._parse_aperture_mask(aperture_mask)
-
     def create_interact_ui(doc):
         tpf_source = prepare_tpf_datasource(tpf, aperture_mask)
 

--- a/src/lightkurve/interact_bls.py
+++ b/src/lightkurve/interact_bls.py
@@ -8,7 +8,7 @@ from astropy.time import Time, TimeDelta
 from astropy.timeseries import BoxLeastSquares
 import astropy.units as u
 
-from .utils import LightkurveWarning
+from .utils import LightkurveWarning, finalize_notebook_url
 
 log = logging.getLogger(__name__)
 
@@ -598,7 +598,7 @@ def _preprocess_lc_for_bls(lc):
 
 def show_interact_widget(
     lc,
-    notebook_url="localhost:8888",
+    notebook_url=None,
     minimum_period=None,
     maximum_period=None,
     resolution=2000,
@@ -616,6 +616,9 @@ def show_interact_widget(
         will need to supply this value for the application to display
         properly. If no protocol is supplied in the URL, e.g. if it is
         of the form "localhost:8888", then "http" will be used.
+        For use with JupyterHub, set the environment variable LK_JUPYTERHUB_EXTERNAL_URL
+        to the public hostname of your JupyterHub and notebook_url will
+        be defined appropriately automatically.
     minimum_period : float or None
         Minimum period to assess the BLS to. If None, default value of 0.3 days
         will be used.
@@ -1001,4 +1004,5 @@ def show_interact_widget(
     lc = _preprocess_lc_for_bls(lc)
 
     output_notebook(verbose=False, hide_banner=True)
+    notebook_url = finalize_notebook_url(notebook_url)
     return show(_create_interact_ui, notebook_url=notebook_url)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -32,6 +32,7 @@ from .utils import (
     btjd_to_astropy_time,
     validate_method,
     _query_solar_system_objects,
+    finalize_notebook_url
 )
 from .utils import LightkurveWarning, LightkurveDeprecationWarning
 
@@ -2118,7 +2119,7 @@ class LightCurve(TimeSeries):
 
     def interact_bls(
         self,
-        notebook_url="localhost:8888",
+        notebook_url=None,
         minimum_period=None,
         maximum_period=None,
         resolution=2000,
@@ -2146,6 +2147,9 @@ class LightCurve(TimeSeries):
             will need to supply this value for the application to display
             properly. If no protocol is supplied in the URL, e.g. if it is
             of the form "localhost:8888", then "http" will be used.
+            For use with JupyterHub, set the environment variable LK_JUPYTERHUB_EXTERNAL_URL
+            to the public hostname of your JupyterHub and notebook_url will
+            be defined appropriately automatically.
         minimum_period : float or None
             Minimum period to assess the BLS to. If None, default value of 0.3 days
             will be used.
@@ -2172,6 +2176,8 @@ class LightCurve(TimeSeries):
         .. [1] https://docs.astropy.org/en/stable/timeseries/bls.html
         """
         from .interact_bls import show_interact_widget
+
+        notebook_url = finalize_notebook_url(notebook_url)
 
         return show_interact_widget(
             self,

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -655,12 +655,6 @@ class TargetPixelFile(object):
             # Kepler and TESS pipeline style integer flags
             if np.issubdtype(aperture_mask.dtype, np.dtype('>i4')):
                 aperture_mask = (aperture_mask & 2) == 2
-<<<<<<< HEAD
-            elif isinstance(aperture_mask.flat[0], (np.integer, np.float_)):
-                aperture_mask = aperture_mask.astype(bool)
-        self._last_aperture_mask = aperture_mask
-
-=======
             elif np.issubdtype(aperture_mask.dtype, int):
                 if ((aperture_mask & 2) == 2).any():
                     # Kepler and TESS pipeline style integer flags
@@ -670,7 +664,6 @@ class TargetPixelFile(object):
             elif np.issubdtype(aperture_mask.dtype, float):
                 aperture_mask = aperture_mask.astype(bool)                
         self._last_aperture_mask = aperture_mask 
->>>>>>> edcdd65173345bc354030c496548bfddf9a87266
         return aperture_mask
 
     def create_threshold_mask(self, threshold=3, reference_pixel="center"):

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -50,10 +50,6 @@ def test_malformed_notebook_url():
     with pytest.raises(ValueError) as exc:
         tpf.interact(notebook_url="")
     assert "Empty host value" in exc.value.args[0]
-    with pytest.raises(AttributeError) as exc:
-        tpf.interact(notebook_url=None)
-    assert "object has no attribute" in exc.value.args[0]
-
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_graceful_exit_outside_notebook():

--- a/tests/test_interact_bls.py
+++ b/tests/test_interact_bls.py
@@ -24,10 +24,6 @@ def test_malformed_notebook_url():
     with pytest.raises(ValueError) as exc:
         lc.interact_bls(notebook_url="")
     assert "Empty host value" in exc.value.args[0]
-    with pytest.raises(AttributeError) as exc:
-        lc.interact_bls(notebook_url=None)
-    assert "object has no attribute" in exc.value.args[0]
-
 
 @pytest.mark.remote_data
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh and astropy.stats.bls")


### PR DESCRIPTION
Modify show/interact functions to automatically supply a callable for the notebook_url parameter to adapt to operating behind the a JupyterHub proxy with randomly generated ports for the Bokeh server.   

This implements Bokeh's proposed fix here: https://docs.bokeh.org/en/latest/docs/user_guide/output/jupyter.html

An issue with more information / discussion is here:  https://github.com/lightkurve/lightkurve/issues/1348

While it may be premature (pending discussion),  this PR gives a concrete representation of what we're proposing.