### PR TITLE
Fixing CDIPs stitching bug

### DIFF
--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -67,7 +67,13 @@ def read_generic_lightcurve(
         elif unitstr == "ppm" and repr(tab[colname].unit).startswith("Unrecognized"):
             # Workaround for issue #956
             tab[colname].unit = ppm
-
+        elif unitstr == "ADU":
+            tab[colname].unit = "adu"
+        elif unitstr.lower() == "unitless":
+            tab[colname].unit = ""
+        elif unitstr.lower() == "degcelcius":
+            # CDIPS has non-astropy units
+            tab[colname].unit = "deg_C"
         # Rename columns to lowercase
         tab.rename_column(colname, colname.lower())
 

--- a/tests/io/test_cdips.py
+++ b/tests/io/test_cdips.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from lightkurve import search_lightcurve
+from lightkurve import search_lightcurve, LightCurveCollection
 from lightkurve.io.cdips import read_cdips_lightcurve
 from lightkurve.io.detect import detect_filetype
 
@@ -59,3 +59,7 @@ def test_search_cdips():
     lc = search.download()
     assert type(lc).__name__ == "TessLightCurve"
     assert hasattr(lc, "sector")
+    assert str(lc['bge'].unit) == 'adu'
+    slc = LightCurveCollection([lc, lc]).stitch()
+    assert len(slc) == 2*len(lc)
+


### PR DESCRIPTION
@Nschanche has found that the CDIPs files can not be stitched because their units aren't real astropy units. This PR fixes the unit reader so it can parse the weird CDIPs units.

Fixes #1294