### PR TITLE
Updated filename check to fix issue #1358

### DIFF
--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -84,8 +84,10 @@ def detect_filetype(hdulist: HDUList) -> str:
 
     # Is it a K2VARCAT file?
     # There are no self-identifying keywords in the header, so go by filename.
-    if "hlsp_k2varcat" in (hdulist.filename() or ""):
-        return "K2VARCAT"
+    fname = hdulist.filename() if callable(hdulist.filename) else hdulist.filename
+    if fname is not None:
+        if "hlsp_k2varcat" in fname:
+            return "K2VARCAT"
 
     # Is it a K2SC file?
     if "k2sc" in hdulist[0].header.get("creator", "").lower():


### PR DESCRIPTION
This PR should allow users to create a lightkurve object from an hdulist, for example from the hdulist returned from astroquery.mast.Tesscut. This addresses issue #1358 .