### PR TITLE
Fix download error due to no dataURL in MAST result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.4.1dev (unreleased)
 =====================
 
-
+- Fixed download issue due to MAST API change [#1380]
 - Updated interact features to work with JupyterHub (e.g. TiKE) [#1349]
 - Exposed niters parameter in the PCA function of design matrix
 - Fixed the aperture parsing functions inside TPFs to be compliant with `numpy` v1.25 [#1360]

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -348,7 +348,7 @@ class SearchResult(object):
             else:
                 from astroquery.mast import Observations
 
-                download_url = table[:1]["dataURL"][0]
+                download_url = table[:1]["dataURI"][0]
                 log.debug("Started downloading {}.".format(download_url))
                 download_response = Observations.download_products(
                     table[:1], mrp_only=False, download_dir=download_dir
@@ -953,8 +953,6 @@ def _search_products(
                 "Please add the prefix 'EPIC' or 'TIC' to disambiguate."
                 "".format(target)
             )
-
-    
 
     # Specifying quarter, campaign, or quarter should constrain the mission
     if quarter is not None:

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -54,6 +54,7 @@ AUTHOR_LINKS = {
     "TESScut": "https://mast.stsci.edu/tesscut/",
     "GSFC-ELEANOR-LITE": "https://archive.stsci.edu/hlsp/gsfc-eleanor-lite",
     "TGLC": "https://archive.stsci.edu/hlsp/tglc",
+    "KBONUS-BKG":"https://archive.stsci.edu/hlsp/kbonus-bkg",
 }
 
 REPR_COLUMNS_BASE = [
@@ -133,11 +134,11 @@ class SearchResult(object):
         This ordering is not a judgement on the quality of one product vs another,
         because we love all pipelines!
         """
-        sort_priority = {"Kepler": 1, "K2": 1, "SPOC": 1, "TESS-SPOC": 2, "QLP": 3}
+        sort_priority = {"Kepler": 1, "K2": 1, "SPOC": 1, "KBONUS-BKG":2, "TESS-SPOC": 2, "QLP": 3}
         self.table["sort_order"] = [
             sort_priority.get(author, 9) for author in self.table["author"]
         ]
-        self.table.sort(["distance", "year", "mission", "sort_order", "exptime"])
+        self.table.sort(["distance", "project", "sort_order", "year", "exptime"])
 
     def _add_columns(self):
         """Adds a user-friendly index (``#``) column and adds column unit

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -106,7 +106,7 @@ def test_search_lightcurve(caplog):
     # The name Kepler-10 somehow no longer works on MAST. So we use 2MASS instead:
     #   https://simbad.cds.unistra.fr/simbad/sim-id?Ident=%405506010&Name=Kepler-10
     assert (
-        len(search_lightcurve("2MASS J19024305+5014286", mission="Kepler", cadence="long").table)
+        len(search_lightcurve("2MASS J19024305+5014286", mission="Kepler", author="Kepler", cadence="long").table)
         == 15
     )
     # An invalid KIC/EPIC ID or target name should be dealt with gracefully
@@ -115,14 +115,14 @@ def test_search_lightcurve(caplog):
     search_lightcurve("DOES_NOT_EXIST (UNIT TEST)")
     assert "disambiguate" in caplog.text
     # If we ask for all cadence types, there should be four Kepler files given
-    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="any").table) == 4
+    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="any", author="Kepler").table) == 4
     # ...and only one should have long cadence
-    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="long").table) == 1
+    assert len(search_lightcurve("KIC 4914423", quarter=6, cadence="long", author="Kepler").table) == 1
     # Should be able to resolve an ra/dec
-    assert len(search_lightcurve("297.5835, 40.98339", quarter=6).table) == 1
+    assert len(search_lightcurve("297.5835, 40.98339", quarter=6, author="Kepler").table) == 1
     # Should be able to resolve a SkyCoord
     c = SkyCoord("297.5835 40.98339", unit=(u.deg, u.deg))
-    search = search_lightcurve(c, quarter=6)
+    search = search_lightcurve(c, quarter=6, author="Kepler")
     assert len(search.table) == 1
     assert len(search) == 1
     # We should be able to download a light curve

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -385,11 +385,10 @@ def test_mast_http_error_handling(monkeypatch):
     from astroquery.mast import Observations
 
     result = search_lightcurve("TIC 273985862", mission="TESS")
-    remote_url = result.table[0]["dataURL"]
+    remote_url = result.table[0]["dataURI"]
 
     def mock_http_error_response(*args, **kwargs):
         """Mock the `download_product()` response to simulate MAST returns HTTP error"""
-        print("DBG mock_http_error_response called")
         return Table(data={
             "Local Path": ["./mastDownload/acme_lc.fits"],
             "Status": ["ERROR"],


### PR DESCRIPTION
Close #1377 

---
Changelog:

Fixed `SearchResult.download() / download_all()`'s misuse of dataURL. [#1380]