### PR TITLE
Read in new HLSPs, fix search

### DIFF
--- a/src/lightkurve/__init__.py
+++ b/src/lightkurve/__init__.py
@@ -71,6 +71,7 @@ class Conf(_config.ConfigNamespace):
     warn_legacy_cache_dir
         If set to True, issue warning if the legacy default cache directory exists. Default is True.
     """
+
     # Note: when using list or string_list datatype,
     # the behavior of astropy's parsing of the config file value:
     # - it does not accept python list literal
@@ -81,22 +82,23 @@ class Conf(_config.ConfigNamespace):
         [],
         "List of extra columns to be included when displaying a SearchResult object.",
         cfgtype="string_list",
-        module="lightkurve.search"
+        module="lightkurve.search",
     )
 
     cache_dir = _config.ConfigItem(
         None,
         "Default cache directory for data files downloaded, etc.",
         cfgtype="string",
-        module="lightkurve.config"
+        module="lightkurve.config",
     )
 
     warn_legacy_cache_dir = _config.ConfigItem(
         True,
         "If set to True, issue warning if the legacy default cache directory exists.",
         cfgtype="boolean",
-        module="lightkurve.config"
+        module="lightkurve.config",
     )
+
 
 conf = Conf()
 
@@ -106,13 +108,14 @@ from . import units  # enable ppt and ppm as units
 from .time import *
 from .lightcurve import *
 from .lightcurvefile import *
-from .correctors import *
 from .targetpixelfile import *
-from .utils import *
-from .convenience import *
-from .collections import *
 from .io import *
 from .search import *
+from .collections import *
+from .utils import *
+from .convenience import *
+from .correctors import *
 
 from . import config
+
 config.warn_if_default_cache_dir_migration_needed()

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -9,7 +9,6 @@ from astropy.table import vstack
 from astropy.utils.decorators import deprecated
 
 from . import MPLSTYLE
-from .targetpixelfile import TargetPixelFile
 from .utils import LightkurveWarning, LightkurveDeprecationWarning
 
 

--- a/src/lightkurve/io/__init__.py
+++ b/src/lightkurve/io/__init__.py
@@ -14,6 +14,7 @@ from . import (
     tasoc,
     tess,
     tglc,
+    kbonus,
 )
 from .detect import *
 from .read import *
@@ -37,5 +38,6 @@ try:
         "kepseismic", LightCurve, kepseismic.read_kepseismic_lightcurve
     )
     registry.register_reader("tglc", LightCurve, tglc.read_tglc_lightcurve)
+    registry.register_reader("kbonus", LightCurve, kbonus.read_kbonus_lightcurve)
 except registry.IORegistryError:
     pass  # necessary to enable autoreload during debugging

--- a/src/lightkurve/io/detect.py
+++ b/src/lightkurve/io/detect.py
@@ -28,6 +28,7 @@ def detect_filetype(hdulist: HDUList) -> str:
         * `'KEPSEISMIC'`
         * `'CDIPS'`
         * `'TGLC'`
+        * `'KBONUS-BKG'`
 
     If the data product cannot be detected, `None` will be returned.
 
@@ -71,6 +72,11 @@ def detect_filetype(hdulist: HDUList) -> str:
         ]
     ):
         return "PATHOS"
+
+    # Is it a KBONUS-BKG light curve?
+    # cf. https://archive.stsci.edu/hlsp/kbonus-bkg
+    if hdulist[0].header.get("HLSPID") == "KBONUS-BKG":
+        return "KBONUS-BKG"
 
     # Is it a TASOC TESS light curve?
     # cf. https://tasoc.dk and https://archive.stsci.edu/hlsp/tasoc

--- a/src/lightkurve/io/kbonus.py
+++ b/src/lightkurve/io/kbonus.py
@@ -1,0 +1,123 @@
+"""Reader function for KBONUS-BKG community light curve products."""
+from ..lightcurve import KeplerLightCurve
+from ..collections import LightCurveCollection
+from .generic import read_generic_lightcurve
+from astropy.io import fits
+import numpy as np
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _warn_bonus_file(filename):
+    with fits.open(filename, lazy_load_hdus=True) as hdulist:
+        if hdulist[0].header["KEPMAG"] < 12:
+            log.warning(
+                "Kepler magnitude is bright (less than 12), indicating the target is saturated. KBONUS-BKG data is invalid for saturated targets."
+            )
+        quarter_map = {
+            ext.header["quarter"]: idx
+            for idx, ext in enumerate(hdulist)
+            if "QUARTER" in ext.header
+        }
+        psffrac = np.asarray(
+            [
+                ext.header["PSFFRAC"]
+                for idx, ext in enumerate(hdulist)
+                if "QUARTER" in ext.header
+            ]
+        )
+        if (psffrac < 0.6).any():
+            log.warning(
+                "PSF Fraction is low, indicating not all of the flux is captured in the PSF model. This data may be unreliable."
+            )
+    return
+
+
+def _read_kbonus_lightcurve(filename, ext, **kwargs):
+    """Read an extension of kbonus light curve"""
+    lc = read_generic_lightcurve(
+        filename,
+        time_format="bkjd",
+        ext=ext,
+        centroid_col_column="centroid_column",
+        centroid_row_column="centroid_row",
+    )
+
+    lc.meta["AUTHOR"] = "KBONUS-BKG"
+    lc.meta["TARGETID"] = lc.meta.get("GAIAID")
+    with fits.open(lc.filename, lazy_load_hdus=True) as hdu:
+        lc.meta["FLFRCSAP"] = hdu[2].header["FLFRCSAP"]
+        lc.meta["CROWDSAP"] = hdu[2].header["CROWDSAP"]
+    return KeplerLightCurve(data=lc, **kwargs)
+
+
+def read_kbonus_lightcurve(filename, **kwargs):
+    """Read a KBONUS-BKG light curve file.
+
+    More information: https://archive.stsci.edu/hlsp/kbonus-bkg
+
+    By default this will return the corrected, stitched light curve.
+    Use the `quarters` argument to extract specific separated quarters.
+
+    Parameters
+    ----------
+    filename : str
+        Path or URL of a KBONUS-BKG light curve FITS file.
+    quarters : None, int, list of int, or 'all'
+        Which quarters to load. If None, will load the stitched light curve
+        from the first extension. If a list of ints, int, or 'any', will load
+        each of those quarters into a LightCurveCollection.
+
+    Returns
+    -------
+    lc : `KeplerLightCurve`
+    """
+
+    _warn_bonus_file(filename)
+    return _read_kbonus_lightcurve(filename, ext=1, **kwargs)
+
+
+def read_kbonus_lightcurve_quarters(filename, quarters="any", **kwargs):
+    """Read a KBONUS-BKG light curve file.
+
+    More information: https://archive.stsci.edu/hlsp/kbonus-bkg
+
+    By default this will return the corrected, stitched light curve.
+    Use the `quarters` argument to extract specific separated quarters.
+
+    Parameters
+    ----------
+    filename : str
+        Path or URL of a KBONUS-BKG light curve FITS file.
+    quarters : None, int, list of int, or 'all'
+        Which quarters to load. If None, will load the stitched light curve
+        from the first extension. If a list of ints, int, or 'any', will load
+        each of those quarters into a LightCurveCollection.
+
+    Returns
+    -------
+    lc : `LightCurveCollection`
+
+    """
+    _warn_bonus_file(filename)
+    with fits.open(filename, lazy_load_hdus=True) as hdulist:
+        quarter_map = {
+            ext.header["quarter"]: idx
+            for idx, ext in enumerate(hdulist)
+            if "QUARTER" in ext.header
+        }
+    if isinstance(quarters, str):
+        if quarters.lower() in ["all", "any"]:
+            quarters = np.arange(18)
+    if isinstance(quarters, (int, float, list, np.ndarray)):
+        quarters = np.atleast_1d(quarters).astype(int)
+        lcs = [
+            _read_kbonus_lightcurve(filename, ext=quarter_map[quarter], **kwargs)
+            for quarter in quarters
+            if quarter in quarter_map
+        ]
+        return LightCurveCollection(lcs)
+    else:
+        raise ValueError("Can not parse `quarters`.")

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -87,7 +87,6 @@ def read(path_or_url, **kwargs):
         # Raise an explicit FileNotFoundError if file not found
         if "No such file" in str(e):
             raise e
-
     try:
         if filetype == "KeplerLightCurve":
             return KeplerLightCurve.read(path_or_url, format="kepler", **kwargs)
@@ -111,6 +110,20 @@ def read(path_or_url, **kwargs):
             return KeplerLightCurve.read(path_or_url, format="kepseismic", **kwargs)
         elif filetype == "TGLC":
             return TessLightCurve.read(path_or_url, format="tglc", **kwargs)
+        elif filetype == "KBONUS-BKG":
+            quarters = kwargs.pop("quarters", None)
+            if quarters is None:
+                return KeplerLightCurve.read(path_or_url, format="kbonus", **kwargs)
+            else:
+                log.warn(
+                    f"Opening as `LightCurveCollection` because `quarters` set to `{quarters}.`"
+                )
+                from .kbonus import read_kbonus_lightcurve_quarters
+
+                lcs = read_kbonus_lightcurve_quarters(
+                    path_or_url, quarters=quarters, **kwargs
+                )
+                return lcs
     except BaseException as exc:
         # ensure path_or_url is in the error
         raise LightkurveError(

--- a/tests/io/test_kbonus.py
+++ b/tests/io/test_kbonus.py
@@ -1,0 +1,51 @@
+import pytest
+
+from astropy.io import fits
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from lightkurve.io.kbonus import read_kbonus_lightcurve, read_kbonus_lightcurve_quarters
+from lightkurve import search_lightcurve
+
+
+@pytest.mark.remote_data
+def test_read_kbonus():
+    """Can we read KBONUS files?"""
+    url = "http://archive.stsci.edu/hlsps/kbonus-bkg/lcs/0119/011904151/hlsp_kbonus-bkg_kepler_kepler_kic-011904151_kepler_v1.0_lc.fits"
+    f = fits.open(url)
+    # verify can open
+    lc = read_kbonus_lightcurve(url)
+    assert type(lc).__name__ == "KeplerLightCurve"
+    # Are `time` and `flux` consistent with the FITS file?
+    assert_array_equal(f[1].data["TIME"], lc.time.value)
+    assert_array_equal(f[1].data["FLUX"], lc.flux.value)
+    assert lc.FLFRCSAP > 0.94
+    assert lc.CROWDSAP == 1.0
+
+    # In this special case we get a light curve collection
+    lcs = read_kbonus_lightcurve_quarters(url, quarters=[2, 10])
+    assert type(lcs).__name__ == "LightCurveCollection"
+    assert len(lcs) == 2
+    assert_array_equal(np.asarray([lc.quarter for lc in lcs]), np.asarray([2, 10]))
+
+
+@pytest.mark.remote_data
+def test_search_kbonus(caplog):
+    """Can we search and download a KBONUS light curve?"""
+    # Try an early campaign
+    search = search_lightcurve("Kepler-10", author="KBONUS-BKG")
+    assert len(search) == 1
+    assert search.table["author"][0] == "KBONUS-BKG"
+    lc = search.download()
+    # Kepler-10 should have 2 warnings to user
+    assert len(caplog.records) == 2
+    for record in caplog.records:
+        assert record.levelname == "WARNING"
+    assert (
+        "KBONUS-BKG data is invalid for saturated targets" in caplog.records[0].message
+    )
+    assert "This data may be unreliable." in caplog.records[1].message
+    assert type(lc).__name__ == "KeplerLightCurve"
+    lcs = search.download(quarters=[2, 10])
+    assert type(lcs).__name__ == "LightCurveCollection"
+    assert_array_equal(np.asarray([lc.quarter for lc in lcs]), np.asarray([2, 10]))


### PR DESCRIPTION
Right now there are some problems with search which are only becoming apparent as we have more and more data from TESS;

* Right now if you search for a TIC, KIC or EPIC explicitly it will only show you TESS, Kepler, or K2 data. This is helpful because it does an object query not a cone search. I'm changing this so that it will only do an object query if the ID and **author** is set
* I added an author alias for "SPOC" as "TESS" to be inline with "Kepler" and "K2" being the mission product authors
* I added a mission product column to help people figure out which products are "official"
* I added start and end times for the datasets as `astropy.time.Time` objects, and implemented a slightly hacky fix for the incorrect Kepler dates.
* I split the mission column into `mission` and `sequence` so that it's easier for people to narrow down based on a mission or a particular sequence of quarter, campaign, sector etc.

For readers I'm adding in a reader for the new KBONUS HLSP.

This is a weird one, because there are extensions in the file for each quarter, so we need a way to return a LightCurveCollection as well as a LightCurve. I've added a special case for if quarters are passed.

@jorgemarpa is going to write a tutorial on how to use this reader that I can add to the docs.