### PR TITLE
tpf.interact: y-label fix for normalized flux

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
   corrupted TargetPixelFile. [#1399]
 - Fixed ``FoldedLightCurve.cycle``, case ``epoch_time`` not specified [#1398]
 - Various improvements to the online documentation. [#1400]
+- Fixed a bug in ``tpf.interact()`` so that proper y label is displayed when
+  lightcurve is normalized with ``transform_func``. [#1387]
 
 
 2.4.2 (2023-11-03)

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -298,7 +298,19 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
         border_fill_color="whitesmoke",
     )
     fig.title.offset = -10
-    fig.yaxis.axis_label = "Flux (e/s)"
+
+    # ylabel: mimic the logic in lc._create_plot()
+    ylabel = "Flux"
+    if lc.meta.get("NORMALIZED"):
+        ylabel = "Normalized " + ylabel
+    elif (lc["flux"].unit) and (lc["flux"].unit.to_string() != ""):
+        if lc["flux"].unit == (u.electron / u.second):
+            yunit_str = "e/s"  # the common case, use abbreviation
+        else:
+            yunit_str = lc["flux"].unit.to_string()
+        ylabel += f" ({yunit_str})"
+    fig.yaxis.axis_label = ylabel
+
     fig.xaxis.axis_label = "Time (days)"
     try:
         if (lc.mission == "K2") or (lc.mission == "Kepler"):
@@ -536,7 +548,7 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
     """Make the Gaia Figure Elements"""
 
     result = _get_nearby_gaia_objects(tpf, magnitude_limit)
-    
+
     source_colnames_extras = []
     tooltips_extras = []
     try:

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -797,7 +797,7 @@ def test_normalize():
 
     # already in relative units
     lc = LightCurve(time=np.arange(10), flux=np.ones(10)).normalize()
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         lc.normalize()
     assert len(warn_record) == 0
     assert lc.meta["NORMALIZED"]
@@ -1562,7 +1562,7 @@ def test_attr_access_columns():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         lc.foo = "bar"
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         lc.foo = "bar2"
     assert len(warn_record) == 0
 
@@ -1647,7 +1647,7 @@ def test_meta_assignment(lc):
 
     # ensure lc.meta assignment does not emit any warnings.
     meta_new = {'TSTART': 123456789.0}
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         lc.meta = meta_new
 
     if (len(record) > 0):


### PR DESCRIPTION
Close #1061 

An additional unrelated fix to pytest v8 compatibility in the regression test suite.

Test suite: no change. The scenario has been tested by `test_transform_and_ylim_funcs()`: 
https://github.com/lightkurve/lightkurve/blob/9dbb63433fcaa391f45a3fccda65d9ac1bb96340/tests/test_interact.py#L111

- The change is plot label, which can only be verified manually.
- The existing test ensures that no error is raised in the scenario.

---

Note: the changes to support #1386 (requiring a slight public API enhancement for `tpf.interact()`) is split into its own PR so that the bug fix here can be merged.
