### PR TITLE
pytests: isolate astropy cache from user defaults

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,3 +59,7 @@ else:
 _cache_dir = os.path.join(os.environ['XDG_CACHE_HOME'], 'lightkurve')
 if not os.path.isdir(_cache_dir):
     os.mkdir(_cache_dir)
+
+_astropy_cache_dir = os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy')
+if not os.path.isdir(_astropy_cache_dir):
+    os.mkdir(_astropy_cache_dir)


### PR DESCRIPTION
The regression tests have been isolated from user default `lightkurve` cache.
This PR further isolates the tests from user default `astropy` cache ([astropy doc](https://docs.astropy.org/en/stable/config/index.html#:~:text=XDG_CACHE_HOME)) that is implicitly used, e.g., `astroquery` cache, FITS file cache from `lk.read(an_url)` (as opposed to `SearchResult.download()`, which is managed by `lightkurve`), etc.



