### PR TITLE
Fix FoldedLightCurve.cycle , case epoch_time not specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
   corrupted. [#1399]
 - Fixed to ensure file handles are properly released when reading
   corrupted TargetPixelFile. [#1399]
+- Fixed ``FoldedLightCurve.cycle``, case ``epoch_time`` not specified [#1398]
 
 
 2.4.2 (2023-11-03)

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2994,7 +2994,12 @@ class FoldedLightCurve(LightCurve):
         """The cycle of the correspond `time_original`.
         The first cycle is cycle 0, irrespective of whether it is a complete one or not.
         """
-        cycle_epoch_start = self.epoch_time - self.period / 2
+        epoch_time = self.meta.get("EPOCH_TIME")
+        if epoch_time is None:
+            # explicit check needed (cannot be the default value in get() function call above)
+            # because Lightcurve.fold() will put an explicit None in meta, if epoch_time is not specified.
+            epoch_time = self.time.min()
+        cycle_epoch_start = epoch_time - self.period / 2
         result = np.asarray(np.floor(((self.time_original - cycle_epoch_start) / self.period).value), dtype=int)
         result = result - result.min()
         return result

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -248,6 +248,8 @@ def test_lightcurve_fold():
     assert_almost_equal(fold.phase[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
+    assert np.min(fold.cycle) == 0  # for #1397, case lc.fold() without epoch_time
+    assert np.max(fold.cycle) == 10
     assert fold.targetid == lc.targetid
     assert fold.label == lc.label
     assert set(lc.meta).issubset(set(fold.meta))
@@ -258,6 +260,8 @@ def test_lightcurve_fold():
     assert_almost_equal(fold.time[0], -0.5, 2)
     assert_almost_equal(np.min(fold.phase), -0.5, 2)
     assert_almost_equal(np.max(fold.phase), 0.5, 2)
+    assert np.min(fold.cycle) == 0
+    assert np.max(fold.cycle) == 10
     with warnings.catch_warnings():
         # `transit_midpoint` is deprecated and its use will emit a warning
         warnings.simplefilter("ignore", LightkurveWarning)


### PR DESCRIPTION
 Close #1397

changelog
```rst
- Fixed ``FoldedLightCurve.cycle``, case ``epoch_time`` not specified [#1398]
```

I plan to merge the PR in a week.