### PR TITLE
Fixed documentation: astropy doc base url, various docstrings, option to skip ipynb in doc build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Fixed to ensure file handles are properly released when reading
   corrupted TargetPixelFile. [#1399]
 - Fixed ``FoldedLightCurve.cycle``, case ``epoch_time`` not specified [#1398]
+- Various improvements to the online documentation. [#1400]
 
 
 2.4.2 (2023-11-03)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,4 +143,4 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
                        'matplotlib': ('https://matplotlib.org', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-                       'astropy': ('https://docs.astropy.org/en/latest/', None)}
+                       'astropy': ('https://docs.astropy.org/en/stable/', None)}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,12 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["**/.ipynb_checkpoints"]
 
+if os.environ.get('LK_DOC_BUILD_EXCLUDE_IPYNB', None) is not None:
+    # Skip building ipynb (in tutorials) to speed up doc build
+    # for testing changes in other sections: API reference, etc.
+    exclude_patterns.append("**.ipynb")
+    print("Note: .ipynb build is excluded")
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 

--- a/docs/source/reference/misc.rst
+++ b/docs/source/reference/misc.rst
@@ -1,7 +1,7 @@
 .. _api.misc:
 
 =======================
-Miscellaneous utilities 
+Miscellaneous utilities
 =======================
 .. currentmodule:: lightkurve
 
@@ -14,3 +14,4 @@ Working with quality flags
 
   KeplerQualityFlags
   TessQualityFlags
+  utils.plot_image

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2268,7 +2268,8 @@ class LightCurve(TimeSeries):
         path_or_buf : string or file handle
             File path or object. By default, the result is returned as a string.
         **kwargs : dict
-            Dictionary of arguments to be passed to `TimeSeries.write()`.
+            Dictionary of arguments to be passed to
+            `astropy`'s `~astropy.timeseries.TimeSeries.write`.
 
         Returns
         -------
@@ -2292,8 +2293,8 @@ class LightCurve(TimeSeries):
 
         The data frame will be indexed by `time` using values corresponding
         to the light curve's time format.  This is different from the
-        default behavior of `Table.to_pandas()` in AstroPy, which converts
-        time values into ISO timestamps.
+        default behavior of `astropy`'s `~astropy.timeseries.TimeSeries.to_pandas`,
+        which converts time values into ISO timestamps.
 
         Returns
         -------

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1097,7 +1097,7 @@ class TargetPixelFile(object):
             matplotlib's built-in stylesheets (e.g. 'ggplot').
             Lightkurve's custom stylesheet is used by default.
         kwargs : dict
-            Keywords arguments passed to `lightkurve.utils.plot_image`.
+            Keywords arguments passed to `~lightkurve.utils.plot_image`.
 
         Returns
         -------

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1346,8 +1346,8 @@ class TargetPixelFile(object):
             before saving a fits file.  Default: None (no transform is applied).
         ylim_func: function
             A function that returns ylimits (low, high) given a LightCurve object.
-            The default is to return an expanded window around the 10-90th
-            percentile of lightcurve flux values.
+            The default is to return a window approximately around 5 sigma-clipped
+            lightcurve flux values.
 
         Examples
         --------
@@ -1884,8 +1884,8 @@ class TargetPixelFile(object):
             Inspired by https://github.com/noraeisner/LATTE
         corrector_func : function
             Function that accepts and returns a `~lightkurve.lightcurve.LightCurve`.
-            This function is applied to each light curve in the collection
-            prior to stitching. The default is to normalize each light curve.
+            This function is applied to each pixel's light curve.
+            The default is to return a 5 sigma-clipped light curve.
         style : str
             Path or URL to a matplotlib style file, or name of one of
             matplotlib's built-in stylesheets (e.g. 'ggplot').
@@ -1894,7 +1894,7 @@ class TargetPixelFile(object):
             Size of the markers in the lightcurve plot. For periodogram plot, it is used as the line width.
             Default: 0.5
         kwargs : dict
-            e.g. extra parameters to be passed to `lc.to_periodogram`.
+            e.g. extra parameters to be passed to `~lightkurve.LightCurve.to_periodogram`.
 
         Examples
         --------
@@ -1911,7 +1911,7 @@ class TargetPixelFile(object):
             >>>
             >>> # Variation: Customize the plot's size so that each pixel is about 1 inch by 1 inch
             >>> import matplotlib.pyplot as plt
-            >>> fig = plt.figure(figsize=(tpf.flux[0].shape[0] * 1.0, tpf.flux[0].shape[1] * 1.0))    # doctest: +SKIP
+            >>> fig = plt.figure(figsize=(tpf.flux[0].shape[1] * 1.0, tpf.flux[0].shape[0] * 1.0))    # doctest: +SKIP
             >>> tpf.plot_pixels(ax=fig.gca(), aperture_mask='pipeline')    # doctest: +SKIP
 
 


### PR DESCRIPTION
Miscellaneous doc fixes
- Documentation has been referring to the development version of astropy doc, https://docs.astropy.org/en/latest/ , th PR changes it to the latest release https://docs.astropy.org/en/stable/ .
- close #1099 (docstring for `tpf.interact()` and `tpf.plot_pixels()`
- `tpf.plot()`
- `lc.to_csv()` and `lc.to_pandas()`

The PR also changes doc build so that one can optionally skip all `ipynb` in doc build. E.g., it can speed up the cycle if one wants to review the changes in api docstring.

It's done with an environment variable `LK_DOC_BUILD_EXCLUDE_IPYNB`: 
```shell
$ cd docs
$ LK_DOC_BUILD_EXCLUDE_IPYNB=true make html
```
