### PR TITLE
Enhanced tpf.interact(): return pixel selection optionally.

### DIFF
--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -1009,6 +1009,7 @@ def show_interact_widget(
     vmax=None,
     scale="log",
     cmap="Viridis256",
+    return_selected_mask=False,
 ):
     """Display an interactive Jupyter Notebook widget to inspect the pixel data.
 
@@ -1073,6 +1074,9 @@ def show_interact_widget(
         Maximum color scale for tpf figure
     cmap: str
         Colormap to use for tpf plot. Default is 'Viridis256'
+    return_selected_mask: bool
+        Optional, if set to `True`, also return the pixel selection as an aperture mask.
+    TODO: 1) document return result, 2) update for the docstring in tpf.interact(), 3) remind users to copy the result once satisfied.
     """
     if _BOKEH_IMPORT_ERROR is not None:
         log.error(
@@ -1113,6 +1117,9 @@ def show_interact_widget(
         aperture_mask[0, 0] = True
 
     lc.meta["APERTURE_MASK"] = aperture_mask
+
+    # a copy of current pixel current selection for the use of caller
+    selected_mask_to_return = aperture_mask.copy()
 
     if transform_func is not None:
         lc = transform_func(lc)
@@ -1222,10 +1229,12 @@ def show_interact_widget(
                     ylims = _to_unitless(ylim_func(lc_new))
                 fig_lc.y_range.start = ylims[0]
                 fig_lc.y_range.end = ylims[1]
+                np.copyto(selected_mask_to_return,  lc_new.meta["APERTURE_MASK"])  # Update selected_mask_to_return
             else:
                 lc_source.data["flux"] = lc.flux.value * 0.0
                 fig_lc.y_range.start = -1
                 fig_lc.y_range.end = 1
+                selected_mask_to_return.fill(False)  # Update selected_mask_to_return
 
             message_on_save.text = " "
             export_button.button_type = "success"
@@ -1312,7 +1321,11 @@ def show_interact_widget(
         doc.add_root(widgets_and_figures)
 
     output_notebook(verbose=False, hide_banner=True)
-    return show(create_interact_ui, notebook_url=notebook_url)
+    show_result = show(create_interact_ui, notebook_url=notebook_url)
+    if return_selected_mask:
+        return show_result, selected_mask_to_return
+    else:
+        return show_result
 
 
 

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -1009,7 +1009,7 @@ def show_interact_widget(
     vmax=None,
     scale="log",
     cmap="Viridis256",
-    return_selected_mask=False,
+    return_selection_mask=False,
 ):
     """Display an interactive Jupyter Notebook widget to inspect the pixel data.
 
@@ -1074,9 +1074,16 @@ def show_interact_widget(
         Maximum color scale for tpf figure
     cmap: str
         Colormap to use for tpf plot. Default is 'Viridis256'
-    return_selected_mask: bool
-        Optional, if set to `True`, also return the pixel selection as an aperture mask.
-    TODO: 1) document return result, 2) update for the docstring in tpf.interact(), 3) remind users to copy the result once satisfied.
+    return_selection_mask: bool
+        Optional, if set to `True`, return the pixel selection as an aperture mask.
+
+    Returns
+    -------
+    If ``return_selection_mask`` is set to ``True``, this method will return:
+    selection_mask: array-like
+    The mask representing the pixels the user has currently selected.
+    The user should copy the result after pixel selection is finalized, because the values
+    of the return array change dynamically as user changes the pixel selection.
     """
     if _BOKEH_IMPORT_ERROR is not None:
         log.error(
@@ -1321,12 +1328,9 @@ def show_interact_widget(
         doc.add_root(widgets_and_figures)
 
     output_notebook(verbose=False, hide_banner=True)
-    show_result = show(create_interact_ui, notebook_url=notebook_url)
-    if return_selected_mask:
-        return show_result, selected_mask_to_return
-    else:
-        return show_result
-
+    show(create_interact_ui, notebook_url=notebook_url)
+    if return_selection_mask:
+        return selected_mask_to_return
 
 
 def show_skyview_widget(tpf, notebook_url=None, aperture_mask="empty",  magnitude_limit=18):

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1303,6 +1303,7 @@ class TargetPixelFile(object):
         exported_filename=None,
         transform_func=None,
         ylim_func=None,
+        return_selection_mask=False,
         **kwargs,
     ):
         """Display an interactive Jupyter Notebook widget to inspect the pixel data.
@@ -1360,6 +1361,16 @@ class TargetPixelFile(object):
             A function that returns ylimits (low, high) given a LightCurve object.
             The default is to return a window approximately around 5 sigma-clipped
             lightcurve flux values.
+        return_selection_mask: bool
+            Optional, if set to `True`, return the pixel selection as an aperture mask.
+
+        Returns
+        -------
+        If ``return_selection_mask`` is set to ``True``, this method will return:
+        selection_mask : array-like
+            The mask representing the pixels the user has currently selected.
+            The user should copy the result after pixel selection is finalized, because the values
+            of the return array change dynamically as the user changes the pixel selection.
 
         Examples
         --------
@@ -1377,6 +1388,13 @@ class TargetPixelFile(object):
             >>> transform_func = lambda lc: lc.normalize()  # doctest: +SKIP
             >>> tpf.interact(ylim_func=ylim_func, transform_func=transform_func)  # doctest: +SKIP
 
+        the lightcurve after each pixel selection::
+
+            >>> interact_mask = tpf.interact(return_selection_mask=True)  # doctest: +SKIP
+            >>> # Once the desired pixels have been selected, save the result in
+            >>> # a separate variable to "freeze" the selection.
+            >>> my_custom_mask = interact_mask.copy()
+
         """
         from .interact import show_interact_widget
 
@@ -1390,6 +1408,7 @@ class TargetPixelFile(object):
             exported_filename=exported_filename,
             transform_func=transform_func,
             ylim_func=ylim_func,
+            return_selection_mask=return_selection_mask,
             **kwargs,
         )
 

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1393,7 +1393,7 @@ class TargetPixelFile(object):
             >>> interact_mask = tpf.interact(return_selection_mask=True)  # doctest: +SKIP
             >>> # Once the desired pixels have been selected, save the result in
             >>> # a separate variable to "freeze" the selection.
-            >>> my_custom_mask = interact_mask.copy()
+            >>> my_custom_mask = interact_mask.copy()  # doctest: +SKIP
 
         """
         from .interact import show_interact_widget

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -62,6 +62,19 @@ def test_graceful_exit_outside_notebook():
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
+def test_return_selected_mask():
+    """Test to `return_selected_mask=True` can run without any syntax error."""
+    import bokeh
+
+    tpf = TessTargetPixelFile(example_tpf)
+    mask_to_use = tpf.create_threshold_mask()
+    result, selection_mask = tpf.interact(aperture_mask=mask_to_use, return_selected_mask=True)
+    assert result is None
+    # the returned mask should be the same as the supplied one initially
+    assert_array_equal(selection_mask, mask_to_use)
+
+
+@pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
 def test_custom_aperture_mask():
     """Can we provide a custom lightcurve to show?"""
     with warnings.catch_warnings():

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -62,14 +62,13 @@ def test_graceful_exit_outside_notebook():
 
 
 @pytest.mark.skipif(bad_optional_imports, reason="requires bokeh")
-def test_return_selected_mask():
-    """Test to `return_selected_mask=True` can run without any syntax error."""
+def test_return_selection_mask():
+    """Test to `return_selection_mask=True` can run without any syntax error."""
     import bokeh
 
     tpf = TessTargetPixelFile(example_tpf)
     mask_to_use = tpf.create_threshold_mask()
-    result, selection_mask = tpf.interact(aperture_mask=mask_to_use, return_selected_mask=True)
-    assert result is None
+    selection_mask = tpf.interact(aperture_mask=mask_to_use, return_selection_mask=True)
     # the returned mask should be the same as the supplied one initially
     assert_array_equal(selection_mask, mask_to_use)
 


### PR DESCRIPTION
Close #1386

it requires a slight public API change for `tpf.interact()` (a new optional parameter and the correspond return object).

TODOs:
- [x] make the API more generic to leave room for future additions: return a `dict` object that holds the selected pixels mask, rather than the mask directly.
- [x] correspond tests
- [x] docstring update

Misc. changes from review:
- [ ] rename `return_selection_mask` to `return_selected_mask`.

Changelog:
```rst
- Added ``return_selection_mask`` parameter to ``tpf.interact()``, to optionally 
  return the pixel selection as an aperture mask. [#1402]
```