### PR TITLE
short exposure changed to <200s due to new TESS FFI time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@
 - Various improvements to the online documentation. [#1400]
 - Fixed a bug in ``tpf.interact()`` so that proper y label is displayed when
   lightcurve is normalized with ``transform_func``. [#1387]
+- Changed 'short' cadence in search.py to be <200s so the new TESS FFI cadence is excluded [#1394]
 
 
 2.4.2 (2023-11-03)

--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -1375,9 +1375,9 @@ def _mask_by_exptime(products, exptime):
         if exptime in ["fast"]:
             mask &= products["exptime"] < 60
         elif exptime in ["short"]:
-            mask &= (products["exptime"] >= 60) & (products["exptime"] < 300)
+            mask &= (products["exptime"] >= 60) & (products["exptime"] < 200)
         elif exptime in ["long", "ffi"]:
-            mask &= products["exptime"] >= 300
+            mask &= products["exptime"] >= 200
     return mask
 
 


### PR DESCRIPTION
Addresses Issue #1394 . The 'short' cadence was previously defined as 300s, which returned TESS FFI data in Sector 56+, when the FFI cadence was changed to 200s. When using the 'short' flag, users likely want mission product light curves (2-minute or 20-second), so I have updated the filter. 