### PR TITLE
Issue #1401 - centroid_quadratic

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -629,15 +629,22 @@ def centroid_quadratic(data, mask=None):
         data = data.value
     # Step 1: identify the patch of 3x3 pixels (z_)
     # that is centered on the brightest pixel (xx, yy)
+        
+     # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
+    # replacing 0 with nan allows the correct max to be identified. 
     if mask is not None:
         data = data * mask
-    # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
-    # replacing 0 with nan allows the correct max to be identified. 
-    data_masked = data.copy()
-    if np.issubdtype(data_masked.dtype, int):
-        data_masked = data_masked.astype(float)
-    data_masked[data_masked == 0] = np.nan
-    arg_data_max = np.nanargmax(data_masked)
+        
+        data_masked = data.copy()
+        if np.issubdtype(data_masked.dtype, int): # can't replace an int array with nan
+            data_masked = data_masked.astype(float)
+        data_masked[data_masked == 0] = np.nan
+        arg_data_max = np.nanargmax(data_masked)
+    else: 
+        arg_data_max = np.nanargmax(data)
+
+
+
     yy, xx = np.unravel_index(arg_data_max, data.shape)
     # Make sure the 3x3 patch does not leave the TPF bounds
     if yy < 1:

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -631,7 +631,11 @@ def centroid_quadratic(data, mask=None):
     # that is centered on the brightest pixel (xx, yy)
     if mask is not None:
         data = data * mask
-    arg_data_max = np.nanargmax(data)
+    # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
+    # replacing 0 with nan allows the correct max to be identified. 
+    data_masked = data.copy()
+    data_masked[data_masked == 0] = np.nan
+    arg_data_max = np.nanargmax(data_masked)
     yy, xx = np.unravel_index(arg_data_max, data.shape)
     # Make sure the 3x3 patch does not leave the TPF bounds
     if yy < 1:

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -634,6 +634,8 @@ def centroid_quadratic(data, mask=None):
     # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
     # replacing 0 with nan allows the correct max to be identified. 
     data_masked = data.copy()
+    if np.issubdtype(data_masked.dtype, int):
+        data_masked = data_masked.astype(float)
     data_masked[data_masked == 0] = np.nan
     arg_data_max = np.nanargmax(data_masked)
     yy, xx = np.unravel_index(arg_data_max, data.shape)


### PR DESCRIPTION
This PR addresses #1401 which raises the issue that estimate_centroid fails when all flux values are negative and a mask is provided. 
When a mask is provided, this PR sets the mask value as nans rather than 0 before locating the brightest pixel. When all fluxes are negative, this allows for a negative max value location. 