### PR TITLE
Workaround for poetry install error "Package docutils (0.21.post1) not found"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,17 @@ mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
 [tool.poetry.group.dev.dependencies]
 ghp-import = "^2.1.0"
 
+[[tool.poetry.source]]
+# the source is needed to workaround the poetry install error
+# "Package docutils (0.21.post1) not found."
+# details:
+# https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226
+# - the root cause is at pypi / docutils, so the workaround might not
+#   be needed when they fix it.
+name = "pypi-public"
+url = "https://pypi.org/simple/"
+
+
 [build-system]
 requires = ["setuptools", "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Currently, `poetry install` would fail with error "Package docutils (0.21.post1) not found".

CIs would also thus fail: [sample runs](https://github.com/orionlee/lightkurve/actions/runs/8710041215/job/23891040112#step:4:177)

Applying the workaround from:
https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226

Note: the root cause seems to be pypi / docutils . When they fix the underlying issue, the workaround would no longer be needed.