### PR TITLE
docfix: Periodogram.from_lightcurve(): add links to underlying astropy classes

### DIFF
--- a/src/lightkurve/periodogram.py
+++ b/src/lightkurve/periodogram.py
@@ -650,7 +650,8 @@ class LombScarglePeriodogram(Periodogram):
         ls_method="fast",
         **kwargs
     ):
-        """Creates a `Periodogram` from a LightCurve using the Lomb-Scargle method.
+        """Creates a `Periodogram` from a LightCurve using the Lomb-Scargle method in
+        `astropy`'s `~astropy.timeseries.LombScargle`.
 
         By default, the periodogram will be created for a regular grid of
         frequencies from one frequency separation to the Nyquist frequency,
@@ -768,9 +769,11 @@ class LombScarglePeriodogram(Periodogram):
             (`'amplitude'`).
         ls_method : str
             Default: `'fast'`. Passed to the `method` keyword of
-            `astropy.stats.LombScargle()`.
+            `astropy.timeseries.LombScargle()`.
         kwargs : dict
-            Keyword arguments passed to `astropy.stats.LombScargle()`
+            Keyword arguments passed to
+            `LombScargle() <astropy.timeseries.LombScargle>`
+
 
         Returns
         -------
@@ -1019,7 +1022,8 @@ class BoxLeastSquaresPeriodogram(Periodogram):
 
     @staticmethod
     def from_lightcurve(lc, **kwargs):
-        """Creates a `Periodogram` from a LightCurve using the Box Least Squares (BLS) method.
+        """Creates a `Periodogram` from a LightCurve using the Box Least Squares (BLS) method
+        in `astropy`'s `~astropy.timeseries.BoxLeastSquares`.
 
         Parameters
         ----------


### PR DESCRIPTION
The docstring of 
[`LombScarglePeriodogram.from_lightcurve()`](https://docs.lightkurve.org/reference/api/lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve.html#lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve) does not link to underling astropy's classs, and still contains text of the outdated `astropy.stats` package.

This PR fixes it, and similarly for BLS version.

Changelog. Need to amend the existing line
```rst
- Various improvements to the online documentation. [#1400, #1425]
```

