### PR TITLE
Fix `centroid_quadratic()` edge cases 

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -648,6 +648,13 @@ def centroid_quadratic(data, mask=None):
         xx = data.shape[1] - 2
 
     z_ = data[yy - 1 : yy + 2, xx - 1 : xx + 2]
+    if np.any(np.isnan(z_)):
+        # handle edge case the 3X3 patch has NaN
+        # Need some finite value for NaN pixels for the
+        # quadratic fit below: use the mean the mean of the 3x3 patch
+        # to reduce the skew
+        z_ = z_.copy()
+        z_[np.isnan(z_)] = np.nanmean(z_)
 
     # Next, we will fit the coefficients of the bivariate quadratic with the
     # help of a design matrix (A) as defined by Eqn 20 in Vakili & Hogg

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -630,7 +630,11 @@ def centroid_quadratic(data, mask=None):
     # Step 1: identify the patch of 3x3 pixels (z_)
     # that is centered on the brightest pixel (xx, yy)
     if mask is not None:
-        data = data * mask
+        # mask handling.
+        # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
+        # set masked pixels to be smaller than the existing minimum (instead of 0) to resolve it.
+        data = data.copy()
+        data[~mask] = np.nanmin(data) - 1
     arg_data_max = np.nanargmax(data)
     yy, xx = np.unravel_index(arg_data_max, data.shape)
     # Make sure the 3x3 patch does not leave the TPF bounds

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -627,14 +627,20 @@ def centroid_quadratic(data, mask=None):
     """
     if isinstance(data, u.Quantity):
         data = data.value
+
+    if np.issubdtype(data.dtype, int):
+        # multiple code paths below require data be of float type
+        # proactively convert int to float once and for all.
+        data = data.astype(float)
+
     # Step 1: identify the patch of 3x3 pixels (z_)
     # that is centered on the brightest pixel (xx, yy)
     if mask is not None:
         # mask handling.
         # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
-        # set masked pixels to be smaller than the existing minimum (instead of 0) to resolve it.
+        # set masked pixels NaN (instead of 0) to resolve it.
         data = data.copy()
-        data[~mask] = np.nanmin(data) - 1
+        data[~mask] = np.nan
     arg_data_max = np.nanargmax(data)
     yy, xx = np.unravel_index(arg_data_max, data.shape)
     # Make sure the 3x3 patch does not leave the TPF bounds
@@ -651,7 +657,7 @@ def centroid_quadratic(data, mask=None):
     if np.any(np.isnan(z_)):
         # handle edge case the 3X3 patch has NaN
         # Need some finite value for NaN pixels for the
-        # quadratic fit below: use the mean the mean of the 3x3 patch
+        # quadratic fit below: use the mean of the 3x3 patch
         # to reduce the skew
         z_ = z_.copy()
         z_[np.isnan(z_)] = np.nanmean(z_)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,6 +189,13 @@ def test_centroid_quadratic_robustness(mask):
     col, row = centroid_quadratic(data, mask=mask)
     assert np.isfinite(col) & np.isfinite(row)
 
+    # has NaN in the identified 3x3 patch
+    data = np.zeros((5, 5))
+    data[3, 2] = 10
+    data[3, 3] = np.nan
+    col, row = centroid_quadratic(data, mask=mask)
+    assert np.isfinite(col) & np.isfinite(row)
+
     # Data contains are all negative (#1401 case `mask` is specified)
     # in a difference image
     data = np.full((5, 5), -9.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -169,39 +169,61 @@ def test_centroid_quadratic():
 a_mask = np.full((5, 5), True, dtype=bool)
 a_mask[0:2, :] = False
 
-@pytest.mark.parametrize("mask", [None, a_mask])
-def test_centroid_quadratic_robustness(mask):
+@pytest.mark.parametrize("data_dtype, mask", [
+    (float, None),
+    (float, a_mask),
+    (int, None),
+    (int, a_mask),
+    ])
+def test_centroid_quadratic_robustness(data_dtype, mask):
     """Test quadratic centroids in edge cases; regression test for #610, etc."""
     # Brightest pixel in upper left
-    data = np.zeros((5, 5))
+    data = np.zeros((5, 5), dtype=data_dtype)
     data[0, 0] = 1
     centroid_quadratic(data, mask=mask)
+    col, row = centroid_quadratic(data, mask=mask)
+    if mask is None:
+        assert np.isfinite(col) & np.isfinite(row)
+    else:
+        # the mask (of top 2 rows) would make the eligible pixels to be uniformly at 0
+        # no centroid can be calculated in such case.
+        assert np.isnan(col) & np.isnan(row)
 
     # Brightest pixel in bottom right
-    data = np.zeros((5, 5))
+    data = np.zeros((5, 5), dtype=data_dtype)
     data[-1, -1] = 1
-    centroid_quadratic(data, mask=mask)
+    col, row = centroid_quadratic(data, mask=mask)
+    assert np.isfinite(col) & np.isfinite(row)
 
     # Data contains a NaN
-    data = np.zeros((5, 5))
-    data[0, 0] = np.nan
-    data[-1, -1] = 10
-    col, row = centroid_quadratic(data, mask=mask)
-    assert np.isfinite(col) & np.isfinite(row)
+    if data_dtype is float:  # NaN only applicable to float
+        data = np.zeros((5, 5), dtype=data_dtype)
+        data[0, 0] = np.nan
+        data[-1, -1] = 10
+        col, row = centroid_quadratic(data, mask=mask)
+        assert np.isfinite(col) & np.isfinite(row)
 
     # has NaN in the identified 3x3 patch
-    data = np.zeros((5, 5))
-    data[3, 2] = 10
-    data[3, 3] = np.nan
+    if data_dtype is float:  # NaN only applicable to float
+        data = np.zeros((5, 5), dtype=data_dtype)
+        data[3, 2] = 10
+        data[3, 3] = np.nan
+        col, row = centroid_quadratic(data, mask=mask)
+        assert np.isfinite(col) & np.isfinite(row)
+
+    # Data contains are all negative (#1401 case `mask` is specified)
+    # e.g., in a difference image
+    data = np.full((5, 5), -9, dtype=data_dtype)
+    data[3, 2] = -5
     col, row = centroid_quadratic(data, mask=mask)
     assert np.isfinite(col) & np.isfinite(row)
 
-    # Data contains are all negative (#1401 case `mask` is specified)
-    # in a difference image
-    data = np.full((5, 5), -9.0)
-    data[3, 2] = -5.0
-    col, row = centroid_quadratic(data, mask=mask)
-    assert np.isfinite(col) & np.isfinite(row)
+    # case the 3x3 patch contains masked pixels
+    if mask is not None:
+        data = np.zeros((5, 5), dtype=data_dtype)
+        data[2, 1] = 10  # the row above is masked
+        col, row = centroid_quadratic(data, mask=mask)
+        assert np.isfinite(col) & np.isfinite(row)
 
 
 def test_show_citation_instructions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,23 +165,35 @@ def test_centroid_quadratic():
     assert np.isclose(row, 5) & np.isclose(col, 1.5)
 
 
-def test_centroid_quadratic_robustness():
-    """Test quadratic centroids in edge cases; regression test for #610."""
+# create a mask that'd mask out first 2 rows
+a_mask = np.full((5, 5), True, dtype=bool)
+a_mask[0:2, :] = False
+
+@pytest.mark.parametrize("mask", [None, a_mask])
+def test_centroid_quadratic_robustness(mask):
+    """Test quadratic centroids in edge cases; regression test for #610, etc."""
     # Brightest pixel in upper left
     data = np.zeros((5, 5))
     data[0, 0] = 1
-    centroid_quadratic(data)
+    centroid_quadratic(data, mask=mask)
 
     # Brightest pixel in bottom right
     data = np.zeros((5, 5))
     data[-1, -1] = 1
-    centroid_quadratic(data)
+    centroid_quadratic(data, mask=mask)
 
     # Data contains a NaN
     data = np.zeros((5, 5))
     data[0, 0] = np.nan
     data[-1, -1] = 10
-    col, row = centroid_quadratic(data)
+    col, row = centroid_quadratic(data, mask=mask)
+    assert np.isfinite(col) & np.isfinite(row)
+
+    # Data contains are all negative (#1401 case `mask` is specified)
+    # in a difference image
+    data = np.full((5, 5), -9.0)
+    data[3, 2] = -5.0
+    col, row = centroid_quadratic(data, mask=mask)
     assert np.isfinite(col) & np.isfinite(row)
 
 


### PR DESCRIPTION
1. Close #1401 . 
I think the fix here is more robust than PR #1414. Tests are added too.
2. Fix an unrelated scenario where the identified 3x3 patch contains NaN, be it in the data supplied or due to implementation details (in handling masks)

---

changelog  to add:
```rst
- Fixed ``lightkurve.utils.centroid_quadratic()`` in edge cases, e.g., fluxes are all negative with mask specified, NaN in the identified brightest 3X3 patch. [#1426] 
```