### PR TITLE
Fix bokeh 3.4.0 deprecation warnings for `circle()`, `cross()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
   lightcurve is normalized with ``transform_func``. [#1387]
 - Fixed ``lightkurve.utils.centroid_quadratic()`` in edge cases, e.g., fluxes are
   all negative with mask specified, NaN in the identified brightest 3X3 patch. [#1426]
+- Fixed interact features, e.g. ``tpf.interact()``, to be compliant
+  with Bokeh v3.4.0. The minimum Bokeh version is raised to v2.3.2 accordingly. [#1428]
 
 
 2.4.2 (2023-11-03)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ pandas = ">=1.1.4"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"
-# bokeh v2+ requirement due to https://github.com/lightkurve/lightkurve/issues/1261
-bokeh = ">=2.0.0"
+# bokeh v2.3.2+ requirement due to https://github.com/lightkurve/lightkurve/pull/1428
+bokeh = ">=2.3.2"
 memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
 

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -336,7 +336,7 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
         nonselection_line_color="gray",
         nonselection_line_alpha=1.0,
     )
-    circ = fig.circle(
+    circ = fig.scatter(
         "time",
         "flux",
         source=lc_source,
@@ -605,7 +605,7 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
         ]
     tooltips = tooltips_extras + tooltips
 
-    r = fig.circle(
+    r = fig.scatter(
         "x",
         "y",
         source=source,
@@ -637,7 +637,7 @@ def add_gaia_figure_elements(tpf, fig, magnitude_limit=18):
     if target_ra is not None and target_dec is not None:
         pix_x, pix_y = tpf.wcs.all_world2pix([(target_ra, target_dec)], 0)[0]
         target_x, target_y = tpf.column + pix_x, tpf.row + pix_y
-        fig.cross(x=target_x, y=target_y, size=20, color="black", line_width=1)
+        fig.scatter(marker="cross", x=target_x, y=target_y, size=20, color="black", line_width=1)
         if not pm_corrected:
             warnings.warn(("Proper motion correction cannot be applied to the target, as none is available. "
                            "Thus the target (the cross) might be noticeably away from its actual position, "

--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -34,9 +34,10 @@ from .utils import KeplerQualityFlags, LightkurveWarning, LightkurveError, final
 log = logging.getLogger(__name__)
 
 # Import the optional Bokeh dependency, or print a friendly error otherwise.
+_BOKEH_IMPORT_ERROR = None
 try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
-    from bokeh.io import show, output_notebook, push_notebook
+    from bokeh.io import show, output_notebook
     from bokeh.plotting import figure, ColumnDataSource
     from bokeh.models import (
         LogColorMapper,
@@ -55,9 +56,10 @@ try:
     from bokeh.models.tools import HoverTool
     from bokeh.models.widgets import Button, Div
     from bokeh.models.formatters import PrintfTickFormatter
-except ImportError:
+except Exception as e:
     # We will print a nice error message in the `show_interact_widget` function
-    pass
+    # the error would be raised there in case users need to diagnose problems
+    _BOKEH_IMPORT_ERROR = e
 
 
 def _search_nearby_of_tess_target(tic_id):
@@ -1065,19 +1067,12 @@ def show_interact_widget(
     cmap: str
         Colormap to use for tpf plot. Default is 'Viridis256'
     """
-    try:
-        import bokeh
-
-        if bokeh.__version__[0] == "0":
-            warnings.warn(
-                "interact() requires Bokeh version 1.0 or later", LightkurveWarning
-            )
-    except ImportError:
+    if _BOKEH_IMPORT_ERROR is not None:
         log.error(
             "The interact() tool requires the `bokeh` Python package; "
             "you can install bokeh using e.g. `conda install bokeh`."
         )
-        return None
+        raise _BOKEH_IMPORT_ERROR
 
     notebook_url = finalize_notebook_url(notebook_url)
 
@@ -1339,19 +1334,12 @@ def show_skyview_widget(tpf, notebook_url=None, aperture_mask="empty",  magnitud
     magnitude_limit : float
         A value to limit the results in based on Gaia Gmag. Default, 18.
     """
-    try:
-        import bokeh
-
-        if bokeh.__version__[0] == "0":
-            warnings.warn(
-                "interact_sky() requires Bokeh version 1.0 or later", LightkurveWarning
-            )
-    except ImportError:
+    if _BOKEH_IMPORT_ERROR is not None:
         log.error(
             "The interact_sky() tool requires the `bokeh` Python package; "
             "you can install bokeh using e.g. `conda install bokeh`."
         )
-        return None
+        raise _BOKEH_IMPORT_ERROR
 
     notebook_url = finalize_notebook_url(notebook_url)
 

--- a/src/lightkurve/interact_bls.py
+++ b/src/lightkurve/interact_bls.py
@@ -312,7 +312,7 @@ def make_lightcurve_figure_elements(
     fig.y_range = Range1d(start=float(ylims[0]), end=float(ylims[1]))
 
     # Add light curve
-    fig.circle(
+    fig.scatter(
         "time",
         "flux",
         line_width=1,
@@ -346,7 +346,7 @@ def make_lightcurve_figure_elements(
         text_alpha=0.6,
     )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle(
+    help = fig.scatter(
         "time",
         "flux",
         alpha=0.0,
@@ -407,7 +407,7 @@ def make_folded_figure_elements(
     fig.xaxis.axis_label = f"Phase [{f.time.format.upper()}]"
 
     # Scatter point for data
-    fig.circle(
+    fig.scatter(
         "phase",
         "flux",
         line_width=1,
@@ -442,7 +442,7 @@ def make_folded_figure_elements(
         text_alpha=0.6,
     )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle(
+    help = fig.scatter(
         "phase",
         "flux",
         alpha=0.0,
@@ -507,7 +507,7 @@ def make_bls_figure_elements(result, bls_source, help_source):
     )
 
     # Add circles for the selection of new period. These are always hidden
-    fig.circle(
+    fig.scatter(
         "period",
         "power",
         source=bls_source,
@@ -559,7 +559,7 @@ def make_bls_figure_elements(result, bls_source, help_source):
         text_alpha=0.6,
     )
     fig.add_glyph(help_source, question_mark)
-    help = fig.circle(
+    help = fig.scatter(
         "period",
         "power",
         alpha=0.0,

--- a/src/lightkurve/seismology/core.py
+++ b/src/lightkurve/seismology/core.py
@@ -17,15 +17,17 @@ from .utils import SeismologyQuantity
 
 # Import the optional Bokeh dependency required by ``interact_echelle```,
 # or print a friendly error otherwise.
+_BOKEH_IMPORT_ERROR = None
 try:
     import bokeh  # Import bokeh first so we get an ImportError we can catch
     from bokeh.io import show, output_notebook
     from bokeh.plotting import figure
     from bokeh.models import LogColorMapper, Slider, RangeSlider, Button
     from bokeh.layouts import layout, Spacer
-except:
-    # Nice error will be raised when ``interact_echelle``` is called.
-    pass
+except Exception as e:
+    # We will print a nice error message when ``interact_echelle``` is called.
+    # the error would be raised there in case users need to diagnose problems
+    _BOKEH_IMPORT_ERROR = e
 
 log = logging.getLogger(__name__)
 
@@ -516,19 +518,12 @@ class Seismology(object):
             properly. If no protocol is supplied in the URL, e.g. if it is
             of the form "localhost:8888", then "http" will be used.
         """
-        try:
-            import bokeh
-
-            if bokeh.__version__[0] == "0":
-                warnings.warn(
-                    "interact() requires Bokeh version 1.0 or later", LightkurveWarning
-                )
-        except ImportError:
+        if _BOKEH_IMPORT_ERROR is not None:
             log.error(
-                "The interact() tool requires the `bokeh` Python package; "
+                "The interact_echelle() tool requires the `bokeh` package; "
                 "you can install bokeh using e.g. `conda install bokeh`."
             )
-            return None
+            raise _BOKEH_IMPORT_ERROR
 
         maximum_frequency = kwargs.pop(
             "maximum_frequency", self.periodogram.frequency.max().value


### PR DESCRIPTION
Close #1424 

Manually tested on bokeh 3.4.1 and bokeh 2.4.3 . No regression found.

changelog:
```rst
- Fixed interact features, e.g. ``tpf.interact()``, to be compliant
  with Bokeh v3.4.0. The minimum Bokeh version is raised to v2.3.2 accordingly. [#1428]
```