### PR TITLE
Rectangles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
   all negative with mask specified, NaN in the identified brightest 3X3 patch. [#1426]
 - Fixed interact features, e.g. ``tpf.interact()``, to be compliant
   with Bokeh v3.4.0. The minimum Bokeh version is raised to v2.3.2 accordingly. [#1428]
+- Updated aperture plotting to speed it up in the case of large (bleed column) apertures. [#1434]
 
 
 2.4.2 (2023-11-03)

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -1185,23 +1185,18 @@ class TargetPixelFile(object):
         # Overlay the aperture mask if given
         if aperture_mask is not None:
             aperture_mask = self._parse_aperture_mask(aperture_mask)
-            for i in range(self.shape[1]):
-                for j in range(self.shape[2]):
-                    if aperture_mask[i, j]:
-                        if hasattr(ax, "wcs"):
-                            # When using WCS coordinates, do not add col/row to mask coords
-                            xy = (j - 0.5, i - 0.5)
-                        else:
-                            xy = (j + self.column - 0.5, i + self.row - 0.5)
-                        rect = patches.Rectangle(
-                            xy=xy,
-                            width=1,
-                            height=1,
-                            color=mask_color,
-                            fill=False,
-                            hatch="//",
-                        )
-                        ax.add_patch(rect)
+            in_aperture = np.where(aperture_mask)
+            if hasattr(ax, "wcs"):
+                ap_row = in_aperture[0] - 0.5
+                ap_col = in_aperture[1] - 0.5
+            else:
+                ap_row = in_aperture[0] + self.row - 0.5
+                ap_col = in_aperture[1] + self.column - 0.5    
+            for ii in range(len(ap_row)):
+                
+                rect=patches.Rectangle((ap_col[ii],ap_row[ii]),1,1, fill=False, hatch="//", color=mask_color)
+                ax.add_patch(rect)
+                
         return ax
 
     def _to_matplotlib_animation(


### PR DESCRIPTION
This PR is to speed up the aperture mask plotting. Lightkurve issue #1430 pointed out that for extended sources, over-plotting the aperture mask onto the image was very slow. This PR reduces the plotting speed from 1min 24s ± 1.96 s per loop to 1.33 s ± 15.1 ms for the case of the star 'Beta Gem'. 