### PR TITLE
changed moving median to mean

### DIFF
--- a/docs/source/tutorials/3-science-examples/asteroseismology-oscillating-star-periodogram.ipynb
+++ b/docs/source/tutorials/3-science-examples/asteroseismology-oscillating-star-periodogram.ipynb
@@ -491,7 +491,7 @@
    "source": [
     "### 3.1. The box kernel filter\n",
     "\n",
-    "To further explore the oscillation modes, we will demonstrate some of Lightkurve's smoothing tools. There are two types of smoothing functions we can call through the [smooth()](https://docs.lightkurve.org/reference/api/lightkurve.periodogram.Periodogram.smooth.html?highlight=smooth) function. Let's start with a basic \"moving median,\" also known as a 1D box kernel."
+    "To further explore the oscillation modes, we will demonstrate some of Lightkurve's smoothing tools. There are two types of smoothing functions we can call through the [smooth()](https://docs.lightkurve.org/reference/api/lightkurve.periodogram.Periodogram.smooth.html?highlight=smooth) function. Let's start with a basic \"moving mean,\" also known as a 1D box kernel."
    ]
   },
   {
@@ -532,7 +532,7 @@
     "id": "RGjW6wRch84H"
    },
    "source": [
-    "In the figure above, the smoothed periodogram is plotted over the top of the original periodogram. In this case we have used the [Astropy `Box1DKernel`](https://docs.astropy.org/en/stable/api/astropy.convolution.Box1DKernel.html) filter, with a filter width of $0.5\\, \\mu \\rm{Hz}$. The filter takes the median value of power in a region $0.5\\, \\mu \\rm{Hz}$ around a data point, and replaces that point with the median value. It then moves on to the next data point. This creates a smoothed periodogram of the same length as the original. Because the power values are now correlated, these smoothed periodograms usually aren't used for computational analysis, but they can aid visual explorations of the location of the oscillation modes."
+    "In the figure above, the smoothed periodogram is plotted over the top of the original periodogram. In this case we have used the [Astropy `Box1DKernel`](https://docs.astropy.org/en/stable/api/astropy.convolution.Box1DKernel.html) filter, with a filter width of $0.5\\, \\mu \\rm{Hz}$. The filter takes the mean value of power in a region $0.5\\, \\mu \\rm{Hz}$ around a data point, and replaces that point with the mean value. It then moves on to the next data point. This creates a smoothed periodogram of the same length as the original. Because the power values are now correlated, these smoothed periodograms usually aren't used for computational analysis, but they can aid visual explorations of the location of the oscillation modes."
    ]
   },
   {


### PR DESCRIPTION
The tutorial on asterosesimology mistakenly said the moving median and a 1D box kernel is the same thing. However, according to the Astropy documentation, it relies on a moving mean. The language has been updated to reflect this. 