### PR TITLE
fix KEPSEISMIC time format from bkjd to mjd

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@
   all negative with mask specified, NaN in the identified brightest 3X3 patch. [#1426]
 - Fixed interact features, e.g. ``tpf.interact()``, to be compliant
   with Bokeh v3.4.0. The minimum Bokeh version is raised to v2.3.2 accordingly. [#1428]
+- Fixed time format for KEPSEISMIC light curves from bjkd to mjd. [#1443]
 
 
 2.4.2 (2023-11-03)

--- a/src/lightkurve/io/kepseismic.py
+++ b/src/lightkurve/io/kepseismic.py
@@ -21,7 +21,7 @@ def read_kepseismic_lightcurve(filename, **kwargs):
 
     lc = read_generic_lightcurve(
         filename,
-        time_format='bkjd')
+        time_format='mjd')
 
     lc.meta["AUTHOR"] = "KEPSEISMIC"
     lc.meta["TARGETID"] = lc.meta.get("KEPLERID")


### PR DESCRIPTION
From the metadata, it seems the correct format is MJD (based on `MJD-BEG` and `MJD-END` entries).  Without this PR, calling `lc.time.iso` gives timestamps in the year 2159.