### PR TITLE
Read LCs and TPFs from the Cloud

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
   all negative with mask specified, NaN in the identified brightest 3X3 patch. [#1426]
 - Fixed interact features, e.g. ``tpf.interact()``, to be compliant
   with Bokeh v3.4.0. The minimum Bokeh version is raised to v2.3.2 accordingly. [#1428]
+- Added support to read data products hosted on public AWS S3 buckets. [#1451]
+- Added functions to read in collections of light curves or target pixel files. [#1451]
 
 
 2.4.2 (2023-11-03)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ fbpca = ">=1.0"
 bokeh = ">=2.3.2"
 memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
+s3fs = ">=2024.6.1"
 
 [tool.poetry.dev-dependencies]
 jupyterlab = ">=2.0.0"

--- a/src/lightkurve/collections.py
+++ b/src/lightkurve/collections.py
@@ -9,7 +9,6 @@ from astropy.table import vstack
 from astropy.utils.decorators import deprecated
 
 from . import MPLSTYLE
-from .targetpixelfile import TargetPixelFile
 from .utils import LightkurveWarning, LightkurveDeprecationWarning
 
 

--- a/src/lightkurve/io/generic.py
+++ b/src/lightkurve/io/generic.py
@@ -7,7 +7,6 @@ from astropy.table import Table
 from astropy.time import Time
 from astropy.units import UnitsWarning
 import numpy as np
-import s3fs
 
 from ..utils import validate_method
 from ..lightcurve import LightCurve
@@ -32,17 +31,15 @@ def read_generic_lightcurve(
     """Generic helper function to convert a Kepler ot TESS light curve file
     into a generic `LightCurve` object.
     """
-    to_close_fs, to_close_hdul = False, False
+    to_close_hdul = True
     if (isinstance(filename, str) and filename.startswith('s3://')):
         # Filename is an S3 cloud URI
         log.debug('Reading file from AWS S3 cloud.')
-        fs = s3fs.S3FileSystem(anon=True)
-        f, to_close_fs = fs.open(filename, 'rb'), True
-        hdulist, to_close_hdul = fits.open(f), True
+        hdulist = fits.open(filename, use_fsspec=True, fsspec_kwargs={"anon": True})
     elif isinstance(filename, fits.HDUList):
-        hdulist = filename  # Allow HDUList to be passed
+        hdulist, to_close_hdul = filename, False # Allow HDUList to be passed
     else:
-        hdulist, to_close_hdul = fits.open(filename), True
+        hdulist = fits.open(filename)
 
     try:
         # Raise an exception if the requested extension is invalid
@@ -146,5 +143,3 @@ def read_generic_lightcurve(
         if to_close_hdul:
             # avoid hdulist closing from emitting exceptions
             hdulist.close(output_verify="warn")
-        if to_close_fs:
-            f.close()

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -202,7 +202,7 @@ def _read_collection(path_list, products, *, stitch=False, **kwargs):
     else:
         return TargetPixelFileCollection(prod_list)
     
-def read_lc_collection(path_list, *, stitch=True, **kwargs):
+def read_lc_collection(path_list, *, stitch=False, **kwargs):
     return _read_collection(path_list, [TessLightCurve, KeplerLightCurve], stitch=stitch, **kwargs)
 
 def read_tpf_collection(path_list, **kwargs):

--- a/src/lightkurve/io/read.py
+++ b/src/lightkurve/io/read.py
@@ -184,7 +184,7 @@ def _read_collection(path_list, product, *, stitch=False, **kwargs):
             'The resulting collection contains no products.'
         )
     
-    if isinstance(product(), LightCurve):
+    if product is LightCurve:
         # stitch into single LightCurve if indicated
         return LightCurveCollection(prod_list).stitch() if stitch else LightCurveCollection(prod_list)
     else:

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -102,6 +102,8 @@ class TargetPixelFile(object):
 
     def __init__(self, path, quality_bitmask="default", targetid=None, **kwargs):
         self.path = path
+        self.fs_file = None
+        self.gz_file = None
         if isinstance(path, fits.HDUList):
             self.hdu = path
         elif (isinstance(path, str) and path.startswith('s3://')):
@@ -2143,7 +2145,7 @@ class KeplerTargetPixelFile(TargetPixelFile):
                 self.targetid = self.get_header().get("KEPLERID")
         except Exception as e:
             # Cannot instantiate TargetPixelFile, close the HDU to release the file handle
-            self.close_files()
+            self._close_files()
             raise e
 
     def __repr__(self):
@@ -2823,7 +2825,7 @@ class TessTargetPixelFile(TargetPixelFile):
                 self.targetid = self.get_header().get("TICID")
         except Exception as e:
             # Cannot instantiate TargetPixelFile, close the HDU to release the file handle
-            self.close_files()
+            self._close_files()
             raise e
 
     def __repr__(self):

--- a/tests/test_periodogram.py
+++ b/tests/test_periodogram.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 
 from astropy import units as u
 from astropy.time import Time
-from astropy.stats.bls import BoxLeastSquares
+from astropy.timeseries import BoxLeastSquares
 from astropy.utils.masked import Masked
 
 from lightkurve.lightcurve import LightCurve

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 from astropy.utils.data import get_pkg_data_filename
-from astropy.stats.bls import BoxLeastSquares
+from astropy.timeseries import BoxLeastSquares
 
 import numpy as np
 import pytest


### PR DESCRIPTION
This PR allows users to read data products from the cloud using S3 URIs.

- Users can read data products (light curve files and TPFs) from the AWS S3 cloud.
- New functions to read a collection of light curves or a collection of TPFs.
  - Optional `stitch` parameter in `read_lc_collection` to return a single light curve from a collection. 
- Added relevant test cases to `test_read.py`.
- Fixed out-of-date astropy import in `test_periodogram.py` and `test_synthetic_data.py` 

