### PR TITLE
Fix unit bug in `to_fits`

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2488,7 +2488,10 @@ class LightCurve(TimeSeries):
             ).any():
                 cols.append(
                     fits.Column(
-                        name=flux_column_name, format="E", unit="e-/s", array=self.flux
+                        name=flux_column_name,
+                        format="E",
+                        unit=self.flux.unit.to_string(),
+                        array=self.flux,
                     )
                 )
             if hasattr(self,'flux_err'):
@@ -2497,7 +2500,7 @@ class LightCurve(TimeSeries):
                         fits.Column(
                             name=flux_column_name.upper() + "_ERR",
                             format="E",
-                            unit="e-/s",
+                            unit=self.flux_err.unit.to_string(),
                             array=self.flux_err,
                         )
                     )

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -932,6 +932,25 @@ def test_to_fits():
         )
 
 
+def test_to_fits_flux_units_in_header():
+    # Test the units
+    hdu = LightCurve(
+        time=[0, 1, 2, 3, 4] * u.s,
+        flux=[1, 1, 1, 1, 1] * u.dimensionless_unscaled,
+        flux_err=[0.1, 0.1, 0.1, 0.1, 0.1] * u.dimensionless_unscaled,
+    ).to_fits()
+    assert "TUNIT2" not in hdu[1].header
+    assert "TUNIT3" not in hdu[1].header
+
+    hdu = LightCurve(
+        time=[0, 1, 2, 3, 4] * u.s,
+        flux=[1, 1, 1, 1, 1] * u.Jy,
+        flux_err=[0.1, 0.1, 0.1, 0.1, 0.1] * u.Jy,
+    ).to_fits()
+    assert hdu[1].header["TUNIT2"] == "Jy"
+    assert hdu[1].header["TUNIT3"] == "Jy"
+
+
 def test_astropy_time_bkjd():
     """Does `KeplerLightCurve` support bkjd?"""
     bkjd = np.array([100, 200])


### PR DESCRIPTION
The `to_fits` writer was assigning the same units to all fluxes. This fix was copied from @christinahedges's branch: https://github.com/christinahedges/lightkurve/tree/fitskeywordcheck. I also added some tests.

closes #1453 