### PR TITLE
Add max numpy version to `pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-numpy = {">=1.18, <=1.24"}
+numpy = ">=1.18, <=1.24"
 astropy = ">=5.0"
 scipy = { version = ">=1.7", python = ">=3.8,<3.11" }
 matplotlib = ">=3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ include = ["AUTHORS.rst", "CHANGES.rst", "CONTRIBUTING.rst", "CITATION"]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-numpy = ">=1.18"
+numpy = {">=1.18, <=1.24"}
 astropy = ">=5.0"
 scipy = { version = ">=1.7", python = ">=3.8,<3.11" }
 matplotlib = ">=3.1"


### PR DESCRIPTION
There seem to be problems with using numpy 2.0 but I found that 1.24 works!  Modified `pyproject.toml` accordingly. 