### PR TITLE
better workaround for docutils installation with poetry/pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,19 +67,12 @@ ghp-import = ">=1.0.1"
 openpyxl = ">=3.0.7"
 tox = ">=3.24.5"
 mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
+# docutils 0.21 cannot be installed with poetry
+# See https://github.com/python-poetry/poetry/issues/9293
+docutils = "!=0.21"
 
 [tool.poetry.group.dev.dependencies]
 ghp-import = "^2.1.0"
-
-[[tool.poetry.source]]
-# the source is needed to workaround the poetry install error
-# "Package docutils (0.21.post1) not found."
-# details:
-# https://github.com/python-poetry/poetry/issues/9293#issuecomment-2048205226
-# - the root cause is at pypi / docutils, so the workaround might not
-#   be needed when they fix it.
-name = "pypi-public"
-url = "https://pypi.org/simple/"
 
 
 [build-system]


### PR DESCRIPTION
This is to replace the workaround in PR #1419  for pypi/poetry issue with docutils 0.21.post1
- this workaround is localized to docutils version, without the possible installation-wise side effects.
- the previous workaround in PR #1419 changed the pypi repository url to https://pypi.org/simple/ for entire installation, possibly inviting unforeseen side-effects.