### PR TITLE
Update targetpixelfile.py (Pixel to world coordinate transform consistency Issue #1457)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 2.5.1  (unreleased)
 =====================
-
+- Fixed pixel to world coordinate transformation in ``TargetPixelFile.get_coordinates()`` 
+  in line 488 ("ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)"), where for consistency with 
+  Gaia the origin should be 0 instead of 1.
 
 2.5.0 (2024-08-29)
 =====================

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -485,7 +485,7 @@ class TargetPixelFile(object):
         ).transpose([1, 2, 0])
 
         # Pass through WCS
-        ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)
+        ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 0)
         ra = ra.reshape((pos_corr1_pix.shape[0], self.shape[1], self.shape[2]))
         dec = dec.reshape((pos_corr2_pix.shape[0], self.shape[1], self.shape[2]))
         ra, dec = ra[self.quality_mask], dec[self.quality_mask]


### PR DESCRIPTION
@orynaivashtenko  noticed that TargetPixelFile.get_coordinates uses origin index of 1 in line 488:

"ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)"

whereas for consistency with Gaia it should be 0. This affects TargetPixelFile.get_coordinates and TargetPixelFile.cutout