### PR TITLE
Fixed select_flux() inconsistency between flux and flux_err in some cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,12 @@
 2.5.1  (unreleased)
 =====================
-- Fixed pixel to world coordinate transformation in ``TargetPixelFile.get_coordinates()`` 
-  in line 488 ("ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)"), where for consistency with 
-  Gaia the origin should be 0 instead of 1.
+
+- Fixed pixel to world coordinate transformation in ``TargetPixelFile.get_coordinates()``
+  in line 488 ("ra, dec = w.wcs_pix2world(X.ravel(), Y.ravel(), 1)"), where for consistency with
+  Gaia the origin should be 0 instead of 1. [#1465]
+- Fixed ``LightCurve.select_flux()`` in edge cases, where the unit of
+  the new ``flux`` column is different from that of the ``flux_err`` column. [#1467]
+
 
 2.5.0 (2024-08-29)
 =====================

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -561,7 +561,7 @@ class LightCurve(TimeSeries):
             else:
                 # fill in a dummy all-nan flux_err column
                 # ensure the unit of new flux_err is consistent with that of flux.
-                flux_err_col_vals = np.full_like(lc["flux"].value, np.nan)
+                flux_err_col_vals = np.full(lc["flux"].shape, np.nan)
                 if lc["flux"].unit is not None:
                     flux_err_col_vals = flux_err_col_vals * lc["flux"].unit
                 lc["flux_err"] = flux_err_col_vals

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -559,7 +559,12 @@ class LightCurve(TimeSeries):
             if flux_err_column in lc.columns:
                 lc["flux_err"] = lc[flux_err_column]
             else:
-                lc["flux_err"][:] = np.nan
+                # fill in a dummy all-nan flux_err column
+                # ensure the unit of new flux_err is consistent with that of flux.
+                flux_err_col_vals = np.full_like(lc["flux"].value, np.nan)
+                if lc["flux"].unit is not None:
+                    flux_err_col_vals = flux_err_col_vals * lc["flux"].unit
+                lc["flux_err"] = flux_err_col_vals
 
         lc.meta['FLUX_ORIGIN'] = flux_column
         normalized_new_flux = lc["flux"].unit is None or lc["flux"].unit is u.dimensionless_unscaled

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -566,6 +566,15 @@ class LightCurve(TimeSeries):
                     flux_err_col_vals = flux_err_col_vals * lc["flux"].unit
                 lc["flux_err"] = flux_err_col_vals
 
+        # Ensure resulting flux / flux_err have the same
+        # Do the check here after the columns are selected so as to uniformly handle
+        # different cases.
+        if lc["flux"].unit != lc["flux_err"].unit:
+            raise ValueError(
+                f"Columns '{flux_column}' and '{flux_err_column}' have different units: "
+                f"{lc.flux.unit} and {lc.flux_err.unit} respectively."
+            )
+
         lc.meta['FLUX_ORIGIN'] = flux_column
         normalized_new_flux = lc["flux"].unit is None or lc["flux"].unit is u.dimensionless_unscaled
         # Note: here we assume unitless flux means it's normalized

--- a/tests/io/test_eleanor.py
+++ b/tests/io/test_eleanor.py
@@ -3,7 +3,7 @@ import pytest
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_equal
 
 from lightkurve import search_lightcurve
 from lightkurve.io.eleanor import read_eleanor_lightcurve
@@ -31,6 +31,10 @@ def test_gsfc_eleanor_lite():
         lc = read_eleanor_lightcurve(url, quality_bitmask='hardest')
         assert not (lc["quality"] & (2**17 | 2**18)).any()
         assert np.issubdtype(lc["cadenceno"].dtype, np.integer)
+
+        # https://github.com/lightkurve/lightkurve/issues/1467
+        lc = lc.select_flux("flux_bkg")
+        assert_equal(lc["flux_err"].unit, lc["flux"].unit)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1960,6 +1960,10 @@ def test_select_flux():
     assert all(lc.select_flux("newflux", flux_err_column="newflux").flux_err == lc.newflux)
     # ensure flux_err in the new lc is nan if the origin does not have it
     assert all(np.isnan(lc.select_flux("newflux_n1")["flux_err"]))
+    assert_equal(  # https://github.com/lightkurve/lightkurve/issues/1467
+        lc.select_flux("newflux_n1")["flux_err"].unit, lc.select_flux("newflux_n1")["flux"].unit,
+        "The unit of the all-nan flux_err should be the same as that of flux [#1467]"
+    )
     # Do invalid column names raise a ValueError?
     with pytest.raises(ValueError):
         lc.select_flux("doesnotexist")

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1947,6 +1947,10 @@ def test_select_flux():
                           'newflux_err': [7, 8, 9] * u_e_s,
                           'newflux_n1': [0.9, 1, 1.1] * u.dimensionless_unscaled,  # normalized, unitless
                           'newflux_n2': [0.9, 1, 1.1],  # normalized, no unit
+                          'newflux_n3': [4, 5, 6] * u_e_s,  # case flux and _err have different units
+                          'newflux_n3_err': [1, 2, 3] * u.percent,
+                          'newflux_n4': [4, 5, 6] * u_e_s,  # case flux and _err have different units
+                          'newflux_n4_err': [.01, .02, .03],  # normalized, no unit
                           },
                           )
     # Can we set flux to newflux?
@@ -1964,6 +1968,11 @@ def test_select_flux():
         lc.select_flux("newflux_n1")["flux_err"].unit, lc.select_flux("newflux_n1")["flux"].unit,
         "The unit of the all-nan flux_err should be the same as that of flux [#1467]"
     )
+    # Do inconsistent units in the selected columns raise a ValueError? [issue 1467]
+    with pytest.raises(ValueError, match="different units"):
+        lc.select_flux("newflux_n3")
+    with pytest.raises(ValueError, match="different units"):
+        lc.select_flux("newflux_n4")
     # Do invalid column names raise a ValueError?
     with pytest.raises(ValueError):
         lc.select_flux("doesnotexist")


### PR DESCRIPTION
Close #1467 

Changelog to be added:
```rst
- Fixed ``LightCurve.select_flux()`` in edge cases, where the unit of
  the new ``flux`` column is different from that of the ``flux_err`` column. [#1467]
```