### PR TITLE
bump version to 2.5.1dev for pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lightkurve"
-version = "2.5.0"
+version = "2.5.1dev"
 description = "A friendly package for Kepler & TESS time series analysis in Python."
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>"]


### PR DESCRIPTION
PR #1464 misses bumping the version for `pyproject.toml`
This PR fixes it.
