### PR TITLE
numpy2 compatibility: replace np.NaN with np.nan

### DIFF
--- a/src/lightkurve/interact.py
+++ b/src/lightkurve/interact.py
@@ -1233,7 +1233,7 @@ def show_interact_widget(
                 vertical_line.update(location=tpf.time.value[frameno])
             else:
                 fig_tpf.select("tpfimg")[0].data_source.data["image"] = [
-                    tpf.flux.value[0, :, :] * np.NaN
+                    tpf.flux.value[0, :, :] * np.nan
                 ]
             lc_source.selected.indices = []
 


### PR DESCRIPTION
`np.NaN` is removed in numpy 2. The offending codes would raise `AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.`

It fixes one of the problems with numpy 2. (see also: #1440)

Searched the entire code base for `np.NaN`. Only 1 occurrence was found (and fixed).

Changelog to add:
```rst
- Fixed numpy v2 compatibility for ``tpf.interact()``. [#1473]
```


