### PR TITLE
Update lightcurve.py

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1989,6 +1989,9 @@ class LightCurve(TimeSeries):
                     log.warning(f"Column `{column}` has no associated errors.")
             else:
                 ax.plot(self.time.value, flux.value, **kwargs)
+            # Default title (none)
+            if title is not None:
+                ax.set_title(title)
             ax.set_xlabel(xlabel)
             ax.set_ylabel(ylabel)
             # Show the legend if labels were set


### PR DESCRIPTION
I have added lines 1992-1994 to `lightkurve/lightkurve/lightkurve.py` which add the ability to title a light kurve plot. This is quite a simple addition to allow for individuals to title their light curve plots and should not cause any issues with other aspects of the file.