### PR TITLE
Update `pyproject.toml` file and GitHub actions to avoid poetry moden-installer problem

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -48,9 +48,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 'poetry>=1.4.0'
-        poetry config installer.modern-installation false
-        poetry install
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install --with dev
     - name: Test with ${{ matrix.pytest-command }}
       run: |
         ${{ matrix.pytest-command }}
@@ -70,9 +70,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 'poetry>=1.4.0'
-        poetry config installer.modern-installation false
-        poetry install
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install --with dev
     - name: Test with pytest
       run: |
         poetry run pytest
@@ -91,9 +91,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip 'poetry>=1.4.0'
-        poetry config installer.modern-installation false
-        poetry install
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install --with dev
     - name: Test with pytest
       run: |
         poetry run pytest
@@ -112,9 +112,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install flake8
       run: |
-        python -m pip install --upgrade pip 'poetry>=1.4.0'
-        poetry config installer.modern-installation false
-        poetry install
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install --with dev
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "lightkurve"
 version = "2.5.0"
 description = "A friendly package for Kepler & TESS time series analysis in Python."
 license = "MIT"
-authors = ["Geert Barentsen <hello@geert.io>"]
+authors = ["Geert Barentsen <hello@geert.io>", "TESS Science Support Center <tesshelp@bigbang.gsfc.nasa.gov>"]
 readme = "README.rst"
 homepage = "https://docs.lightkurve.org"
 repository = "https://github.com/lightkurve/lightkurve"
@@ -34,7 +34,7 @@ beautifulsoup4 = ">=4.6.0"
 requests = ">=2.22.0"
 urllib3 = { version = ">=1.23", python = ">=3.8,<4.0" }  # necessary to make requests work on py310
 tqdm = ">=4.25.0"
-pandas = ">=1.1.4"
+pandas = ">=1.3.6"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"
@@ -44,7 +44,10 @@ memoization = { version = ">=0.3.1", python = ">=3.8,<4.0" }
 scikit-learn = ">=0.24.0"
 s3fs = ">=2024.6.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
 jupyterlab = ">=2.0.0"
 black = ">=21.12b0"
 flake8 = ">=3.8.4"
@@ -63,7 +66,7 @@ sphinx-automodapi = ">=0.13"
 sphinxcontrib-rawfiles = ">=0.1.1"
 pydata-sphinx-theme = "==0.8.1"
 pylint = ">=2.6.0"
-ghp-import = ">=1.0.1"
+ghp-import = "^2.1.0"
 openpyxl = ">=3.0.7"
 tox = ">=3.24.5"
 mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
@@ -71,12 +74,8 @@ mistune = "<2.0.0"  # Workaround for #1162 (not a true dependency)
 # See https://github.com/python-poetry/poetry/issues/9293
 docutils = "!=0.21"
 
-[tool.poetry.group.dev.dependencies]
-ghp-import = "^2.1.0"
-
-
 [build-system]
-requires = ["setuptools", "poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
@Nschanche has found that currently the tests are breaking for her PR #1480 because of the poetry modern installer command being deprecated. This updates the pyproject file and github actions to try to fix this problem.