### PR TITLE
To fits withtime

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2538,9 +2538,7 @@ class LightCurve(TimeSeries):
                             array=extra_data[kw].value,
                         )
                     )
-                    print("{}".format(kw).upper())
-                    print(extra_data[kw].format)
-                    print(extra_data[kw].value)
+
                 
                 elif isinstance(extra_data[kw], (np.ndarray, list)):
                     cols.append(

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -2529,7 +2529,20 @@ class LightCurve(TimeSeries):
                         fits.Column(name="CADENCENO", format="J", array=self.cadenceno)
                     )
             for kw in extra_data:
-                if isinstance(extra_data[kw], (np.ndarray, list)):
+                if isinstance(extra_data[kw], TimeBase):
+                    cols.append(
+                        fits.Column(
+                            name="{}".format(kw).upper(),
+                            format="D",
+                            unit=extra_data[kw].format,
+                            array=extra_data[kw].value,
+                        )
+                    )
+                    print("{}".format(kw).upper())
+                    print(extra_data[kw].format)
+                    print(extra_data[kw].value)
+                
+                elif isinstance(extra_data[kw], (np.ndarray, list)):
                     cols.append(
                         fits.Column(
                             name="{}".format(kw).upper(),
@@ -2537,6 +2550,8 @@ class LightCurve(TimeSeries):
                             array=extra_data[kw],
                         )
                     )
+
+
             if "SAP_QUALITY" not in extra_data:
                 cols.append(
                     fits.Column(


### PR DESCRIPTION
For the final example in [this tutorial](https://lightkurve.github.io/lightkurve/tutorials/2-creating-light-curves/2-1-saving-a-light-curve.html), the phase folded time is not saved if passed to the to_fits method directly. This tutorial solves this by passing DEMO_COLUMN=demo_vector.value.  However, it would be better to allow time objects to be saved, and to add the associated time unit. This PR checks if a time object is passed, and if so saved the value and unit. 