### PR TITLE
update numpy array comparisons to use isin

### DIFF
--- a/docs/source/tutorials/3-science-examples/exoplanets-machine-learning-preprocessing.ipynb
+++ b/docs/source/tutorials/3-science-examples/exoplanets-machine-learning-preprocessing.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "Machine learning offers interesting avenues for automated lightcurve classification, and complex regression tasks.  The key idea is to hand a pile of data to a black box algorithm that learns labels on training data through gradient descent optimization, while mitigating overfitting by checking classification performance against held-out test data.  \n",
     "\n",
-    "Machine learning algorithms work best when data are \"clean\", or devoid of missing values and spurious noise.  Data scientists and machine learning practitioners often quip that data preparation, cleaning, and preprocessing can occupy a large fraction of a machine learning project, so making this step easier will help faciliate machine learning projects.\n",
+    "Machine learning algorithms work best when data are \"clean\", or devoid of missing values and spurious noise.  Data scientists and machine learning practitioners often quip that data preparation, cleaning, and preprocessing can occupy a large fraction of a machine learning project, so making this step easier will help facilitate machine learning projects.\n",
     "\n",
     "In this tutorial we replicate the machine learning *Input Representations* of Kepler lightcurves described by [Shallue & Vanderburg 2018](https://ui.adsabs.harvard.edu/abs/2018AJ....155...94S/abstract):\n",
     "\n",
@@ -120,7 +120,7 @@
     "temp_fold = lc_clean.fold(period, epoch_time=t0)\n",
     "fractional_duration = (duration_hours / 24.0) / period\n",
     "phase_mask = np.abs(temp_fold.phase.value) < (fractional_duration * 1.5)\n",
-    "transit_mask = np.in1d(lc_clean.time.value, temp_fold.time_original.value[phase_mask])"
+    "transit_mask = np.isin(lc_clean.time.value, temp_fold.time_original.value[phase_mask])"
    ]
   },
   {

--- a/src/lightkurve/correctors/cbvcorrector.py
+++ b/src/lightkurve/correctors/cbvcorrector.py
@@ -133,7 +133,7 @@ class CBVCorrector(RegressionCorrector):
         # We do not want any NaNs
         lc = lc.remove_nans()
 
-        # Call the RegresssionCorrector Constructor
+        # Call the RegressionCorrector Constructor
         super(CBVCorrector, self).__init__(lc)
 
         #***
@@ -236,7 +236,7 @@ class CBVCorrector(RegressionCorrector):
             List of CBV vectors to use in each passed cbv_type. {'ALL' => Use all}
             NOTE: 1-Based indexing!
         alpha : float
-            L2-norm regularization penatly term. Default = 1e-20
+            L2-norm regularization penalty term. Default = 1e-20
             {0 => no regularization}
         ext_dm  :  `.DesignMatrix` or `.DesignMatrixCollection`
             Optionally pass an extra design matrix to also be used in the fit
@@ -255,7 +255,7 @@ class CBVCorrector(RegressionCorrector):
         --------
         The following example will perform the correction using the
         SingleScale and Spike basis vectors with a weak regularization alpha
-        term of 0.1. It also adds in an external design matrix to perfomr a
+        term of 0.1. It also adds in an external design matrix to perform a
         joint fit.
             >>> cbv_type = ['SingleScale', 'Spike']
             >>> cbv_indices = [np.arange(1,9), 'ALL']
@@ -394,7 +394,7 @@ class CBVCorrector(RegressionCorrector):
         """ Optimizes the correction by adjusting the L2-Norm (Ridge Regression)
         regularization penalty term, alpha, based on the introduced noise
         (over-fitting) and residual correlation (under-fitting) goodness
-        metrics. The numercial optimization is performed using the
+        metrics. The numerical optimization is performed using the
         scipy.optimize.minimize_scalar Brent's method.
 
         The optimizer attempts to maximize the over- and under-fitting goodness
@@ -422,7 +422,7 @@ class CBVCorrector(RegressionCorrector):
         cadence_mask : np.ndarray of bools (optional)
             Mask, where True indicates a cadence that should be used.
         alpha_bounds : float list(len=2)
-            upper anbd lowe bounds for alpha
+            upper and lower bounds for alpha
         target_over_score : float
             Target Over-fitting metric score
         target_under_score : float
@@ -513,7 +513,7 @@ class CBVCorrector(RegressionCorrector):
         ----------
         n_samples : int
             The number of times to compute and average the metric
-            This can stabalize the value, defaut = 10
+            This can stabilize the value, default = 10
 
         Returns
         -------
@@ -707,7 +707,7 @@ class CBVCorrector(RegressionCorrector):
                         cbv_idx_loop = cbvs.cbv_indices
                     # Trim to nCBVs in cbvs
                     cbv_idx_loop = np.array([idx for idx in cbv_idx_loop if
-                        bool(np.in1d(idx, cbvs.cbv_indices))])
+                        bool(np.isin(idx, cbvs.cbv_indices))])
             
                     if cbv_type[idx].find('MultiScale') >= 0:
                         # Find the correct band if this is a multi-scale CBV set
@@ -780,7 +780,7 @@ class CBVCorrector(RegressionCorrector):
         under-fitting goodness metrics to return a scalar penalty term to
         minimize.
 
-        Uses the paramaters in self.optimization_params.
+        Uses the parameters in self.optimization_params.
 
         Parameters (in self.optimization_params)
         ----------
@@ -1006,7 +1006,7 @@ class CotrendingBasisVectors(TimeSeries):
     ----------
     cadenceno       : int array-like
         Cadence indices
-    time            : flaot array-like
+    time            : float array-like
         CBV cadence times
     gap_indicators  : bool array-like
         True => cadence is gapped
@@ -1021,7 +1021,7 @@ class CotrendingBasisVectors(TimeSeries):
     #***
     def __init__(self, data=None, time=None, **kwargs):
 
-        # Add some columns if not existant
+        # Add some columns if not existent
         if data is not None:
             if not 'GAP' in data.colnames:
                 data['GAP'] = np.full(data[data.colnames[0]].size, False)
@@ -1243,7 +1243,7 @@ class CotrendingBasisVectors(TimeSeries):
 
             # NaN any CBV cadences that are in the light curve and not in CBVs
             # This requires us to add rows to the CBV table
-            lc_nan_mask = np.logical_not(np.in1d(lc.cadenceno, cbvs.cadenceno))
+            lc_nan_mask = np.logical_not(np.isin(lc.cadenceno, cbvs.cadenceno))
             # Determine if the CBVs are poorly aligned to the light curve
             if ((np.count_nonzero(lc_nan_mask) / len(lc_nan_mask)) >
                             poorly_aligned_threshold):
@@ -1271,7 +1271,7 @@ class CotrendingBasisVectors(TimeSeries):
             # REALLY slow.
             try:
                 # This method is fast but might cause errors
-                keep_indices = np.nonzero(np.in1d(cbvs.cadenceno, lc.cadenceno))[0]
+                keep_indices = np.nonzero(np.isin(cbvs.cadenceno, lc.cadenceno))[0]
                 # Determine if the CBVs are poorly aligned to the light curve
                 if (len(keep_indices) / len(cbvs)) < poorly_aligned_threshold:
                     poorly_aligned_flag = True
@@ -1279,7 +1279,7 @@ class CotrendingBasisVectors(TimeSeries):
             except:
                 # This method is slow but appears to be more robust
                 trim_indices = np.nonzero(np.logical_not(
-                    np.in1d(cbvs.cadenceno, lc.cadenceno)))[0]
+                    np.isin(cbvs.cadenceno, lc.cadenceno)))[0]
                 # Determine if the CBVs are poorly aligned to the light curve
                 if (len(trim_indices) / len(cbvs)) > poorly_aligned_threshold:
                     poorly_aligned_flag = True
@@ -1290,7 +1290,7 @@ class CotrendingBasisVectors(TimeSeries):
 
         else:
             raise Exception('align requires cadence numbers for the ' + \
-                    'light curve. NO SYNCHRONIZATION OCCURED')
+                    'light curve. NO SYNCHRONIZATION OCCURRED')
 
         # Only issue this warning once
         if poorly_aligned_flag:
@@ -1569,7 +1569,7 @@ class TessCotrendingBasisVectors(CotrendingBasisVectors):
         """Initiates a TessCotrendingBasisVectors object.
 
         Normally one would use TessCotrendingBasisVectors.from_hdu to
-        automatically set up the object. However, for certain functionaility
+        automatically set up the object. However, for certain functionality
         one must instantiate the object directly.
         """
 
@@ -1612,7 +1612,7 @@ class TessCotrendingBasisVectors(CotrendingBasisVectors):
             raise ValueError('Invalid band')
 
         # Get the requested cbv_type
-        # Curiosly, camera and CCD are not in the primary header!
+        # Curiously, camera and CCD are not in the primary header!
         camera = hdu[1].header['CAMERA']
         ccd = hdu[1].header['CCD']
         switcher = {
@@ -1624,7 +1624,7 @@ class TessCotrendingBasisVectors(CotrendingBasisVectors):
             }
         extName = switcher.get(cbv_type, switcher['unknown'])
         if (extName == 'error'):
-            raise Exception('Invalide cbv_type')
+            raise Exception('Invalid cbv_type')
 
         try:
 

--- a/src/lightkurve/correctors/designmatrix.py
+++ b/src/lightkurve/correctors/designmatrix.py
@@ -644,7 +644,7 @@ class SparseDesignMatrix(DesignMatrix):
 
         # You can't split on the first or last index
         row_indices = list(
-            np.asarray(row_indices)[~np.in1d(row_indices, [0, self.shape[0]])]
+            np.asarray(row_indices)[~np.isin(row_indices, [0, self.shape[0]])]
         )
         if len(row_indices) == 0:
             return self
@@ -659,7 +659,7 @@ class SparseDesignMatrix(DesignMatrix):
         )
         dm._X = hstack(
             [
-                dm.X.multiply(lil_matrix(np.in1d(x, idx).astype(int)).T)
+                dm.X.multiply(lil_matrix(np.isin(x, idx).astype(int)).T)
                 for idx in np.array_split(x, row_indices)
             ],
             format="lil",

--- a/src/lightkurve/correctors/metrics.py
+++ b/src/lightkurve/correctors/metrics.py
@@ -147,7 +147,7 @@ def underfit_metric_neighbors(
     interpolated to the corrected_lc cadence times. extrapolate=True will 
     further extrapolate the targets to the corrected_lc cadence times.
 
-    The returned under-fitting goodness metric is callibrated such that a
+    The returned under-fitting goodness metric is calibrated such that a
     value of 0.95 means the residual correlations in the target is
     equivalent to chance correlations of White Gaussian Noise.
 
@@ -214,7 +214,7 @@ def underfit_metric_neighbors(
 
     # The selection basis for targets used for the PDC-MAP SVD  uses median
     # absolute correlation per star.  However, here we wish to overemphasize
-    # any residual correlation between a handfull of targets and not the
+    # any residual correlation between a handful of targets and not the
     # overall correlation (which should almost always be low).
 
     # We want a residual correlation larger than random correlations of WGN
@@ -384,7 +384,7 @@ def _align_to_lc(lc, ref_lc):
     cadence numbers that exist in ref_lc but not in lc will
     have NaNs returned for those cadences.
 
-    Any cadences in the lc not in ref_lc will be removed from the returnd lc.
+    Any cadences in the lc not in ref_lc will be removed from the returned lc.
 
     The returned lc is sorted by cadenceno.
 
@@ -413,7 +413,7 @@ def _align_to_lc(lc, ref_lc):
 
         # NaN any cadences in ref_lc and not lc
         # This requires us to add rows to the lc table
-        lc_nan_mask = np.logical_not(np.in1d(ref_lc.cadenceno, aligned_lc.cadenceno))
+        lc_nan_mask = np.logical_not(np.isin(ref_lc.cadenceno, aligned_lc.cadenceno))
         lc_nan_indices = np.nonzero(lc_nan_mask)[0]
         if len(lc_nan_indices) > 0:
             row_to_add = LightCurve(aligned_lc[0:len(lc_nan_indices)])
@@ -430,12 +430,12 @@ def _align_to_lc(lc, ref_lc):
         # REALLY slow.
         try:
             # This method is fast but might cause errors
-            keep_indices = np.nonzero(np.in1d(aligned_lc.cadenceno, ref_lc.cadenceno))[0]
+            keep_indices = np.nonzero(np.isin(aligned_lc.cadenceno, ref_lc.cadenceno))[0]
             aligned_lc = aligned_lc[keep_indices]
         except:
             # This method is slow but appears to be more robust
             trim_indices = np.nonzero(np.logical_not(
-                np.in1d(aligned_lc.cadenceno, ref_lc.cadenceno)))[0]
+                np.isin(aligned_lc.cadenceno, ref_lc.cadenceno)))[0]
             aligned_lc.remove_rows(trim_indices)
 
         # Now sort the lc by cadenceno
@@ -443,7 +443,7 @@ def _align_to_lc(lc, ref_lc):
 
     else:
         raise Exception('align requires cadence numbers for the ' + \
-                'light curve. NO ALIGNMENT OCCURED')
+                'light curve. NO ALIGNMENT OCCURRED')
 
     return aligned_lc
 

--- a/src/lightkurve/correctors/sffcorrector.py
+++ b/src/lightkurve/correctors/sffcorrector.py
@@ -104,7 +104,7 @@ class SFFCorrector(RegressionCorrector):
             of input light curve time.
         breakindex : None, int or list of ints (optional)
             Optionally the user can break the light curve into sections. Set
-            break index to either an index at which to break, or list of indicies.
+            break index to either an index at which to break, or list of indices.
         degree : int
             The degree of polynomials in the splines in time and arclength. Higher
             values will create smoother splines. Default 3.
@@ -171,12 +171,12 @@ class SFFCorrector(RegressionCorrector):
                 ar = np.copy(self.arclength)
 
             # Temporary workaround for issue #1161: AstroPy v5.0
-            # Masked arrays cannot be passed to `np.in1d` below
+            # Masked arrays cannot be passed to `np.isin` below
             if hasattr(self.arclength, 'mask'):
                 ar = ar.unmasked
 
             knots = list(np.percentile(ar[a:b], np.linspace(0, 100, bins + 1)[1:-1]))
-            ar[~np.in1d(ar, ar[a:b])] = 0
+            ar[~np.isin(ar, ar[a:b])] = 0
 
             dm = spline(ar, knots=knots, degree=degree).copy()
             dm.columns = [

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -818,7 +818,7 @@ class LightCurve(TimeSeries):
         Returns
         -------
         new_lc : `LightCurve`
-            Light curve which has the other light curves appened to it.
+            Light curve which has the other light curves append to it.
         """
         if inplace:
             raise ValueError(
@@ -1236,7 +1236,7 @@ class LightCurve(TimeSeries):
         if hasattr(lc, "cadenceno"):
             dt = lc.time.value - np.median(np.diff(lc.time.value)) * lc.cadenceno.value
             ncad = np.arange(lc.cadenceno.value[0], lc.cadenceno.value[-1] + 1, 1)
-            in_original = np.in1d(ncad, lc.cadenceno.value)
+            in_original = np.isin(ncad, lc.cadenceno.value)
             ncad = ncad[~in_original]
             ndt = np.interp(ncad, lc.cadenceno.value, dt)
 
@@ -1256,7 +1256,7 @@ class LightCurve(TimeSeries):
                     prevtime = ntime[-1]
                 ntime.append(t)
             ntime = np.asarray(ntime, float)
-            in_original = np.in1d(ntime, lc.time.value)
+            in_original = np.isin(ntime, lc.time.value)
 
         # Fill in time points
         newdata["time"] = Time(ntime, format=lc.time.format, scale=lc.time.scale)
@@ -1714,7 +1714,7 @@ class LightCurve(TimeSeries):
         in the brightness of the target.  They can also cause dips by moving
         through a local background aperture mask (if any is used).
 
-        The artifical spikes and dips introduced by asteroids are frequently
+        The artificial spikes and dips introduced by asteroids are frequently
         confused with stellar flares, planet transits, etc.  This method helps
         to identify false signals injects by asteroids by providing a list of
         the solar system objects (name, brightness, time) that passed in the
@@ -1831,7 +1831,7 @@ class LightCurve(TimeSeries):
             show_progress=show_progress,
         )
         if return_mask:
-            return res, np.in1d(self.time.jd, res.epoch)
+            return res, np.isin(self.time.jd, res.epoch)
         return res
 
     def _create_plot(
@@ -1935,7 +1935,7 @@ class LightCurve(TimeSeries):
             flux_err = np.full(len(flux), np.nan)
 
         # Second workaround for AstroPy v5.0.0 issue #12481:
-        # matplotlib does not work well with `MaskedNDArray` arrays.
+        # matplotlib does not work well with `MaskedANDArray` arrays.
         if hasattr(flux, 'mask'):
             flux = flux.filled(np.nan)
         if hasattr(flux_err, 'mask'):
@@ -1944,7 +1944,7 @@ class LightCurve(TimeSeries):
         # Normalize the data if requested
         if normalize:
             # ignore "light curve is already normalized" message because
-            # the user explicitely asked for normalization here
+            # the user explicitly asked for normalization here
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=".*already.*")
                 if column == "flux":
@@ -2354,7 +2354,7 @@ class LightCurve(TimeSeries):
         which in turn wrap `astropy`'s `~astropy.timeseries.LombScargle` and `~astropy.timeseries.BoxLeastSquares`.
 
         Optional keywords accepted if ``method='lombscargle'`` are:
-        ``minimum_frequency``, ``maximum_frequency``, ``mininum_period``,
+        ``minimum_frequency``, ``maximum_frequency``, ``minimum_period``,
         ``maximum_period``, ``frequency``, ``period``, ``nterms``,
         ``nyquist_factor``, ``oversample_factor``, ``freq_unit``,
         ``normalization``, ``ls_method``.
@@ -2691,7 +2691,7 @@ class LightCurve(TimeSeries):
         y /= med
 
         # Here `ph` is the phase of each time point x
-        # cyc is the number of cycles that have occured at each time point x
+        # cyc is the number of cycles that have occurred at each time point x
         # since the phase 0 before x[0]
         n = int(
             period.value
@@ -3029,7 +3029,7 @@ class FoldedLightCurve(LightCurve):
     def odd_mask(self):
         """Boolean mask which flags the odd-numbered cycles (1, 3, 5, etc).
 
-        This is useful for studying every second occurence of a signal.
+        This is useful for studying every second occurrence of a signal.
         For example, in exoplanet searches, comparisons of odd and even transits
         can help confirm the planetary nature of a signal. Differences in the
         depth, duration, or shape of the odd- and even-numbered transits would

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1935,7 +1935,7 @@ class LightCurve(TimeSeries):
             flux_err = np.full(len(flux), np.nan)
 
         # Second workaround for AstroPy v5.0.0 issue #12481:
-        # matplotlib does not work well with `MaskedANDArray` arrays.
+        # matplotlib does not work well with `MaskedNDArray` arrays.
         if hasattr(flux, 'mask'):
             flux = flux.filled(np.nan)
         if hasattr(flux_err, 'mask'):

--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -684,7 +684,7 @@ class TargetPixelFile(object):
 
         If the thresholding method yields multiple contiguous regions, then
         only the region closest to the (col, row) coordinate specified by
-        `reference_pixel` is returned.  For exmaple, `reference_pixel=(0, 0)`
+        `reference_pixel` is returned.  For example, `reference_pixel=(0, 0)`
         will pick the region closest to the bottom left corner.
         By default, the region closest to the center of the mask will be
         returned. If `reference_pixel=None` then all regions will be returned.
@@ -714,7 +714,7 @@ class TargetPixelFile(object):
             warnings.simplefilter("ignore")
             median_image = np.nanmedian(self.flux, axis=0)
         vals = median_image[np.isfinite(median_image)].flatten()
-        # Calculate the theshold value in flux units
+        # Calculate the threshold value in flux units
         mad_cut = (1.4826 * MAD(vals) * threshold) + np.nanmedian(median_image)
         # Create a mask containing the pixels above the threshold flux
         threshold_mask = np.nan_to_num(median_image) >= mad_cut
@@ -945,7 +945,7 @@ class TargetPixelFile(object):
         in the brightness of the target.  They can also cause dips by moving
         through a local background aperture mask (if any is used).
 
-        The artifical spikes and dips introduced by asteroids are frequently
+        The artificial spikes and dips introduced by asteroids are frequently
         confused with stellar flares, planet transits, etc.  This method helps
         to identify false signals injects by asteroids by providing a list of
         the solar system objects (name, brightness, time) that passed in the
@@ -1052,7 +1052,7 @@ class TargetPixelFile(object):
             show_progress=show_progress,
         )
         if return_mask:
-            return res, np.in1d(self.time.jd, res.epoch)
+            return res, np.isin(self.time.jd, res.epoch)
         return res
 
     def plot(
@@ -1785,7 +1785,7 @@ class TargetPixelFile(object):
                 hdu_idx["POS_CORR1"] = column_current - column_ref
                 hdu_idx["POS_CORR2"] = row_current - row_ref
 
-            # Cutout (if neccessary) and get data
+            # Cutout (if necessary) and get data
             cutout_list = [
                 _cutout_image(hdu, position, wcs_ref, size) for hdu in hdu_list
             ]

--- a/tests/test_periodogram.py
+++ b/tests/test_periodogram.py
@@ -309,8 +309,8 @@ def test_bls(caplog):
     # Model is LC
     assert isinstance(model, LightCurve)
     # Model is otherwise identical to LC
-    assert np.in1d(model.time, lc.time).all()
-    assert np.in1d(lc.time, model.time).all()
+    assert np.isin(model.time, lc.time).all()
+    assert np.isin(lc.time, model.time).all()
 
     mask = p.get_transit_mask(1, 0.1, 0)
     assert isinstance(mask, np.ndarray)


### PR DESCRIPTION
# PR Summary
This small PR resolves the NumPy deprecation warnings of `np.in1d` which you can find in the [CI logs](https://github.com/lightkurve/lightkurve/actions/runs/14870093767/job/41756341467#step:5:61):
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```
It also fixes a few typos in those relevant files.