### PR TITLE
Fixed RMSE calc in binning `flux_err` and improved overall `bin` performance

### DIFF
--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -70,7 +70,7 @@ def _is_np_structured_array(data1):
 def rmse(x):
     """Root Mean Square Error implementation for `bin`"""
     if np.any(np.isfinite(x)):
-        return np.sqrt(np.nansum(x**2)) / np.nansum(np.isfinite(x))
+        return np.sqrt(np.nansum(x**2) / np.nansum(np.isfinite(x)))
     else:
         return np.nan
 
@@ -96,8 +96,7 @@ def rmse_reduceat(values, indices):
     # for bins with all masked values / nan, i.e., count is 0, the result should be nan
     count[count == 0] = np.nan
 
-    # return np.sqrt(sum_of_squares / count)  # FIXME: this is probably the correct one
-    return np.sqrt(sum_of_squares) / count
+    return np.sqrt(sum_of_squares / count)
 
 
 rmse.reduceat = rmse_reduceat


### PR DESCRIPTION
1. Fix #1493 , the RMSE calculation in binning `flux_err`
   **Feedback needed**: some questions on the RMSE definition 

2. Fix the `lc.bin()` performance issue related to `flux_err`. ~~The change is not in PR yet. I'd like to see if it's likely to be accepted before I proceed further.~~

---
Changelog to be added: 
```rst
- Fixed bugs in ``bin`` for ``flux_err`` column. Improved ``bin`` performance. [#1499]
```
---

On RMSE:
- Fixed the issue that the existing codes incorrectly counts `np.nan` and masked values.
- **Feedback needed**. The RMSE formula in the existing codes seems to be incorrect to me. 
  The formula in the existing codes: `sqrt(sum_of_squares) / n`
  Shouldn't `n` be inside the square root, i.e., `sqrt(sum_of_squares / n)` ?
  I have not changed the formula in the PR yet: There are some [test codes](https://github.com/lightkurve/lightkurve/blob/e360709b0c5743a3adb2233b17a714b18190bc6d/tests/test_lightcurve.py#L615) that explicitly test the RMSE value. So it's possible that the non-standard formula is used deliberately for some reasons I don't understand.

---

`lc.bin()` performance issue fix: 
- With astropy 7.1.0+ , the bottleneck in the underlying `aggregate_downsample()` is largely addressed by using an optimized nanmean. However, `lc.bin()` performance is not improved because `lightkurve` also uses (non-optimized) rmse / nanstd for flux_err.
- On my machine, the bin time is **reduced from ~18s to ~0.1s** for a TESS SPOC 2 minute lightcurve.
  - The fix is largely complimentary to the one used in PR #1328, and is more isolated.
