### PR TITLE
Astroquery update workaround

### DIFF
--- a/src/lightkurve/search.py
+++ b/src/lightkurve/search.py
@@ -938,18 +938,24 @@ def _search_products(
     SearchResult : :class:`SearchResult` object.
     """
     if isinstance(target, int):
+        # see: https://archive.stsci.edu/search_fields.php?mission=kic10
         if (0 < target) and (target < 13161030):
             log.warning(
                 "Warning: {} may refer to a different Kepler or TESS target. "
                 "Please add the prefix 'KIC' or 'TIC' to disambiguate."
                 "".format(target)
             )
-        elif (0 < 200000000) and (target < 251813739):
+        # see: https://archive.stsci.edu/k2/manuals/KSCI-19082-021.pdf
+        elif (0 < 200000000) and (target < 252090718): 
             log.warning(
                 "Warning: {} may refer to a different K2 or TESS target. "
                 "Please add the prefix 'EPIC' or 'TIC' to disambiguate."
                 "".format(target)
             )
+        # astroquery 0.4.11 update breaks if passing an integer, so convert to string
+        else:
+            target = f"TIC {target}"
+
 
     # Specifying quarter, campaign, or quarter should constrain the mission
     if quarter is not None:


### PR DESCRIPTION
astroquery 0.4.11 update now breaks if passing an integer. Fix this by converting the int into a string. See issue #1509 

