### PR TITLE
Fixed the incorrect name for python 3.12 test in CI

### DIFF
--- a/.github/workflows/lightkurve-tests.yml
+++ b/.github/workflows/lightkurve-tests.yml
@@ -41,7 +41,7 @@ jobs:
             pytest-command: ./poetry/bin/poetry run pytest
           - name: "3.11"
             python-version: "3.11"
-            pytest-command: poetry run pytest
+            pytest-command: ./poetry/bin/poetry run pytest
           - name: "3.12"
             python-version: "3.12"
             pytest-command: ./poetry/bin/poetry run pytest


### PR DESCRIPTION
The CIs are incorrectly setup with a bogus (no-op) pytest-linux (3,12), while the actual python 3.12 test (non remote-data) runs in the incorrectly-named pytest-linux (3,12-remote-data). E.g.,

https://github.com/lightkurve/lightkurve/actions/runs/18387905020/job/52390898395

This PR fixes the issue.