### PR TITLE
Fix normalize() crash with masked flux arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@
   fallback cone search [#1541]
 - Modified how SAP_QUALITY is treated when reading/writing TESS and Kepler data [#1538]
 - Added ability to use nifty-ls for periodograms [#1550]
+- Fixed ``LightCurve.normalize()`` crash on masked flux arrays where ``np.nanmedian``
+  returned ``nan`` instead of computing over unmasked values [#1543]
 
 2.5.1  (2025-05-20)
 =====================

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1250,7 +1250,10 @@ class LightCurve(TimeSeries):
             from zero.
         """
         validate_method(unit, ["unscaled", "percent", "ppt", "ppm"])
-        flux_data = np.ma.filled(self.flux, np.nan) if hasattr(self.flux, "filled") else np.asarray(self.flux)
+        if hasattr(self.flux, "mask") and hasattr(self.flux, "filled"):
+            flux_data = self.flux.filled(np.nan)
+        else:
+            flux_data = self.flux
         median_flux = np.nanmedian(flux_data)
         std_flux = np.nanstd(flux_data)
 

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1250,8 +1250,9 @@ class LightCurve(TimeSeries):
             from zero.
         """
         validate_method(unit, ["unscaled", "percent", "ppt", "ppm"])
-        median_flux = np.nanmedian(self.flux)
-        std_flux = np.nanstd(self.flux)
+        flux_data = np.ma.filled(self.flux, np.nan) if hasattr(self.flux, "filled") else np.asarray(self.flux)
+        median_flux = np.nanmedian(flux_data)
+        std_flux = np.nanstd(flux_data)
 
         # If the median flux is within half a standard deviation from zero, the
         # light curve is likely zero-centered and normalization makes no sense.

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1250,12 +1250,12 @@ class LightCurve(TimeSeries):
             from zero.
         """
         validate_method(unit, ["unscaled", "percent", "ppt", "ppm"])
-        if hasattr(self.flux, "mask") and hasattr(self.flux, "filled"):
-            flux_data = self.flux.filled(np.nan)
+        if hasattr(self.flux, "mask"):
+            median_flux = np.ma.median(self.flux)
+            std_flux = np.ma.std(self.flux)
         else:
-            flux_data = self.flux
-        median_flux = np.nanmedian(flux_data)
-        std_flux = np.nanstd(flux_data)
+            median_flux = np.nanmedian(self.flux)
+            std_flux = np.nanstd(self.flux)
 
         # If the median flux is within half a standard deviation from zero, the
         # light curve is likely zero-centered and normalization makes no sense.

--- a/src/lightkurve/lightcurve.py
+++ b/src/lightkurve/lightcurve.py
@@ -1250,12 +1250,12 @@ class LightCurve(TimeSeries):
             from zero.
         """
         validate_method(unit, ["unscaled", "percent", "ppt", "ppm"])
-        if hasattr(self.flux, "mask"):
-            median_flux = np.ma.median(self.flux)
-            std_flux = np.ma.std(self.flux)
+        if hasattr(self.flux, "mask") and hasattr(self.flux, "filled"):
+            flux_data = self.flux.filled(np.nan)
         else:
-            median_flux = np.nanmedian(self.flux)
-            std_flux = np.nanstd(self.flux)
+            flux_data = self.flux
+        median_flux = np.nanmedian(flux_data)
+        std_flux = np.nanstd(flux_data)
 
         # If the median flux is within half a standard deviation from zero, the
         # light curve is likely zero-centered and normalization makes no sense.

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -942,6 +942,26 @@ def test_normalize():
     assert len(warn_record) == 0
     assert lc.meta["NORMALIZED"]
 
+    # Issue #1505: normalize() must handle MaskedColumn flux without
+    # collapsing to nan. np.nanmedian on a MaskedColumn returns nan because
+    # numpy's partition step ignores the mask before nan-skipping runs.
+    t = Time([2458000.0 + i * 0.02 for i in range(6)], format="jd", scale="tdb")
+    masked_lc = LightCurve(time=t)
+    masked_lc["flux"] = MaskedColumn(
+        data=[1.00, 1.01, np.nan, 1.02, np.nan, 1.03],
+        mask=[False, False, True, False, True, False],
+        fill_value=np.nan,
+    )
+    masked_lc["flux_err"] = masked_lc["flux"]
+    normalized = masked_lc.normalize()
+    # Median of unmasked values [1.00, 1.01, 1.02, 1.03] is 1.015, so the
+    # normalised median should be 1.0 (not nan, which is the bug).
+    assert_allclose(np.nanmedian(normalized.flux), 1.0, atol=1e-6)
+    expected = np.array([1.00, 1.01, np.nan, 1.02, np.nan, 1.03]) / 1.015
+    assert_allclose(
+        np.ma.filled(normalized.flux, np.nan), expected, atol=1e-6, equal_nan=True
+    )
+
 
 def test_invalid_normalize():
     """Normalization makes no sense if the light curve is negative,


### PR DESCRIPTION
Fixes #1505.

np.nanmedian and np.nanstd don't handle MaskedColumn correctly when the fill value is nan - they return nan instead of computing over the unmasked values.

Fixed by converting to a plain ndarray first via np.ma.filled(self.flux, np.nan), which works for both masked and non-masked inputs.