### PR TITLE
Fix #1551: Add missing TESS Quality flags 17 and 18

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -248,6 +248,8 @@ class TessQualityFlags(QualityFlags):
     BadCalibrationExclude = 16384
     # Set in the sector 20 data release notes
     InsufficientTargets = 32768
+    RollingBandInAperture = 131072
+    RollingBandInMask = 262144
 
     #: DEFAULT bitmask identifies all cadences which are definitely useless.
     # See https://outerspace.stsci.edu/display/TESS/2.0+-+Data+Product+Overview
@@ -260,7 +262,7 @@ class TessQualityFlags(QualityFlags):
         DEFAULT_BITMASK | ApertureCosmic | CollateralCosmic | Straylight | Straylight2
     )
     #: HARDEST bitmask identifies cadences with any flag set. Its use is not recommended.
-    HARDEST_BITMASK = 65535
+    HARDEST_BITMASK = 524287
 
     #: Dictionary which provides friendly names for the various bitmasks.
     OPTIONS = {
@@ -288,6 +290,8 @@ class TessQualityFlags(QualityFlags):
         8192: "Planet Search Exclude",
         16384: "Bad Calibration Exclude",
         32768: "Insufficient Targets for Error Correction Exclude",
+        131072: "Rolling band in optimal aperture",
+        262144: "Rolling band in full mask",
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,17 @@ def test_quality_flag_decoding_quantity_object():
     ) == [flags[3][1], flags[4][1], flags[5][1]]
 
 
+def test_tess_rolling_band_flags():
+    """Verify the new RollingBandInAperture and RollingBandInMask flags."""
+    assert TessQualityFlags.RollingBandInAperture == 131072
+    assert TessQualityFlags.RollingBandInMask == 262144
+    assert "Rolling band in optimal aperture" in TessQualityFlags.decode(131072)
+    assert "Rolling band in full mask" in TessQualityFlags.decode(262144)
+    # Check that they are included in HARDEST_BITMASK
+    assert (TessQualityFlags.HARDEST_BITMASK & TessQualityFlags.RollingBandInAperture) > 0
+    assert (TessQualityFlags.HARDEST_BITMASK & TessQualityFlags.RollingBandInMask) > 0
+
+
 def test_quality_mask():
     """Can we create a quality mask using KeplerQualityFlags?"""
     quality = np.array([0, 0, 1])


### PR DESCRIPTION
This PR fixes Issue #1551 by implementing the missing TESS quality flags for Rolling Band artifacts.