### PR TITLE
Perf: Speed up centroid_quadratic by 2x by reducing duplicate work

### DIFF
--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -665,9 +665,11 @@ def centroid_quadratic(data, mask=None):
         # proactively convert int to float once and for all.
         data = data.astype(float)
 
-    # Step 1: identify the brightest in-aperture pixel. Setting masked
-    # pixels (and NaNs) to -inf. See Issue #1401 for the all-negative-flux
-    # case this protects.
+    # Step 1: identify the brightest in-aperture pixel. When a mask is
+    # given we set out-of-aperture and NaN positions to -inf so a plain
+    # argmax skips them; without a mask we fall back to nanargmax. See
+    # Issue #1401 for the all-negative-flux case the -inf substitution
+    # protects.
     if mask is not None:
         # Cast -inf to `data`'s dtype to avoid f64 promotion of f32 data.
         neg_inf = data.dtype.type(-np.inf)

--- a/src/lightkurve/utils.py
+++ b/src/lightkurve/utils.py
@@ -597,6 +597,36 @@ def validate_method(method, supported_methods):
     )
 
 
+# Pseudo-inverse of the 3x3 quadratic-centroid design matrix
+# (Vakili & Hogg 2016, arXiv:1610.05873). Columns of A are the basis
+# functions [1, x, y, x^2, x*y, y^2] evaluated at each of the nine pixel
+# offsets in the 3x3 patch (Eqn 20 of V&H):
+#
+#   A = [[1, -1, -1, 1,  1, 1],
+#        [1,  0, -1, 0,  0, 1],
+#        [1,  1, -1, 1, -1, 1],
+#        [1, -1,  0, 1,  0, 0],
+#        [1,  0,  0, 0,  0, 0],
+#        [1,  1,  0, 1,  0, 0],
+#        [1, -1,  1, 1, -1, 1],
+#        [1,  0,  1, 0,  0, 1],
+#        [1,  1,  1, 1,  1, 1]]
+#
+# Given Z = (z_1, ..., z_9) -- the row-major-flattened patch -- the
+# least-squares fit coefficients X = (a, b, c, d, e, f) are
+# X = APRIME @ Z (Eqn 21 of V&H), with APRIME = (A.T @ A)^-1 @ A.T.
+# Hardcoded here.
+_APRIME = np.array(
+    [[-1 / 9,  2 / 9, -1 / 9,  2 / 9,  5 / 9,  2 / 9, -1 / 9,  2 / 9, -1 / 9],  # a
+     [-1 / 6,      0,  1 / 6, -1 / 6,      0,  1 / 6, -1 / 6,      0,  1 / 6],  # b (x)
+     [-1 / 6, -1 / 6, -1 / 6,      0,      0,      0,  1 / 6,  1 / 6,  1 / 6],  # c (y)
+     [ 1 / 6, -1 / 3,  1 / 6,  1 / 6, -1 / 3,  1 / 6,  1 / 6, -1 / 3,  1 / 6],  # d (x^2)
+     [ 1 / 4,      0, -1 / 4,      0,      0,      0, -1 / 4,      0,  1 / 4],  # e (x*y)
+     [ 1 / 6,  1 / 6,  1 / 6, -1 / 3, -1 / 3, -1 / 3,  1 / 6,  1 / 6,  1 / 6]], # f (y^2)
+    dtype=float,
+)
+
+
 def centroid_quadratic(data, mask=None):
     """Computes the quadratic estimate of the centroid in a 2d-array.
 
@@ -635,15 +665,16 @@ def centroid_quadratic(data, mask=None):
         # proactively convert int to float once and for all.
         data = data.astype(float)
 
-    # Step 1: identify the patch of 3x3 pixels (z_)
-    # that is centered on the brightest pixel (xx, yy)
+    # Step 1: identify the brightest in-aperture pixel. Setting masked
+    # pixels (and NaNs) to -inf. See Issue #1401 for the all-negative-flux
+    # case this protects.
     if mask is not None:
-        # mask handling.
-        # Issue 1401 demonstrates that using 'data' to find the max will break when all flux is negative
-        # set masked pixels NaN (instead of 0) to resolve it.
-        data = data.copy()
-        data[~mask] = np.nan
-    arg_data_max = np.nanargmax(data)
+        # Cast -inf to `data`'s dtype to avoid f64 promotion of f32 data.
+        neg_inf = data.dtype.type(-np.inf)
+        eligible = np.where(mask & ~np.isnan(data), data, neg_inf)
+        arg_data_max = np.argmax(eligible)
+    else:
+        arg_data_max = np.nanargmax(data)
     yy, xx = np.unravel_index(arg_data_max, data.shape)
     # Make sure the 3x3 patch does not leave the TPF bounds
     if yy < 1:
@@ -656,40 +687,20 @@ def centroid_quadratic(data, mask=None):
         xx = data.shape[1] - 2
 
     z_ = data[yy - 1 : yy + 2, xx - 1 : xx + 2]
-    if np.any(np.isnan(z_)):
-        # handle edge case the 3X3 patch has NaN
-        # Need some finite value for NaN pixels for the
-        # quadratic fit below: use the mean of the 3x3 patch
-        # to reduce the skew
-        z_ = z_.copy()
-        z_[np.isnan(z_)] = np.nanmean(z_)
-
-    # Next, we will fit the coefficients of the bivariate quadratic with the
-    # help of a design matrix (A) as defined by Eqn 20 in Vakili & Hogg
-    # (arxiv:1610.05873). The design matrix contains a
-    # column of ones followed by pixel coordinates: x, y, x**2, xy, y**2.
-    A = np.array(
-        [
-            [1, -1, -1, 1, 1, 1],
-            [1, 0, -1, 0, 0, 1],
-            [1, 1, -1, 1, -1, 1],
-            [1, -1, 0, 1, 0, 0],
-            [1, 0, 0, 0, 0, 0],
-            [1, 1, 0, 1, 0, 0],
-            [1, -1, 1, 1, -1, 1],
-            [1, 0, 1, 0, 0, 1],
-            [1, 1, 1, 1, 1, 1],
-        ]
-    )
-    # We also pre-compute $(A^t A)^-1 A^t$, cf. Eqn 21 in Vakili & Hogg.
-    At = A.transpose()
-    # In Python 3 this can become `Aprime = np.linalg.inv(At @ A) @ At`
-    Aprime = np.matmul(np.linalg.inv(np.matmul(At, A)), At)
+    # handle edge case the 3x3 patch contains NaN or out-of-aperture
+    # pixels. Need some finite value for those positions for the
+    # quadratic fit below: use the mean of the remaining 3x3 patch
+    # pixels to reduce the skew
+    excluded_pixels = np.isnan(z_)
+    if mask is not None:
+        excluded_pixels = excluded_pixels | ~mask[yy - 1 : yy + 2, xx - 1 : xx + 2]
+    if excluded_pixels.any():
+        fill = z_[~excluded_pixels].mean()
+        z_ = np.where(excluded_pixels, fill, z_)
 
     # Step 2: fit the polynomial $P = a + bx + cy + dx^2 + exy + fy^2$
-    # following Equation 21 in Vakili & Hogg.
-    # In Python 3 this can become `Aprime @ z_.flatten()`
-    a, b, c, d, e, f = np.matmul(Aprime, z_.flatten())
+    # using the precomputed pseudo-inverse (cf. Eqn 21 in Vakili & Hogg).
+    a, b, c, d, e, f = np.dot(_APRIME, z_.ravel())
 
     # Step 3: analytically find the function maximum,
     # following https://en.wikipedia.org/wiki/Quadratic_function

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,6 +231,14 @@ def test_centroid_quadratic_robustness(data_dtype, mask):
 
 
 def test_centroid_quadratic_all_nan_aperture():
+    """All-NaN data inside the aperture should return (NaN, NaN), not raise.
+
+    Regression test: np.nanargmax previously raised
+    ValueError("All-NaN slice encountered") for this input, killing
+    any surrounding centroid loop. The function should instead return
+    NaN -- matching the docstring contract that NaN is returned 'if the
+    fit failed'.
+    """
     data = np.full((5, 5), np.nan, dtype=float)
     mask = np.full((5, 5), True, dtype=bool)
     col, row = centroid_quadratic(data, mask=mask)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -172,11 +172,15 @@ a_mask[0:2, :] = False
 @pytest.mark.parametrize("data_dtype, mask", [
     (float, None),
     (float, a_mask),
+    (np.float32, None),
+    (np.float32, a_mask),
     (int, None),
     (int, a_mask),
     ])
 def test_centroid_quadratic_robustness(data_dtype, mask):
     """Test quadratic centroids in edge cases; regression test for #610, etc."""
+    is_float = np.issubdtype(np.dtype(data_dtype), np.floating)
+
     # Brightest pixel in upper left
     data = np.zeros((5, 5), dtype=data_dtype)
     data[0, 0] = 1
@@ -196,7 +200,7 @@ def test_centroid_quadratic_robustness(data_dtype, mask):
     assert np.isfinite(col) & np.isfinite(row)
 
     # Data contains a NaN
-    if data_dtype is float:  # NaN only applicable to float
+    if is_float:  # NaN only applicable to float
         data = np.zeros((5, 5), dtype=data_dtype)
         data[0, 0] = np.nan
         data[-1, -1] = 10
@@ -204,7 +208,7 @@ def test_centroid_quadratic_robustness(data_dtype, mask):
         assert np.isfinite(col) & np.isfinite(row)
 
     # has NaN in the identified 3x3 patch
-    if data_dtype is float:  # NaN only applicable to float
+    if is_float:  # NaN only applicable to float
         data = np.zeros((5, 5), dtype=data_dtype)
         data[3, 2] = 10
         data[3, 3] = np.nan
@@ -224,6 +228,14 @@ def test_centroid_quadratic_robustness(data_dtype, mask):
         data[2, 1] = 10  # the row above is masked
         col, row = centroid_quadratic(data, mask=mask)
         assert np.isfinite(col) & np.isfinite(row)
+
+
+def test_centroid_quadratic_all_nan_aperture():
+    data = np.full((5, 5), np.nan, dtype=float)
+    mask = np.full((5, 5), True, dtype=bool)
+    col, row = centroid_quadratic(data, mask=mask)
+    assert np.isnan(col)
+    assert np.isnan(row)
 
 
 def test_show_citation_instructions():


### PR DESCRIPTION
`centroid_quadratic` is called once per cadence, so every microsecond multiplies by thousands of frames. This PR makes it roughly 2.2x faster on ARM, and 2.7x faster on x86.

On every frame, `centroid_quadratic` created, transposed, inverted, and multiplied the same design matrix, even though the design matrix is hardcoded and does not depend on the data or any other inputs. This adds up! I made a few related changes here:
- Hardcoded `Aprime` instead of `A` and moved it out of the function. There are a few other ways to achieve a similar result, but I felt this was clean and the matrix itself is small enough and straightforward enough to just write out.
- Removed a few `copy()` calls which weren't really necessary after switching from nan to `-inf`.
- Changed the handling of degenerate all-nan inputs from throwing to returning nans.
- Added a bit of test coverage around the above and float32s.

Here are some numbers from running benchmarks on synthetic data simulating different problem scales (important note: this measures *just* the impact on `centroid_quadratic`):
```
  ARM (Apple M-series, macOS, numpy 2.4.4)                                                                        
  
  ┌───────────────────────────────┬───────┬─────┬─────┬──────────┬─────────┬─────────┐                            
  │           workflow            │   N   │  Y  │  X  │ upstream │   new   │ speedup │
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ Kepler Q4 / TESS 2-min, 11×11 │  4400 │  11 │  11 │   91.9ms │  41.3ms │   2.22× │                            
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ TESS 2-min sector, 11×11      │ 15000 │  11 │  11 │  315.9ms │ 138.3ms │   2.28× │                            
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ Kepler primary mission, 11×11 │ 65000 │  11 │  11 │ 1382.7ms │ 619.6ms │   2.23× │                            
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ TESScut, 50×50 / 1 sector     │ 15000 │  50 │  50 │  325.4ms │ 154.1ms │   2.11× │
  └───────────────────────────────┴───────┴─────┴─────┴──────────┴─────────┴─────────┘  

  x86 (Intel Xeon Platinum 8581C, GCP c4-standard-4, numpy 2.4.4)                                                 
                                                         
  ┌───────────────────────────────┬───────┬─────┬─────┬──────────┬─────────┬─────────┐                            
  │           workflow            │   N   │  Y  │  X  │ upstream │   new   │ speedup │
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ Kepler Q4 / TESS 2-min, 11×11 │  4400 │  11 │  11 │  184.3ms │  67.1ms │   2.75× │
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤
  │ TESS 2-min sector, 11×11      │ 15000 │  11 │  11 │  632.6ms │ 231.9ms │   2.73× │                            
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ Kepler primary mission, 11×11 │ 65000 │  11 │  11 │ 2755.7ms │ 994.4ms │   2.77× │                            
  ├───────────────────────────────┼───────┼─────┼─────┼──────────┼─────────┼─────────┤                            
  │ TESScut, 50×50 / 1 sector     │ 15000 │  50 │  50 │  584.6ms │ 257.9ms │   2.27× │
  └───────────────────────────────┴───────┴─────┴─────┴──────────┴─────────┴─────────┘   
```

Important note: the *real* win will be a followup PR to this one to compute all centroids in one shot. Even with this change, `estimate_centroids_via_quadratic` is still dominated by loop overhead and array slicing operations, and we could get a much, much more significant improvement to wall clock time by just operating on the full 3D data array. But for that to work, we first need to clean up `centroid_quadratic`.