### PR TITLE
Close TargetPixelFile FITS handles on cleanup

### DIFF
--- a/src/lightkurve/targetpixelfile.py
+++ b/src/lightkurve/targetpixelfile.py
@@ -100,6 +100,7 @@ class TargetPixelFile(object):
 
     def __init__(self, path, quality_bitmask="default", targetid=None, **kwargs):
         self.path = path
+        self._owns_hdu = False
         if isinstance(path, fits.HDUList):
             self.hdu = path
         elif isinstance(path, str) and path.startswith("s3://"):
@@ -107,8 +108,10 @@ class TargetPixelFile(object):
             self.hdu = fits.open(
                 path, use_fsspec=True, fsspec_kwargs={"anon": True}, **kwargs
             )
+            self._owns_hdu = True
         else:
             self.hdu = fits.open(self.path, **kwargs)
+            self._owns_hdu = True
         try:
             self.quality_bitmask = quality_bitmask
             self.targetid = targetid
@@ -119,6 +122,23 @@ class TargetPixelFile(object):
             # Cannot instantiate TargetPixelFile, close the HDU to release the file handle
             self.hdu.close()
             raise e
+
+    def close(self):
+        """Close the underlying FITS HDUList."""
+        self.hdu.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def __del__(self):
+        if getattr(self, "_owns_hdu", False):
+            try:
+                self.close()
+            except Exception:
+                pass
 
     def __getitem__(self, key):
         """Implements indexing and slicing.

--- a/tests/test_targetpixelfile.py
+++ b/tests/test_targetpixelfile.py
@@ -1,4 +1,5 @@
 import collections
+import gc
 import os
 import tempfile
 import warnings
@@ -45,6 +46,37 @@ TESS_SIM = (
     "/004/176/tess2019128220341-0000000417699452-0016-s_tp.fits"
 )
 asteroid_TPF = get_pkg_data_filename("data/asteroid_test.fits")
+
+
+def test_tpf_close_releases_opened_file():
+    """TargetPixelFile.close() should release the FITS file handle it opened."""
+    tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
+    opened_file = tpf.hdu._file
+    assert not opened_file.closed
+
+    tpf.close()
+
+    assert opened_file.closed
+
+
+def test_tpf_context_manager_closes_opened_file():
+    """TargetPixelFile should close its opened FITS file when leaving a context."""
+    with KeplerTargetPixelFile(filename_tpf_all_zeros) as tpf:
+        opened_file = tpf.hdu._file
+        assert not opened_file.closed
+
+    assert opened_file.closed
+
+
+def test_tpf_del_closes_owned_hdu():
+    """Owned FITS handles should not be left for Astropy to warn about at GC."""
+    tpf = KeplerTargetPixelFile(filename_tpf_all_zeros)
+    opened_file = tpf.hdu._file
+
+    del tpf
+    gc.collect()
+
+    assert opened_file.closed
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
## Summary

Fixes #1547 by making `TargetPixelFile` clean up FITS HDU handles that it opens from a file path.

The object now supports explicit `close()`, context-manager usage, and best-effort cleanup for owned HDU handles during garbage collection. Externally supplied `fits.HDUList` objects are not treated as implicitly owned.

## Tests

- `.venv\Scripts\python.exe -m pytest tests/test_targetpixelfile.py::test_tpf_close_releases_opened_file tests/test_targetpixelfile.py::test_tpf_context_manager_closes_opened_file tests/test_targetpixelfile.py::test_tpf_del_closes_owned_hdu -q`
- `.venv\Scripts\python.exe -m pytest tests/test_collections.py::test_tpfcollection tests/test_collections.py::test_tpfcollection_plot tests/test_collections.py::test_accessor_tess_sector tests/test_collections.py::test_accessor_kepler_quarter tests/test_collections.py::test_accessor_k2_campaign tests/test_targetpixelfile.py::test_parse_aperture_masks -W error -q`