### PR TITLE
Allow pandas 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.1dev
 =====================
 - Fixed search result sort order for the cases involving TESS sectors 99 and 100, etc. [#1558]
+- Removed the pandas <3.0 dependency cap after verifying compatibility with pandas 3.
 
 2.6.0 (2026-04-16)
 =====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ beautifulsoup4 = ">=4.6.0"
 requests = ">=2.22.0"
 urllib3 = { version = ">=1.23", python = ">=3.8,<4.0" }  # necessary to make requests work on py310
 tqdm = ">=4.25.0"
-pandas = ">=1.3.6, <3.0.0"
+pandas = ">=1.3.6"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"


### PR DESCRIPTION
Summary:
- remove the stale pandas <3.0.0 dependency cap
- document pandas 3 compatibility in the 2.6.1dev changelog

Why:
Lightkurve pandas-facing functionality passes the focused compatibility suite with pandas 3.0.3, so the package metadata no longer needs to reject the latest pandas release.

Validation:
- PYTHONPATH=src python -m pytest tests/test_lightcurve.py::test_to_pandas tests/test_lightcurve.py::test_to_pandas_kepler tests/correctors/test_designmatrix.py tests/correctors/test_sparsedesignmatrix.py -q
- local import check confirmed this checkout imports with pandas 3.0.3