### PR TITLE
Fix pandas 3 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.6.1dev
 =====================
 - Fixed search result sort order for the cases involving TESS sectors 99 and 100, etc. [#1558]
+- Fixed CBV plotting with pandas 3 and removed the pandas <3.0 dependency cap.
 
 2.6.0 (2026-04-16)
 =====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ beautifulsoup4 = ">=4.6.0"
 requests = ">=2.22.0"
 urllib3 = { version = ">=1.23", python = ">=3.8,<4.0" }  # necessary to make requests work on py310
 tqdm = ">=4.25.0"
-pandas = ">=1.3.6, <3.0.0"
+pandas = ">=1.3.6"
 uncertainties = ">=3.1.4"
 patsy = ">=0.5.0"
 fbpca = ">=1.0"

--- a/src/lightkurve/correctors/cbvcorrector.py
+++ b/src/lightkurve/correctors/cbvcorrector.py
@@ -1171,7 +1171,7 @@ class CotrendingBasisVectors(TimeSeries):
             # Get the CBV arrays that were requested
             for idx, cbv_name in enumerate(cbv_designmatrix.columns):
                 cbvIndex = cbv_name[7:]
-                cbv = cbv_designmatrix[cbv_name]
+                cbv = np.array(cbv_designmatrix[cbv_name], copy=True)
                 # Plot gaps as NaN
                 cbv[np.nonzero(self.gap_indicators)[0]] = np.nan
                 ax.plot(timeArray, cbv-idx/10., label='{}'.format(cbvIndex), **kwargs)


### PR DESCRIPTION
Summary:
- fix CBV plotting when design matrix columns are backed by read-only pandas 3 arrays
- remove the stale pandas <3.0 dependency cap
- document pandas 3 compatibility in the 2.6.1dev changelog

Why:
Pandas 3 can expose read-only arrays from DataFrame-backed columns. CBV plotting inserts NaN values into a temporary vector to hide gapped cadences, so it needs a writable copy before plotting.

Validation:
- PYTHONPATH=src python -m pytest tests/correctors/test_cbvcorrector.py::test_CotrendingBasisVectors_nonretrieval tests/correctors/test_cbvcorrector.py::test_cbv_local -q
- PYTHONPATH=src python -m pytest -q
- verified with pandas 3.0.3

Fixes #1534