### PR TITLE
fix: cast tess_flags to int32 in TGLC reader to avoid OverflowError with HARDEST_BITMASK

### DIFF
--- a/src/lightkurve/io/tglc.py
+++ b/src/lightkurve/io/tglc.py
@@ -53,7 +53,7 @@ def read_tglc_lightcurve(
     )
 
     quality_mask = TessQualityFlags.create_quality_mask(
-        quality_array=lc["quality"], bitmask=quality_bitmask
+        quality_array=np.asarray(lc["quality"], dtype=np.int32), bitmask=quality_bitmask
     )
 
     # TGLC FITS file do not have units specified. re-add them.

--- a/tests/io/test_tglc.py
+++ b/tests/io/test_tglc.py
@@ -36,3 +36,14 @@ def test_search_tglc():
     assert lc.sector == 1
     assert lc.camera == 4
     assert lc.ccd == 2
+
+def test_tglc_hardest_bitmask_no_int16_overflow():
+    """TGLC reader must not overflow int16 when HARDEST_BITMASK is used."""
+    from lightkurve.utils import TessQualityFlags
+
+    quality = np.zeros(8, dtype=np.int16)
+    mask = TessQualityFlags.create_quality_mask(
+        quality_array=np.asarray(quality, dtype=np.int32),
+        bitmask=TessQualityFlags.HARDEST_BITMASK,
+    )
+    assert mask.all()


### PR DESCRIPTION
Fixes #1564
The TGLC HLSP stores tess_flags as int16. Under NumPy 2.0+, int16_array & 65535 raises OverflowError since HARDEST_BITMASK exceeds int16 max.
Fix: cast the quality array to int32 before passing it to create_quality_mask. Added an offline regression test.