### PR TITLE
Tweak poetry install in "Developing for Lightkurve" docs

### DIFF
--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -58,8 +58,9 @@ You can set up the environment as follows:
 .. code-block:: bash
 
     $ cd lightkurve
-    $ python -m pip install poetry
-    $ poetry install
+    $ curl -sSL https://install.python-poetry.org | python -
+    # add "--with dev" to include packages useful for development, e.g., pytest
+    $ poetry install --with dev
 
 A key advantage of the development environment is that any changes you make to the Lightkurve source
 code will be reflected right away, i.e., there is no need to re-install Lightkurve or the environment

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -58,7 +58,7 @@ You can set up the environment as follows:
 .. code-block:: bash
 
     $ cd lightkurve
-    $ curl -sSL https://install.python-poetry.org | python -
+    $ curl -sSL https://install.python-poetry.org | python3 -
     # add "--with dev" to include packages useful for development, e.g., pytest
     $ poetry install --with dev
 

--- a/docs/source/development/documentation.rst
+++ b/docs/source/development/documentation.rst
@@ -22,7 +22,7 @@ Building documentation
 
 Building the *lightkurve* documentation requires `sphinx` and a few extra packages. We recommend using `poetry` to install the development dependencies::
 
-    $ poetry install
+    $ poetry install --with dev
 
 To make a clean directory for the docs use::
 
@@ -57,11 +57,11 @@ you can upload the documentation to the web server using::
         $ conda install --channel=conda-forge pandoc
 
 .. note::
-    
+
     To build the docs on a Mac you may have to install the Xcode Command Line Tools, which you can do using::
 
         $ xcode-select --install
-    
+
 
 
 

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -54,7 +54,9 @@ You can set up the environment as follows:
 
     $ cd lightkurve
     $ curl -sSL https://install.python-poetry.org | python -
-    $ poetry install
+    # add "--with dev" to include packages useful for development, e.g., pytest
+    $ poetry install --with dev
+
 
 Refer to `poetry documentation <https://python-poetry.org/docs/#installation>`_ for
 poetry installation options, in addition to the `curl` used in the above example.

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -53,7 +53,7 @@ You can set up the environment as follows:
 .. code-block:: bash
 
     $ cd lightkurve
-    $ curl -sSL https://install.python-poetry.org | python -
+    $ curl -sSL https://install.python-poetry.org | python3 -
     # add "--with dev" to include packages useful for development, e.g., pytest
     $ poetry install --with dev
 


### PR DESCRIPTION
Include `--with dev` in poetry install instruction, as it's needed to run tests, build doc, etc.
